### PR TITLE
Add shape solid flag

### DIFF
--- a/paramak/extruded_mixed_shape.py
+++ b/paramak/extruded_mixed_shape.py
@@ -30,6 +30,8 @@ import cadquery as cq
 
 from paramak import Shape
 
+from hashlib import blake2b
+
 
 class ExtrudeMixedShape(Shape):
     """Extrude a 3d CadQuery solid from points connected with
@@ -71,6 +73,7 @@ class ExtrudeMixedShape(Shape):
         cut=None,
         material_tag=None,
         name=None,
+        hash_value=None,
     ):
 
         super().__init__(
@@ -83,9 +86,10 @@ class ExtrudeMixedShape(Shape):
             workplane,
         )
 
-        self.distance = distance
-        self.solid = solid
         self.cut = cut
+        self.distance = distance
+        self.hash_value = hash_value
+        self.solid = solid
 
     @property
     def cut(self):
@@ -97,7 +101,11 @@ class ExtrudeMixedShape(Shape):
 
     @property
     def solid(self):
-        self.create_solid()
+        if self.get_hash() != self.hash_value:
+            print('hash values are different')
+            self.create_solid()
+        if self.get_hash() == self.hash_value:
+            print('hash values are equal')
         return self._solid
 
     @solid.setter
@@ -112,6 +120,29 @@ class ExtrudeMixedShape(Shape):
     def distance(self, value):
         self._distance = value
 
+    @property
+    def hash_value(self):
+        return self._hash_value
+
+    @hash_value.setter
+    def hash_value(self, value):
+        self._hash_value = value
+
+    def get_hash(self):
+        hash_object = blake2b()
+        hash_object.update(str(self.points).encode('utf-8') +
+                           str(self.workplane).encode('utf-8') +
+                           str(self.name).encode('utf-8') +
+                           str(self.color).encode('utf-8') +
+                           str(self.material_tag).encode('utf-8') +
+                           str(self.stp_filename).encode('utf-8') +
+                           str(self.azimuth_placement_angle).encode('utf-8') +
+                           str(self.distance).encode('utf-8') +
+                           str(self.cut).encode('utf-8')
+        )
+        value = hash_object.hexdigest()
+        return value
+
     def create_solid(self):
         """Creates a 3d solid using points with straight and spline
         connections edges, azimuth_placement_angle and distance.
@@ -119,6 +150,11 @@ class ExtrudeMixedShape(Shape):
         :return: a 3d solid volume
         :rtype: a cadquery solid
         """
+
+        # print('create_solid() has been called')
+
+        # Creates hash value for current solid
+        self.hash_value = self.get_hash()
 
         # obtains the first two values of the points list
         XZ_points = [(p[0], p[1]) for p in self.points]

--- a/paramak/extruded_spline_shape.py
+++ b/paramak/extruded_spline_shape.py
@@ -30,6 +30,8 @@ import cadquery as cq
 
 from paramak import Shape
 
+from hashlib import blake2b
+
 
 class ExtrudeSplineShape(Shape):
     """Extrude a 3d CadQuery solid from points connected with
@@ -69,6 +71,7 @@ class ExtrudeSplineShape(Shape):
         cut=None,
         material_tag=None,
         name=None,
+        hash_value=None,
     ):
 
         super().__init__(
@@ -81,9 +84,10 @@ class ExtrudeSplineShape(Shape):
             workplane,
         )
 
-        self.distance = distance
-        self.solid = solid
         self.cut = cut
+        self.distance = distance
+        self.hash_value = hash_value
+        self.solid = solid
 
     @property
     def cut(self):
@@ -95,7 +99,11 @@ class ExtrudeSplineShape(Shape):
 
     @property
     def solid(self):
-        self.create_solid()
+        if self.get_hash() != self.hash_value:
+            print('hash values are different')
+            self.create_solid()
+        if self.get_hash() == self.hash_value:
+            print('hash values are equal')
         return self._solid
 
     @solid.setter
@@ -110,6 +118,29 @@ class ExtrudeSplineShape(Shape):
     def distance(self, value):
         self._distance = value
 
+    @property
+    def hash_value(self):
+        return self._hash_value
+
+    @hash_value.setter
+    def hash_value(self, value):
+        self._hash_value = value
+
+    def get_hash(self):
+        hash_object = blake2b()
+        hash_object.update(str(self.points).encode('utf-8') +
+                           str(self.workplane).encode('utf-8') +
+                           str(self.name).encode('utf-8') +
+                           str(self.color).encode('utf-8') +
+                           str(self.material_tag).encode('utf-8') +
+                           str(self.stp_filename).encode('utf-8') +
+                           str(self.azimuth_placement_angle).encode('utf-8') +
+                           str(self.distance).encode('utf-8') +
+                           str(self.cut).encode('utf-8')
+        )
+        value = hash_object.hexdigest()
+        return value
+
     def create_solid(self):
         """Creates a 3d solid using points with spline
            edges, azimuth_placement_angle and distance.
@@ -117,6 +148,11 @@ class ExtrudeSplineShape(Shape):
         :return: a 3d solid volume
         :rtype: a cadquery solid
         """
+
+        # print('create_solid() has been called')
+
+        # Creates hash value for current solid
+        self.hash_value = self.get_hash()
 
         # Creates a cadquery solid from points and extrudes
         solid = (

--- a/paramak/extruded_straight_shape.py
+++ b/paramak/extruded_straight_shape.py
@@ -31,6 +31,8 @@ import cadquery as cq
 
 from paramak import Shape
 
+from hashlib import blake2b
+
 
 class ExtrudeStraightShape(Shape):
     """Extrude a 3d CadQuery solid from points connected with
@@ -70,6 +72,7 @@ class ExtrudeStraightShape(Shape):
         cut=None,
         material_tag=None,
         name=None,
+        hash_value=None
     ):
 
         super().__init__(
@@ -82,9 +85,10 @@ class ExtrudeStraightShape(Shape):
             workplane,
         )
 
-        self.distance = distance
-        self.solid = solid
         self.cut = cut
+        self.distance = distance
+        self.hash_value = hash_value
+        self.solid = solid
 
     @property
     def cut(self):
@@ -96,7 +100,11 @@ class ExtrudeStraightShape(Shape):
 
     @property
     def solid(self):
-        self.create_solid()
+        if self.get_hash() != self.hash_value:
+            print('hash values are different')
+            self.create_solid()
+        if self.get_hash() == self.hash_value:
+            print('hash values are equal')
         return self._solid
 
     @solid.setter
@@ -111,6 +119,29 @@ class ExtrudeStraightShape(Shape):
     def distance(self, value):
         self._distance = value
 
+    @property
+    def hash_value(self):
+        return self._hash_value
+
+    @hash_value.setter
+    def hash_value(self, value):
+        self._hash_value = value
+
+    def get_hash(self):
+        hash_object = blake2b()
+        hash_object.update(str(self.points).encode('utf-8') +
+                           str(self.workplane).encode('utf-8') +
+                           str(self.name).encode('utf-8') +
+                           str(self.color).encode('utf-8') +
+                           str(self.material_tag).encode('utf-8') +
+                           str(self.stp_filename).encode('utf-8') +
+                           str(self.azimuth_placement_angle).encode('utf-8') +
+                           str(self.distance).encode('utf-8') +
+                           str(self.cut).encode('utf-8')
+        )
+        value = hash_object.hexdigest()
+        return value
+
     def create_solid(self):
         """Creates a 3d solid using points with straight connections
         edges, azimuth_placement_angle and rotation angle.
@@ -118,6 +149,11 @@ class ExtrudeStraightShape(Shape):
         :return: a 3d solid volume
         :rtype: a cadquery solid
         """
+
+        # print('create_solid() has been called')
+
+        # Creates hash value for current solid
+        self.hash_value = self.get_hash()
 
         # Creates a cadquery solid from points and revolves
         solid = (

--- a/paramak/parametric_shapes/__init__.py
+++ b/paramak/parametric_shapes/__init__.py
@@ -1,6 +1,6 @@
 from .tokamak_plasma import PlasmaShape
 
-from .blanket_constant_width import BlanketConstantThickness
+# from .blanket_constant_width import BlanketConstantThickness
 
 from .divertor_block import DivertorBlock
 

--- a/paramak/parametric_shapes/center_column_cylinder.py
+++ b/paramak/parametric_shapes/center_column_cylinder.py
@@ -26,10 +26,6 @@ ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
 
 from paramak import RotateStraightShape
 
-# at the moment, we have repeated methods in the user-classes and the parametric shapes
-# we need the solid method to be repeated with the new check for solid
-# the super only inherits attributes, not methods, so its only inheriting the .solid attribute, not the .solid method, so it needs to be repeated here?
-
 
 class CenterColumnShieldCylinder(RotateStraightShape):
     def __init__(

--- a/paramak/parametric_shapes/center_column_cylinder.py
+++ b/paramak/parametric_shapes/center_column_cylinder.py
@@ -26,6 +26,10 @@ ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
 
 from paramak import RotateStraightShape
 
+# at the moment, we have repeated methods in the user-classes and the parametric shapes
+# we need the solid method to be repeated with the new check for solid
+# the super only inherits attributes, not methods, so its only inheriting the .solid attribute, not the .solid method, so it needs to be repeated here?
+
 
 class CenterColumnShieldCylinder(RotateStraightShape):
     def __init__(
@@ -43,6 +47,7 @@ class CenterColumnShieldCylinder(RotateStraightShape):
         material_tag=None,
         azimuth_placement_angle=0,
         cut=None,
+        hash_value=None,
     ):
 
         super().__init__(
@@ -56,6 +61,7 @@ class CenterColumnShieldCylinder(RotateStraightShape):
             solid,
             rotation_angle,
             cut,
+            hash_value,
         )
 
         self.height = height
@@ -73,7 +79,11 @@ class CenterColumnShieldCylinder(RotateStraightShape):
 
     @property
     def solid(self):
-        self.create_solid()
+        if self.get_hash() != self.hash_value:
+            print('hash values are different')
+            self.create_solid()
+        if self.get_hash() == self.hash_value:
+            print('hash values are equal')
         return self._solid
 
     @solid.setter

--- a/paramak/parametric_shapes/center_column_flat_top_hyperbola.py
+++ b/paramak/parametric_shapes/center_column_flat_top_hyperbola.py
@@ -45,6 +45,7 @@ class CenterColumnShieldFlatTopHyperbola(RotateMixedShape):
         material_tag="center_column_material",
         azimuth_placement_angle=0,
         cut=None,
+        hash_value=None,
     ):
 
         super().__init__(
@@ -58,6 +59,7 @@ class CenterColumnShieldFlatTopHyperbola(RotateMixedShape):
             solid,
             rotation_angle,
             cut,
+            hash_value,
         )
 
         self.height = height
@@ -77,7 +79,11 @@ class CenterColumnShieldFlatTopHyperbola(RotateMixedShape):
 
     @property
     def solid(self):
-        self.create_solid()
+        if self.get_hash() != self.hash_value:
+            print('hash values are different')
+            self.create_solid()
+        if self.get_hash() == self.hash_value:
+            print('hash values are equal')
         return self._solid
 
     @solid.setter

--- a/paramak/parametric_shapes/center_column_hyperbola.py
+++ b/paramak/parametric_shapes/center_column_hyperbola.py
@@ -44,6 +44,7 @@ class CenterColumnShieldHyperbola(RotateMixedShape):
         material_tag="center_column_material",
         azimuth_placement_angle=0,
         cut=None,
+        hash_value=None,
     ):
 
         super().__init__(
@@ -57,6 +58,7 @@ class CenterColumnShieldHyperbola(RotateMixedShape):
             solid,
             rotation_angle,
             cut,
+            hash_value,
         )
 
         self.height = height
@@ -75,7 +77,11 @@ class CenterColumnShieldHyperbola(RotateMixedShape):
 
     @property
     def solid(self):
-        self.create_solid()
+        if self.get_hash() != self.hash_value:
+            print('hash values are different')
+            self.create_solid()
+        if self.get_hash() == self.hash_value:
+            print('hash values are equal')
         return self._solid
 
     @solid.setter

--- a/paramak/parametric_shapes/center_column_plasma_dependant.py
+++ b/paramak/parametric_shapes/center_column_plasma_dependant.py
@@ -51,6 +51,7 @@ class CenterColumnShieldPlasmaHyperbola(RotateMixedShape):
         inner_radius=None,
         mid_offset=None,
         edge_offset=None,
+        hash_value=None,
     ):
 
         super().__init__(
@@ -64,6 +65,7 @@ class CenterColumnShieldPlasmaHyperbola(RotateMixedShape):
             solid,
             rotation_angle,
             cut,
+            hash_value,
         )
 
         self.major_radius = major_radius
@@ -77,15 +79,6 @@ class CenterColumnShieldPlasmaHyperbola(RotateMixedShape):
         self.edge_offset = edge_offset
 
     @property
-    def solid(self):
-        self.create_solid()
-        return self._solid
-
-    @solid.setter
-    def solid(self, solid):
-        self._solid = solid
-
-    @property
     def points(self):
         self.find_points()
         return self._points
@@ -93,6 +86,19 @@ class CenterColumnShieldPlasmaHyperbola(RotateMixedShape):
     @points.setter
     def points(self, points):
         self._points = points
+
+    @property
+    def solid(self):
+        if self.get_hash() != self.hash_value:
+            print('hash values are different')
+            self.create_solid()
+        if self.get_hash() == self.hash_value:
+            print('hash values are equal')
+        return self._solid
+
+    @solid.setter
+    def solid(self, solid):
+        self._solid = solid
 
     @property
     def major_radius(self):

--- a/paramak/parametric_shapes/divertor_block.py
+++ b/paramak/parametric_shapes/divertor_block.py
@@ -53,6 +53,7 @@ class DivertorBlock(RotateMixedShape):
         azimuth_placement_angle=0,
         material_tag=None,
         cut=None,
+        hash_value=None,
     ):
 
         super().__init__(
@@ -66,6 +67,7 @@ class DivertorBlock(RotateMixedShape):
             solid,
             rotation_angle,
             cut,
+            hash_value,
         )
 
         self.major_radius = major_radius
@@ -88,7 +90,11 @@ class DivertorBlock(RotateMixedShape):
 
     @property
     def solid(self):
-        self.create_solid()
+        if self.get_hash() != self.hash_value:
+            print('hash values are different')
+            self.create_solid()
+        if self.get_hash() == self.hash_value:
+            print('hash values are equal')
         return self._solid
 
     @solid.setter

--- a/paramak/parametric_shapes/poloidal_field_coil.py
+++ b/paramak/parametric_shapes/poloidal_field_coil.py
@@ -56,6 +56,7 @@ class PoloidalFieldCoil(RotateStraightShape):
         name=None,
         material_tag=None,
         cut=None,
+        hash_value=None,
     ):
 
         super().__init__(
@@ -69,6 +70,7 @@ class PoloidalFieldCoil(RotateStraightShape):
             solid,
             rotation_angle,
             cut,
+            hash_value,
         )
 
         self.center_point = center_point
@@ -86,7 +88,11 @@ class PoloidalFieldCoil(RotateStraightShape):
 
     @property
     def solid(self):
-        self.create_solid()
+        if self.get_hash() != self.hash_value:
+            print('hash values are different')
+            self.create_solid()
+        if self.get_hash() == self.hash_value:
+            print('hash values are equal')
         return self._solid
 
     @solid.setter

--- a/paramak/parametric_shapes/poloidal_field_coil_case.py
+++ b/paramak/parametric_shapes/poloidal_field_coil_case.py
@@ -59,6 +59,7 @@ class PoloidalFieldCoilCase(RotateStraightShape):
         name=None,
         material_tag=None,
         cut=None,
+        hash_value=None,
     ):
 
         super().__init__(
@@ -72,6 +73,7 @@ class PoloidalFieldCoilCase(RotateStraightShape):
             solid,
             rotation_angle,
             cut,
+            hash_value,
         )
 
         self.center_point = center_point
@@ -90,7 +92,11 @@ class PoloidalFieldCoilCase(RotateStraightShape):
 
     @property
     def solid(self):
-        self.create_solid()
+        if self.get_hash() != self.hash_value:
+            print('hash values are different')
+            self.create_solid()
+        if self.get_hash() == self.hash_value:
+            print('hash values are equal')
         return self._solid
 
     @solid.setter

--- a/paramak/parametric_shapes/tokamak_plasma.py
+++ b/paramak/parametric_shapes/tokamak_plasma.py
@@ -65,6 +65,7 @@ class PlasmaShape(RotateSplineShape):
         rotation_angle=360,
         azimuth_placement_angle=0,
         cut=None,
+        hash_value=None,
     ):
 
         super().__init__(
@@ -78,6 +79,7 @@ class PlasmaShape(RotateSplineShape):
             solid,
             rotation_angle,
             cut,
+            hash_value,
         )
 
         # properties needed for plasma shapes
@@ -94,15 +96,6 @@ class PlasmaShape(RotateSplineShape):
         self.stp_filename = stp_filename
 
     @property
-    def solid(self):
-        self.create_solid()
-        return self._solid
-
-    @solid.setter
-    def solid(self, value):
-        self._solid = value
-
-    @property
     def points(self):
         self.find_points()
         return self._points
@@ -110,6 +103,19 @@ class PlasmaShape(RotateSplineShape):
     @points.setter
     def points(self, value):
         self._points = value
+
+    @property
+    def solid(self):
+        if self.get_hash() != self.hash_value:
+            print('hash values are different')
+            self.create_solid()
+        if self.get_hash() == self.hash_value:
+            print('hash values are equal')
+        return self._solid
+
+    @solid.setter
+    def solid(self, value):
+        self._solid = value
 
     @property
     def rotation_angle(self):

--- a/paramak/rotate_mixed_shape.py
+++ b/paramak/rotate_mixed_shape.py
@@ -30,6 +30,8 @@ import cadquery as cq
 
 from paramak import Shape
 
+from hashlib import blake2b
+
 
 class RotateMixedShape(Shape):
     """Rotates a 3d CadQuery solid from points connected with
@@ -70,6 +72,7 @@ class RotateMixedShape(Shape):
         solid=None,
         rotation_angle=360,
         cut=None,
+        hash_value=None,
     ):
 
         super().__init__(
@@ -83,8 +86,9 @@ class RotateMixedShape(Shape):
         )
 
         self.cut = cut
-        self.solid = solid
         self.rotation_angle = rotation_angle
+        self.hash_value = hash_value
+        self.solid = solid
 
     @property
     def cut(self):
@@ -96,7 +100,11 @@ class RotateMixedShape(Shape):
 
     @property
     def solid(self):
-        self.create_solid()
+        if self.get_hash() != self.hash_value:
+            print('hash values are different')
+            self.create_solid()
+        if self.get_hash() == self.hash_value:
+            print('hash values are equal')
         return self._solid
 
     @solid.setter
@@ -111,6 +119,29 @@ class RotateMixedShape(Shape):
     def rotation_angle(self, value):
         self._rotation_angle = value
 
+    @property
+    def hash_value(self):
+        return self._hash_value
+
+    @hash_value.setter
+    def hash_value(self, value):
+        self._hash_value = value
+
+    def get_hash(self):
+        hash_object = blake2b()
+        hash_object.update(str(self.points).encode('utf-8') +
+                           str(self.workplane).encode('utf-8') +
+                           str(self.name).encode('utf-8') +
+                           str(self.color).encode('utf-8') +
+                           str(self.material_tag).encode('utf-8') +
+                           str(self.stp_filename).encode('utf-8') +
+                           str(self.azimuth_placement_angle).encode('utf-8') +
+                           str(self.rotation_angle).encode('utf-8') +
+                           str(self.cut).encode('utf-8')
+        )
+        value = hash_object.hexdigest()
+        return value
+
     def create_solid(self):
         """Creates a 3d solid using points with straight and spline
         connections edges, azimuth_placement_angle and distance.
@@ -118,6 +149,11 @@ class RotateMixedShape(Shape):
         :return: a 3d solid volume
         :rtype: a cadquery solid
         """
+
+        # print('create_solid() has been called')
+
+        # Creates hash value for current solid
+        self.hash_value = self.get_hash()
 
         # obtains the first two values of the points list
         XZ_points = [(p[0], p[1]) for p in self.points]

--- a/paramak/rotate_spline_shape.py
+++ b/paramak/rotate_spline_shape.py
@@ -31,6 +31,8 @@ import cadquery as cq
 
 from paramak import Shape
 
+from hashlib import blake2b
+
 
 class RotateSplineShape(Shape):
     """Rotates a 3d CadQuery solid from points connected with
@@ -70,6 +72,7 @@ class RotateSplineShape(Shape):
         solid=None,
         rotation_angle=360,
         cut=None,
+        hash_value=None,
     ):
 
         super().__init__(
@@ -83,8 +86,9 @@ class RotateSplineShape(Shape):
         )
 
         self.cut = cut
-        self.solid = solid
         self.rotation_angle = rotation_angle
+        self.hash_value = hash_value
+        self.solid = solid
 
     @property
     def cut(self):
@@ -96,7 +100,11 @@ class RotateSplineShape(Shape):
 
     @property
     def solid(self):
-        self.create_solid()
+        if self.get_hash() != self.hash_value:
+            print('hash values are different')
+            self.create_solid()
+        if self.get_hash() == self.hash_value:
+            print('hash values are equal')
         return self._solid
 
     @solid.setter
@@ -111,6 +119,29 @@ class RotateSplineShape(Shape):
     def rotation_angle(self, value):
         self._rotation_angle = value
 
+    @property
+    def hash_value(self):
+        return self._hash_value
+
+    @hash_value.setter
+    def hash_value(self, value):
+        self._hash_value = value
+
+    def get_hash(self):
+        hash_object = blake2b()
+        hash_object.update(str(self.points).encode('utf-8') +
+                           str(self.workplane).encode('utf-8') +
+                           str(self.name).encode('utf-8') +
+                           str(self.color).encode('utf-8') +
+                           str(self.material_tag).encode('utf-8') +
+                           str(self.stp_filename).encode('utf-8') +
+                           str(self.azimuth_placement_angle).encode('utf-8') +
+                           str(self.rotation_angle).encode('utf-8') +
+                           str(self.cut).encode('utf-8')
+        )
+        value = hash_object.hexdigest()
+        return value
+
     def create_solid(self):
         """Creates a 3d solid using points with straight connections
         edges, azimuth_placement_angle and rotation angle.
@@ -118,6 +149,11 @@ class RotateSplineShape(Shape):
         :return: a 3d solid volume
         :rtype: a cadquery solid
         """
+
+        # print('create_solid() has been called')
+
+        # Creates hash value for current solid
+        self.hash_value = self.get_hash()
 
         # Creates a cadquery solid from points and revolves
         solid = (

--- a/paramak/rotate_straight_shape.py
+++ b/paramak/rotate_straight_shape.py
@@ -30,6 +30,8 @@ import cadquery as cq
 
 from paramak import Shape
 
+from hashlib import blake2b
+
 
 class RotateStraightShape(Shape):
     """Rotates a 3d CadQuery solid from points connected with
@@ -69,6 +71,7 @@ class RotateStraightShape(Shape):
         solid=None,
         rotation_angle=360,
         cut=None,
+        hash_value=None,
     ):
 
         super().__init__(
@@ -82,8 +85,9 @@ class RotateStraightShape(Shape):
         )
 
         self.cut = cut
-        self.solid = solid
         self.rotation_angle = rotation_angle
+        self.hash_value = hash_value
+        self.solid = solid
 
     @property
     def cut(self):
@@ -95,7 +99,11 @@ class RotateStraightShape(Shape):
 
     @property
     def solid(self):
-        self.create_solid()
+        if self.get_hash() != self.hash_value:
+            print('hash values are different')
+            self.create_solid()
+        if self.get_hash() == self.hash_value:
+            print('hash values are equal')
         return self._solid
 
     @solid.setter
@@ -110,6 +118,29 @@ class RotateStraightShape(Shape):
     def rotation_angle(self, value):
         self._rotation_angle = value
 
+    @property
+    def hash_value(self):
+        return self._hash_value
+
+    @hash_value.setter
+    def hash_value(self, value):
+        self._hash_value = value
+
+    def get_hash(self):
+        hash_object = blake2b()
+        hash_object.update(str(self.points).encode('utf-8') +
+                           str(self.workplane).encode('utf-8') +
+                           str(self.name).encode('utf-8') +
+                           str(self.color).encode('utf-8') +
+                           str(self.material_tag).encode('utf-8') +
+                           str(self.stp_filename).encode('utf-8') +
+                           str(self.azimuth_placement_angle).encode('utf-8') +
+                           str(self.rotation_angle).encode('utf-8') +
+                           str(self.cut).encode('utf-8')
+        )
+        value = hash_object.hexdigest()
+        return value
+
     def create_solid(self):
         """Creates a 3d solid using points with straight connections
         edges, azimuth_placement_angle and rotation angle.
@@ -117,6 +148,11 @@ class RotateStraightShape(Shape):
         :return: a 3d solid volume
         :rtype: a cadquery solid
         """
+
+        # print('create_solid() has been called')
+
+        # Creates hash value for current solid
+        self.hash_value = self.get_hash()
 
         # Creates a cadquery solid from points and revolves
         solid = (

--- a/tests/test_ExtrudeCircleShape.py
+++ b/tests/test_ExtrudeCircleShape.py
@@ -85,3 +85,112 @@ class test_object_properties(unittest.TestCase):
         assert outer_shape_with_cut.volume == pytest.approx(
             (math.pi * 10 ** 2 * 20) - (math.pi * 5 ** 2 * 20)
         )
+
+    def test_initial_solid_construction(self):
+        """tests that a cadquery solid with a unique hash is constructed when .solid is called"""
+
+        test_shape = ExtrudeCircleShape(
+            points=[(0, 0), (0, 20), (20, 20), (20, 0), (0, 0)],
+            radius=10,
+            distance=20
+        )
+
+        assert test_shape.hash_value is None
+        assert test_shape.solid is not None
+        assert type(test_shape.solid).__name__ == "Workplane"
+        assert test_shape.hash_value is not None
+
+    def test_solid_return(self):
+        """tests that the same cadquery solid with the same unique hash is returned when shape.solid is called again when no changes have been made to the shape"""
+
+        test_shape = ExtrudeCircleShape(
+            points=[(0, 0), (0, 20), (20, 20), (20, 0), (0, 0)],
+            radius=10,
+            distance=20
+        )
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        assert initial_hash_value == test_shape.hash_value
+
+    def test_conditional_solid_reconstruction(self):
+        """tests that a new cadquery solid with a new unique hash is constructed when .solid is called again after changes have been made to the shape"""
+
+        test_shape = ExtrudeCircleShape(
+            points=[(0, 0), (0, 20), (20, 20), (0, 0)],
+            radius=10,
+            distance=20
+        )
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        test_shape.distance = 30
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        assert initial_hash_value != test_shape.hash_value
+
+    def test_hash_value_update(self):
+        """tests that the hash_value of the shape is not updated until a new solid has been created"""
+
+        test_shape = ExtrudeCircleShape(
+            points=[(0, 0), (0, 20), (20, 20), (0, 0)],
+            radius=10,
+            distance=20
+        )
+        test_shape.solid
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        test_shape.distance = 30
+
+        assert test_shape.hash_value == initial_hash_value
+        test_shape.solid
+        assert test_shape.hash_value != initial_hash_value
+
+    def test_conditional_solid_reconstruction_parameters(self):
+        """tests that a new cadquery solid with a new unique hash is created when the shape properties of points, radius or distance are changed"""
+
+        # points
+        test_shape = ExtrudeCircleShape(
+            points=[(30, 0)], radius=5, distance=20
+        )
+        test_shape.solid
+        initial_hash_value = test_shape.hash_value
+        test_shape.points = [(40, 0)]
+        test_shape.solid
+        assert test_shape.solid is not None
+        assert test_shape.hash_value != initial_hash_value
+
+        # radius
+        test_shape = ExtrudeCircleShape(
+            points=[(30, 0)], radius=5, distance=20
+        )
+        test_shape.solid
+        initial_hash_value = test_shape.hash_value
+        test_shape.radius = 10
+        test_shape.solid
+        assert test_shape.solid is not None
+        assert test_shape.hash_value != initial_hash_value
+
+        # distance
+        test_shape = ExtrudeCircleShape(
+            points=[(30, 0)], radius=5, distance=20
+        )
+        test_shape.solid
+        initial_hash_value = test_shape.hash_value
+        test_shape.distance = 30
+        test_shape.solid
+        assert test_shape.solid is not None
+        assert test_shape.hash_value != initial_hash_value
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_ExtrudeMixedShape.py
+++ b/tests/test_ExtrudeMixedShape.py
@@ -131,6 +131,84 @@ class test_object_properties(unittest.TestCase):
         assert outer_shape.volume == pytest.approx(3462.75)
         assert outer_shape_with_cut.volume == pytest.approx(3462.75 - 1068.75, abs=0.1)
 
+    def test_initial_solid_construction(self):
+        """tests that a cadquery solid with a unique hash is constructed when .solid is called"""
+
+        test_shape = ExtrudeMixedShape(
+            points=[(0, 0, "straight"),
+                    (0, 20, "spline"),
+                    (20, 20, "spline"),
+                    (20, 0, "straight"),
+                    (0, 0)],
+            distance=20
+        )
+
+        assert test_shape.hash_value is None
+        assert test_shape.solid is not None
+        assert type(test_shape.solid).__name__ == "Workplane"
+        assert test_shape.hash_value is not None
+
+    def test_solid_return(self):
+        """tests that the same cadquery solid with the same unique hash is returned when shape.solid is called again when no changes have been made to the shape"""
+
+        test_shape = ExtrudeMixedShape(
+            points=[(0, 0, "straight"),
+                    (0, 20, "spline"),
+                    (20, 20, "spline"),
+                    (20, 0, "straight"),
+                    (0, 0)],
+            distance=20
+        )
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        assert initial_hash_value == test_shape.hash_value
+
+    def test_conditional_solid_reconstruction(self):
+        """tests that a new cadquery solid with a new unique hash is constructed when .solid is called again after changes have been made to the shape"""
+
+        test_shape = ExtrudeMixedShape(
+            points=[(0, 0, "straight"),
+                    (0, 20, "spline"),
+                    (20, 20, "spline"),
+                    (0, 0)],
+            distance=20
+        )
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        test_shape.distance = 30
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        assert initial_hash_value != test_shape.hash_value
+
+    def test_hash_value_update(self):
+        """tests that the hash_value of the shape is not updated until a new solid has been created"""
+
+        test_shape = ExtrudeMixedShape(
+            points=[(0, 0, "straight"),
+                    (0, 20, "spline"),
+                    (20, 20, "spline"),
+                    (0, 0)],
+            distance=20
+        )
+        test_shape.solid
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        test_shape.distance = 30
+
+        assert test_shape.hash_value == initial_hash_value
+        test_shape.solid
+        assert test_shape.hash_value != initial_hash_value
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ExtrudeSplineShape.py
+++ b/tests/test_ExtrudeSplineShape.py
@@ -88,6 +88,70 @@ class test_object_properties(unittest.TestCase):
             3775.4836 - 1165.2727, abs=0.1
         )
 
+    def test_initial_solid_construction(self):
+        """tests that a cadquery solid with a unique hash is constructed when .solid is called"""
+
+        test_shape = ExtrudeSplineShape(
+            points=[(0, 0), (0, 20), (20, 20), (20, 0), (0, 0)],
+            distance=20
+        )
+
+        assert test_shape.hash_value is None
+        assert test_shape.solid is not None
+        assert type(test_shape.solid).__name__ == "Workplane"
+        assert test_shape.hash_value is not None
+
+    def test_solid_return(self):
+        """tests that the same cadquery solid with the same unique hash is returned when shape.solid is called again when no changes have been made to the shape"""
+
+        test_shape = ExtrudeSplineShape(
+            points=[(0, 0), (0, 20), (20, 20), (20, 0), (0, 0)],
+            distance=20
+        )
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        assert initial_hash_value == test_shape.hash_value
+
+    def test_conditional_solid_reconstruction(self):
+        """tests that a new cadquery solid with a new unique hash is constructed when .solid is called again after changes have been made to the shape"""
+
+        test_shape = ExtrudeSplineShape(
+            points=[(0, 0), (0, 20), (20, 20), (0, 0)],
+            distance=20
+        )
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        test_shape.distance = 30
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        assert initial_hash_value != test_shape.hash_value
+
+    def test_hash_value_update(self):
+        """tests that the hash_value of the shape is not updated until a new solid has been created"""
+
+        test_shape = ExtrudeSplineShape(
+            points=[(0, 0), (0, 20), (20, 20), (0, 0)],
+            distance=20
+        )
+        test_shape.solid
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        test_shape.distance = 30
+
+        assert test_shape.hash_value == initial_hash_value
+        test_shape.solid
+        assert test_shape.hash_value != initial_hash_value
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_RotateCircleShape.py
+++ b/tests/test_RotateCircleShape.py
@@ -121,6 +121,101 @@ class test_object_properties(unittest.TestCase):
             - ((math.pi * 5 ** 2) * ((2 * math.pi * 30) / 2))
         )
 
+    def test_initial_solid_construction(self):
+        """tests that a cadquery solid with a unique hash is constructed when .solid is called"""
+
+        test_shape = RotateCircleShape(
+            points=[(30, 0)], radius=5, rotation_angle=360
+        )
+
+        assert test_shape.hash_value is None
+        assert test_shape.solid is not None
+        assert type(test_shape.solid).__name__ == "Workplane"
+        assert test_shape.hash_value is not None
+
+    def test_solid_return(self):
+        """tests that the same cadquery solid with the same unique hash is returned when shape.solid is called again when no changes have been made to the shape"""
+
+        test_shape = RotateCircleShape(
+            points=[(30, 0)], radius=5, rotation_angle=360
+        )
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        assert initial_hash_value == test_shape.hash_value
+
+    def test_conditional_solid_reconstruction(self):
+        """tests that a new cadquery solid with a new unique hash is constructed when .solid is called again after changes have been made to the shape"""
+
+        test_shape = RotateCircleShape(
+            points=[(30, 0)], radius=5, rotation_angle=360
+        )
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        test_shape.rotation_angle = 180
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        assert initial_hash_value != test_shape.hash_value
+
+    def test_hash_value_update(self):
+        """tests that the hash_value of the shape is not updated until a new solid has been created"""
+
+        test_shape = RotateCircleShape(
+            points=[(30, 0)], radius=5, rotation_angle=360
+        )
+        test_shape.solid
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        test_shape.rotation_angle = 180
+        assert test_shape.hash_value == initial_hash_value
+        test_shape.solid
+        assert test_shape.hash_value != initial_hash_value
+
+    def test_conditional_solid_reconstruction_parameters(self):
+        """tests that a new cadquery solid with a new unique hash is created when the shape properties of points, radius or rotation angle are changed"""
+
+        # points
+        test_shape = RotateCircleShape(
+            points=[(30, 0)], radius=5, rotation_angle=360
+        )
+        test_shape.solid
+        initial_hash_value = test_shape.hash_value
+        test_shape.points = [(40, 0)]
+        test_shape.solid
+        assert test_shape.solid is not None
+        assert test_shape.hash_value != initial_hash_value
+
+        # radius
+        test_shape = RotateCircleShape(
+            points=[(30, 0)], radius=5, rotation_angle=360
+        )
+        test_shape.solid
+        initial_hash_value = test_shape.hash_value
+        test_shape.radius = 10
+        test_shape.solid
+        assert test_shape.solid is not None
+        assert test_shape.hash_value != initial_hash_value
+
+        # rotation_angle
+        test_shape = RotateCircleShape(
+            points=[(30, 0)], radius=5, rotation_angle=360
+        )
+        test_shape.solid
+        initial_hash_value = test_shape.hash_value
+        test_shape.rotation_angle = 180
+        test_shape.solid
+        assert test_shape.solid is not None
+        assert test_shape.hash_value != initial_hash_value
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_RotateMixedShape.py
+++ b/tests/test_RotateMixedShape.py
@@ -199,6 +199,83 @@ class test_object_properties(unittest.TestCase):
         assert outer_shape.volume == pytest.approx(2854.5969)
         assert outer_shape_cut.volume == pytest.approx(2854.5969 - 862.5354)
 
+    def test_initial_solid_construction(self):
+        """tests that a cadquery solid with a unique hash is constructed when .solid is called"""
+
+        test_shape = RotateMixedShape(
+            points=[(0, 0, "straight"),
+                    (0, 20, "spline"),
+                    (20, 20, "spline"),
+                    (20, 0, "straight"),
+                    (0, 0)],
+            rotation_angle=360
+        )
+
+        assert test_shape.hash_value is None
+        assert test_shape.solid is not None
+        assert type(test_shape.solid).__name__ == "Workplane"
+        assert test_shape.hash_value is not None
+
+    def test_solid_return(self):
+        """tests that the same cadquery solid with the same unique hash is returned when shape.solid is called again when no changes have been made to the shape"""
+
+        test_shape = RotateMixedShape(
+            points=[(0, 0, "straight"),
+                    (0, 20, "spline"),
+                    (20, 20, "spline"),
+                    (20, 0, "straight"),
+                    (0, 0)],
+            rotation_angle=360
+        )
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        assert initial_hash_value == test_shape.hash_value
+
+    def test_conditional_solid_reconstruction(self):
+        """tests that a new cadquery solid with a new unique hash is constructed when .solid is called again after changes have been made to the shape"""
+
+        test_shape = RotateMixedShape(
+            points=[(0, 0, "straight"),
+                    (0, 20, "spline"),
+                    (20, 20, "spline"),
+                    (0, 0)],
+            rotation_angle=360
+        )
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        test_shape.rotation_angle = 180
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        assert initial_hash_value != test_shape.hash_value
+
+    def test_hash_value_update(self):
+        """tests that the hash_value of the shape is not updated until a new solid has been created"""
+
+        test_shape = RotateMixedShape(
+            points=[(0, 0, "straight"),
+                    (0, 20, "spline"),
+                    (20, 20, "spline"),
+                    (0, 0)],
+            rotation_angle=360
+        )
+        test_shape.solid
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        test_shape.rotation_angle = 180
+        assert test_shape.hash_value == initial_hash_value
+        test_shape.solid
+        assert test_shape.hash_value != initial_hash_value
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_RotateSplineShape.py
+++ b/tests/test_RotateSplineShape.py
@@ -70,6 +70,69 @@ class test_object_properties(unittest.TestCase):
             2881.75624 - 900.8867073, abs=0.1
         )
 
+    def test_initial_solid_construction(self):
+        """tests that a cadquery solid with a unique hash is constructed when .solid is called"""
+
+        test_shape = RotateSplineShape(
+            points=[(0, 0), (0, 20), (20, 20), (20, 0), (0, 0)],
+            rotation_angle=360
+        )
+
+        assert test_shape.hash_value is None
+        assert test_shape.solid is not None
+        assert type(test_shape.solid).__name__ == "Workplane"
+        assert test_shape.hash_value is not None
+
+    def test_solid_return(self):
+        """tests that the same cadquery solid with the same unique hash is returned when shape.solid is called again when no changes have been made to the shape"""
+
+        test_shape = RotateSplineShape(
+            points=[(0, 0), (0, 20), (20, 20), (20, 0), (0, 0)],
+            rotation_angle=360
+        )
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        assert initial_hash_value == test_shape.hash_value
+
+    def test_conditional_solid_reconstruction(self):
+        """tests that a new cadquery solid with a new unique hash is constructed when .solid is called again after changes have been made to the shape"""
+
+        test_shape = RotateSplineShape(
+            points=[(0, 0), (0, 20), (20, 20), (0, 0)],
+            rotation_angle=360
+        )
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        test_shape.rotation_angle = 180
+
+        assert test_shape.solid is not None
+        assert test_shape.hash_value is not None
+        assert initial_hash_value != test_shape.hash_value
+
+    def test_hash_value_update(self):
+        """tests that the hash_value of the shape is not updated until a new solid has been created"""
+
+        test_shape = RotateSplineShape(
+            points=[(0, 0), (0, 20), (20, 20), (0, 0)],
+            rotation_angle=360
+        )
+        test_shape.solid
+        assert test_shape.hash_value is not None
+        initial_hash_value = test_shape.hash_value
+
+        test_shape.rotation_angle = 180
+        assert test_shape.hash_value == initial_hash_value
+        test_shape.solid
+        assert test_shape.hash_value != initial_hash_value
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Pull request for adding a 'dirty flag' feature to solid creation.
Solids are created with a unique hash_value. create_solid() is only recalled if shape attributes are changed