### PR TITLE
Add circle to mixed shapes

### DIFF
--- a/paramak/extruded_mixed_shape.py
+++ b/paramak/extruded_mixed_shape.py
@@ -188,6 +188,11 @@ class ExtrudeMixedShape(Shape):
                 solid = solid.spline(listOfXYTuple=list(entry.values())[0])
             if list(entry.keys())[0] == "straight":
                 solid = solid.polyline(list(entry.values())[0])
+            if list(entry.keys())[0] == "circle":
+                p0 = list(entry.values())[0][0]
+                p1 = list(entry.values())[0][1]
+                p2 = list(entry.values())[0][2]
+                solid = solid.moveTo(p0[0],p0[1]).threePointArc(p1, p2)
 
         # performs extrude in both directions, hence distance / 2
         solid = solid.close().extrude(distance=-self.distance / 2.0, both=True)

--- a/paramak/rotate_mixed_shape.py
+++ b/paramak/rotate_mixed_shape.py
@@ -186,6 +186,11 @@ class RotateMixedShape(Shape):
                 solid = solid.spline(listOfXYTuple=list(entry.values())[0])
             if list(entry.keys())[0] == "straight":
                 solid = solid.polyline(list(entry.values())[0])
+            if list(entry.keys())[0] == "circle":
+                p0 = list(entry.values())[0][0]
+                p1 = list(entry.values())[0][1]
+                p2 = list(entry.values())[0][2]
+                solid = solid.moveTo(p0[0],p0[1]).threePointArc(p1, p2)
 
         solid = solid.close().revolve(self.rotation_angle)
 

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -205,7 +205,7 @@ class Shape:
 
                 # Checks that only straight and spline are in the connections part of points
                 if len(value) == 3:
-                    if value[2] not in ["straight", "spline"]:
+                    if value[2] not in ["straight", "spline", "circle"]:
                         raise ValueError(
                             'individual connections must be either "straight" or "spline"'
                         )

--- a/tests/test_ExtrudeMixedShape.py
+++ b/tests/test_ExtrudeMixedShape.py
@@ -202,6 +202,16 @@ class test_object_properties(unittest.TestCase):
         test_shape.solid
         assert test_shape.hash_value != initial_hash_value
 
+    def test_mixed_shape_with_straight_and_circle(self):
+        """tests the construction of a shape with straight and circular edges"""
+        test_shape = ExtrudeMixedShape(points=[(10, 20, 'straight'),
+                                                (10, 10, 'straight'),
+                                                (20, 10, 'circle'),
+                                                (22, 15, 'circle'),
+                                                (20, 20, 'straight'),
+                                                ], distance = 10
+                                        )
+        assert test_shape.volume > 10 * 10 * 10
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_RotateMixedShape.py
+++ b/tests/test_RotateMixedShape.py
@@ -266,6 +266,17 @@ class test_object_properties(unittest.TestCase):
         test_shape.solid
         assert test_shape.hash_value != initial_hash_value
 
+    def test_mixed_shape_with_straight_and_circle(self):
+        """tests the construction of a shape with straight and circular edges"""
+        test_shape = RotateMixedShape(points=[(10, 20, 'straight'),
+                                         (10, 10, 'straight'),
+                                         (20, 10, 'circle'),
+                                         (40, 15, 'circle'),
+                                         (20, 20, 'straight'),
+                                        ], rotation_angle = 10
+                                )
+        assert test_shape.volume > 10 * 10
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This adds support for circles to the ExtrudeMixedShape and RotateMixedShape and a couple of tests to check volumes are constructed