### PR TITLE
added required endpoint

### DIFF
--- a/paramak/parametric_shapes/center_column_flat_top_hyperbola.py
+++ b/paramak/parametric_shapes/center_column_flat_top_hyperbola.py
@@ -143,6 +143,7 @@ class CenterColumnShieldFlatTopHyperbola(RotateMixedShape):
             (self.outer_radius, -self.arc_height / 2, "straight"),
             (self.outer_radius, -self.height / 2, "straight"),
             (self.inner_radius, -self.height / 2, "straight"),
+            (self.inner_radius, 0, "straight"),
         ]
 
         self.points = points

--- a/paramak/parametric_shapes/center_column_hyperbola.py
+++ b/paramak/parametric_shapes/center_column_hyperbola.py
@@ -123,6 +123,7 @@ class CenterColumnShieldHyperbola(RotateMixedShape):
             (self.mid_radius, 0, "spline"),
             (self.outer_radius, -self.height / 2, "straight"),
             (self.inner_radius, -self.height / 2, "straight"),
+            (self.inner_radius, 0, "straight"),
         ]
 
         self.points = points

--- a/paramak/parametric_shapes/center_column_plasma_dependant.py
+++ b/paramak/parametric_shapes/center_column_plasma_dependant.py
@@ -190,6 +190,7 @@ class CenterColumnShieldPlasmaHyperbola(RotateMixedShape):
             (bottom_x_point, bottom_z_point, "straight"),
             (bottom_x_point, -1 * self.height / 2, "straight"),
             (self.inner_radius, -1 * self.height / 2, "straight"),
+            (self.inner_radius, 0, "straight"),
         ]
 
         self.points = points


### PR DESCRIPTION
Added endpoint = startpoint to parametric shapes. This is required as the points setter is overwritten in parametric shape classes to accommodate the find_points() methods.