### PR TITLE
updated a few names in the docs and got svg export with stp_filename

### DIFF
--- a/docs/source/example_neutronics_simulations.rst
+++ b/docs/source/example_neutronics_simulations.rst
@@ -1,5 +1,5 @@
-Neutronics Simulations
-======================
+Examples - Neutronics Simulations
+=================================
 
 make_simple_neutronics_model.py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ Features have been added to address particular needs and the software is by no m
 
    paramak.parametric_shapes
    paramak.parametric_components
+   paramak.parametric_reactors
    paramak.core_modules
    example_parametric_shapes
    example_parametric_components

--- a/docs/source/tests.rst
+++ b/docs/source/tests.rst
@@ -1,5 +1,5 @@
-Paramak Module Test Package
-===========================
+Test Suite
+==========
 
 The tests are run automatically with every commit to the github repository and 
 the results are available on Circle Ci. Running the tests locally is also possible

--- a/examples/example_parametric_components/make_all_parametric_components.py
+++ b/examples/example_parametric_components/make_all_parametric_components.py
@@ -8,115 +8,124 @@ import paramak
 def main():
 
     rot_angle = 180
+    all_components = []
 
     plasma = paramak.Plasma(
         # default parameters
-        rotation_angle = rot_angle
+        rotation_angle = rot_angle,
+        stp_filename = 'plasma_shape.stp'
     )
-    plasma.export_stp('plasma_shape.stp')
+    all_components.append(plasma)
 
-
-    shape = paramak.BlanketConstantThicknessFP(
+    component = paramak.BlanketConstantThicknessFP(
         plasma=plasma,
-        thickness = 70,
-        start_angle = 30,
-        stop_angle = 330,
-        offset_from_plasma = 20,
-        rotation_angle = rot_angle
+        thickness=100,
+        stop_angle=90,
+        start_angle=-90,
+        offset_from_plasma=30,
+        rotation_angle=180,
+        stp_filename='blanket_constant_thickness_outboard_plasma.stp'
     )
-    shape.export_stp('blanket_constant_thickness.stp')
+    all_components.append(component)
 
-    shape = paramak.BlanketConstantThicknessFP(
+    component = paramak.BlanketConstantThicknessFP(
+        plasma=plasma,
+        thickness=100,
+        stop_angle=90,
+        start_angle=250,
+        offset_from_plasma=30,
+        rotation_angle=180,
+        stp_filename='blanket_constant_thickness_inboard_plasma.stp'
+    )
+    all_components.append(component)
+
+    component = paramak.BlanketConstantThicknessFP(
         plasma=plasma,
         thickness=100,
         stop_angle=250,
         start_angle=-90,
         offset_from_plasma=30,
-        rotation_angle=180
+        rotation_angle=180,
+        stp_filename='blanket_constant_thickness_plasma.stp'
     )
-    shape.export_stp('blanket_constant_thickness_plasma.stp')
+    all_components.append(component)
 
-    shape = paramak.BlanketConstantThicknessFP(
-        thickness=80, start_angle=-40, stop_angle=230,
-        minor_radius=200, major_radius=620, triangularity=0.55,
-        elongation=1.85, rotation_angle=180)
-    shape.export_stp('blanket_constant_thickness_plasma_from_parameters.stp')
-
-    shape=paramak.ToroidalFieldCoilCoatHanger(
+    component=paramak.ToroidalFieldCoilCoatHanger(
         horizontal_start_point=(200,500),
         horizontal_length=400,
         vertical_start_point=(700,50),
         vertical_length=500,
         thickness=50,
         distance=50,
+        stp_filename='toroidal_field_coil_coat_hanger.stp',
         number_of_coils=5)
-    shape.export_stp('toroidal_field_coil_coat_hanger.stp')
+    all_components.append(component)
 
-
-    shape = paramak.CenterColumnShieldCylinder(
+    component = paramak.CenterColumnShieldCylinder(
         inner_radius = 80,
         outer_radius = 100,
         height = 300,
-        rotation_angle = rot_angle
+        rotation_angle = rot_angle,
+        stp_filename='center_column_shield_cylinder.stp'
     )
-    shape.export_stp('center_column_shield_cylinder.stp')
+    all_components.append(component)
 
-
-    shape = paramak.CenterColumnShieldHyperbola(
+    component = paramak.CenterColumnShieldHyperbola(
         inner_radius = 50,
         mid_radius = 75,
         outer_radius = 100,
         height = 300,
-        rotation_angle = rot_angle
+        rotation_angle = rot_angle,
+        stp_filename='center_column_shield_hyperbola.stp'
     )
-    shape.export_stp('center_column_shield_hyperbola.stp')
+    all_components.append(component)
 
-
-    shape = paramak.CenterColumnShieldCircular(
+    component = paramak.CenterColumnShieldCircular(
         inner_radius = 50,
         mid_radius = 75,
         outer_radius = 100,
         height = 300,
-        rotation_angle = rot_angle
+        rotation_angle = rot_angle,
+        stp_filename='center_column_shield_circular.stp'
     )
-    shape.export_stp('center_column_shield_circular.stp')
+    all_components.append(component)
 
-
-    shape = paramak.CenterColumnShieldFlatTopHyperbola(
-        inner_radius = 50,
-        mid_radius = 75,
-        outer_radius = 100,
-        arc_height = 220,
-        height = 300,
-        rotation_angle = rot_angle
-    )
-    shape.export_stp('center_column_shield_flat_top_hyperbola.stp')
-
-
-    shape = paramak.CenterColumnShieldFlatTopCircular(
+    component = paramak.CenterColumnShieldFlatTopHyperbola(
         inner_radius = 50,
         mid_radius = 75,
         outer_radius = 100,
         arc_height = 220,
         height = 300,
-        rotation_angle = rot_angle
+        rotation_angle = rot_angle,
+        stp_filename='center_column_shield_flat_top_hyperbola.stp'
     )
-    shape.export_stp('center_column_shield_flat_top_Circular.stp')
+    all_components.append(component)
 
+    component = paramak.CenterColumnShieldFlatTopCircular(
+        inner_radius = 50,
+        mid_radius = 75,
+        outer_radius = 100,
+        arc_height = 220,
+        height = 300,
+        rotation_angle = rot_angle,
+        stp_filename='center_column_shield_flat_top_Circular.stp'
+    )
+    all_components.append(component)
 
-    shape = paramak.CenterColumnShieldPlasmaHyperbola(
+    component = paramak.CenterColumnShieldPlasmaHyperbola(
         inner_radius = 150,
         mid_offset = 50,
         edge_offset = 40,
         height = 800,
-        rotation_angle = rot_angle
+        rotation_angle = rot_angle,
+        stp_filename='center_column_shield_plasma_hyperbola.stp'
     )
-    shape.export_stp('center_column_shield_plasma_hyperbola.stp')
+    all_components.append(component)
 
 
     #
 
-    # shape = paramak.DivertorBlock(
+    # component = paramak.DivertorBlock(
     #     major_radius = 800,
     #     minor_radius = 400,
     #     triangularity = 1.2,
@@ -128,80 +137,87 @@ def main():
 
 
 
-    shape = paramak.InnerTfCoilsCircular(
+    component = paramak.InnerTfCoilsCircular(
         inner_radius = 25,
         outer_radius = 100,
         number_of_coils = 10,
         gap_size = 5,
-        height = 300
+        height = 300,
+        stp_filename='inner_tf_coils_circular.stp'
     )
-    shape.export_stp('inner_tf_coils_circular.stp')
+    all_components.append(component)
 
-
-    shape = paramak.InnerTfCoilsFlat(
+    component = paramak.InnerTfCoilsFlat(
         inner_radius = 25,
         outer_radius = 100,
         number_of_coils = 10,
         gap_size = 5,
-        height = 300
+        height = 300,
+        stp_filename='inner_tf_coils_flat.stp'
     )
-    shape.export_stp('inner_tf_coils_flat.stp')
+    all_components.append(component)
 
-
-    shape = paramak.PoloidalFieldCoil(
+    pf_coil = paramak.PoloidalFieldCoil(
         center_point = (100, 100),
         height = 20,
         width = 20,
-        rotation_angle = rot_angle
+        rotation_angle = rot_angle,
+        stp_filename='poloidal_field_coil.stp'
     )
-    shape.export_stp('poloidal_field_coil.stp')
+    all_components.append(pf_coil)
 
-
-    shape = paramak.PoloidalFieldCoilCaseFC(
-        pf_coil=shape,
+    component = paramak.PoloidalFieldCoilCaseFC(
+        pf_coil=pf_coil,
         casing_thickness = 10,
-        rotation_angle = rot_angle
+        rotation_angle = rot_angle,
+        stp_filename='poloidal_field_coil_case_fc.stp'
     )
-    shape.export_stp('poloidal_field_coil_case_fc.stp')
+    all_components.append(component)
 
-
-    shape = paramak.PoloidalFieldCoilCase(
+    component = paramak.PoloidalFieldCoilCase(
         center_point = (100, 100),
         coil_height = 20,
         coil_width = 20,
         casing_thickness = 10,
-        rotation_angle = rot_angle
+        rotation_angle = rot_angle,
+        stp_filename='poloidal_field_coil_case.stp'
     )
-    shape.export_stp('poloidal_field_coil_case.stp')
+    all_components.append(component)
 
-
-    shape = paramak.BlanketConstantThicknessArcV(
+    component = paramak.BlanketConstantThicknessArcV(
                             inner_lower_point=(300,-200),
                             inner_mid_point=(500,0),
                             inner_upper_point=(300,200),
                             thickness=100,
-                            rotation_angle=rot_angle
+                            rotation_angle=rot_angle,
+                            stp_filename='blanket_arc_v.stp'
                             )
-    shape.export_stp('blanket_arc_v.stp')
+    all_components.append(component)
 
-    shape = paramak.BlanketConstantThicknessArcH(
+    component = paramak.BlanketConstantThicknessArcH(
                             inner_lower_point=(300,-200),
                             inner_mid_point=(400,0),
                             inner_upper_point=(300,200),
                             thickness=100,
-                            rotation_angle=rot_angle
+                            rotation_angle=rot_angle,
+                            stp_filename='blanket_arc_h.stp'
                             )
-    shape.export_stp('blanket_arc_h.stp')
+    all_components.append(component)
 
-    shape = paramak.ToroidalFieldCoilRectangle(
+    component = paramak.ToroidalFieldCoilRectangle(
                 inner_upper_point=(100,700),
                 inner_mid_point=(800,0),
                 inner_lower_point=(100,-700),
                 thickness=150,
                 distance=60,
+                stp_filename='tf_coil_rectangle.stp',
                 number_of_coils=6)
-    shape.export_stp('tf_coil_rectangle.stp')
+    all_components.append(component)
+
+    return all_components
 
 
 if __name__ == "__main__":
-    main()
+    all_components = main()
+    for components in all_components:
+        components.export_stp()

--- a/examples/example_parametric_components/make_all_parametric_components_images_for_docs.py
+++ b/examples/example_parametric_components/make_all_parametric_components_images_for_docs.py
@@ -1,0 +1,22 @@
+"""
+This python script demonstrates the creation of all parametric shapes available
+in the paramak tool
+"""
+
+import os
+import paramak
+from make_all_parametric_components import main
+
+def export_images():
+
+    all_componets = main()
+    
+    for componet in all_componets:
+        componet.workplane = 'XY'
+        componet.export_svg(componet.stp_filename[:-3]+'svg')
+        # os.system('conver')
+
+
+
+if __name__ == "__main__":
+    export_images()

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -299,23 +299,29 @@ class Shape:
 
         return str(Pfilename)
 
-    def export_stp(self, filename):
+    def export_stp(self, filename=None):
         """Exports an stp file for the Shape.solid.
         If the provided filename doesn't end with
-        .stp or .step then .stp will be added
+        .stp or .step then .stp will be added. If a
+        filename is not provided and the shapes 
+        stp_filename property is not None the stp_filename
+        will be used as the export filename
 
         :param filename: the filename of the stp
         :type filename: str
         """
 
-        Pfilename = Path(filename)
+        if filename != None:
+            Pfilename = Path(filename)
 
-        if Pfilename.suffix == ".stp" or Pfilename.suffix == ".step":
-            pass
-        else:
-            Pfilename = Pfilename.with_suffix(".stp")
+            if Pfilename.suffix == ".stp" or Pfilename.suffix == ".step":
+                pass
+            else:
+                Pfilename = Pfilename.with_suffix(".stp")
 
-        Pfilename.parents[0].mkdir(parents=True, exist_ok=True)
+            Pfilename.parents[0].mkdir(parents=True, exist_ok=True)
+        elif self.stp_filename != None:
+            Pfilename = Path(self.stp_filename)
 
         with open(Pfilename, "w") as f:
             exporters.exportShape(self.solid, "STEP", f)


### PR DESCRIPTION
This adds a few parts to the read the docs

parametric reactors now have an entry in the docs
the neutronics example has been renamed
shape.export_stp can now check to see if the stp_filename property is uses in the event that the filename argument in none
added a script to generate svg images for the documentation, this required a reworking of the make_all_parametric_componets.py

