### PR TITLE
Add plasma X points locations to Plasma()

### DIFF
--- a/paramak/parametric_components/tokamak_plasma.py
+++ b/paramak/parametric_components/tokamak_plasma.py
@@ -42,6 +42,7 @@ class Plasma(RotateSplineShape):
         triangularity=0.55,
         vertical_displacement=0,
         num_points=50,
+        configuration="non-null",
         solid=None,
         stp_filename="plasma.stp",
         color=None,
@@ -73,10 +74,13 @@ class Plasma(RotateSplineShape):
         self.vertical_displacement = vertical_displacement
         self.num_points = num_points
         self.points = points
+        self.configuration = configuration
+
         self.outer_equatorial_point = None
         self.inner_equatorial_point = None
         self.high_point = None
         self.low_point = None
+        self.lower_x_point, self.upper_x_point = None, None
 
 
     @property

--- a/paramak/parametric_components/tokamak_plasma.py
+++ b/paramak/parametric_components/tokamak_plasma.py
@@ -39,7 +39,6 @@ class Plasma(RotateSplineShape):
         elongation=2.0,
         major_radius=450,
         minor_radius=150,
-        single_null=True,
         triangularity=0.55,
         vertical_displacement=0,
         num_points=50,
@@ -70,13 +69,10 @@ class Plasma(RotateSplineShape):
         self.elongation = elongation
         self.major_radius = major_radius
         self.minor_radius = minor_radius
-        self.single_null = single_null
         self.triangularity = triangularity
         self.vertical_displacement = vertical_displacement
         self.num_points = num_points
         self.points = points
-        self.x_point = None
-        self.z_point = None
         self.outer_equatorial_point = None
         self.inner_equatorial_point = None
         self.high_point = None

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -124,8 +124,8 @@ class test_PoloidalFieldCoilCase(unittest.TestCase):
 
 
 class test_Plasma(unittest.TestCase):
-    def test_plasma_elongation_type(self):
-        """creates a plasma object and checks elongation is type float"""
+    def test_plasma_attributes(self):
+        """creates a plasma object and checks its attributes"""
 
         test_plasma = paramak.Plasma()
 
@@ -144,6 +144,54 @@ class test_Plasma(unittest.TestCase):
             test_plasma.elongation = 400
 
         self.assertRaises(ValueError, test_plasma_elongation_max_setting)
+
+    def test_plasma_x_points(self):
+        """Checks the location of the x point for various plasma configurations
+        """
+        triangularity = -0.7
+        elongation = 1.6
+        minor_radius = 200
+        major_radius = 600
+        for triangularity, elongation, minor_radius, major_radius in zip(
+                [-0.7, 0, 0.5],  # triangularity
+                [1, 1.5, 2],  # elongation
+                [100, 200, 300],  # minor radius
+                [300, 400, 600]):  # major radius
+
+            for config in ["non-null", "single-null", "double-null"]:
+
+                # Run
+                test_plasma = paramak.Plasma(
+                    configuration=config,
+                    triangularity=triangularity,
+                    elongation=elongation,
+                    minor_radius=minor_radius,
+                    major_radius=major_radius)
+
+                # Expected
+                expected_lower_x_point, expected_upper_x_point = None, None
+                if config == "single-null" or \
+                   config == "double-null":
+                    expected_lower_x_point = (
+                        1-(1+test_plasma.x_point_shift)*triangularity *
+                        minor_radius,
+                        (1+test_plasma.x_point_shift)*elongation *
+                        minor_radius
+                    )
+
+                    if config == "double-null":
+                        expected_upper_x_point = (
+                            expected_lower_x_point[0],
+                            -expected_lower_x_point[1]
+                        )
+
+                # Check
+                for point, expected_point in zip(
+                        [test_plasma.lower_x_point,
+                            test_plasma.upper_x_point],
+                        [expected_lower_x_point,
+                            expected_upper_x_point]):
+                    assert point == expected_point
 
     def test_export_plasma_source(self):
         """checks that export_stp() exports plasma stp file"""


### PR DESCRIPTION
This PR includes an extension of the `Plasma()` object by adding several attributes:

`Plasma().configuration` determines if the plasma is non-null, single-null or double-null
`Plasma().lower_x_point` (resp. `Plasma().upper_x_point`) contains the (x, y) coordinates of the lower (resp.upper) X point and is None if there isn't any lower (resp. upper) X point.

This does not change the geometrical aspect of the plasma.

# Usage

```python
import paramak

myPlasma = paramak.Plasma(configuration="single-null")

print(myPlasma.lower_x_points, myPlasma.upper_x_points)

```

# Tests

Some tests were added and existing ones were renamed
