### PR TITLE
Improving parametric reactors

### DIFF
--- a/paramak/parametric_reactors/submersion_ball_reactor.py
+++ b/paramak/parametric_reactors/submersion_ball_reactor.py
@@ -36,6 +36,7 @@ class SubmersionBallReactor(paramak.Reactor):
 
         super().__init__()
 
+        self.inner_bore = 30
         self.major_radius = major_radius
         self.minor_radius = minor_radius
         self.elongation = elongation
@@ -103,7 +104,7 @@ class SubmersionBallReactor(paramak.Reactor):
         inboard_tf_coils = paramak.InnerTfCoilsCircular(
             height=2*(plasma.high_point[1] + self.offset_from_plasma),
             outer_radius = self.center_column_shield_inner_radius,
-            inner_radius = 30,
+            inner_radius = self.inner_bore,
             number_of_coils = self.number_of_tf_coils,
             gap_size=5,
             stp_filename="inboard_tf_coils.stp",

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -29,6 +29,14 @@ class Reactor():
         self.stp_filenames = []
         self.solid = None
 
+    @property
+    def solid(self):
+        return cq.Compound.makeCompound([a.solid.val() for a in self.shapes_and_components])
+
+    @solid.setter
+    def solid(self, value):
+        self._solid = value
+
     def add_shape_or_component(self, shapes):
         """Adds a parametric shape(s) or a parametric component(s) to the Reactor 
         object. An individual shape/component or a list of shapes/ components are
@@ -62,8 +70,6 @@ class Reactor():
                 else:
                     self.stp_filenames.append(shapes.stp_filename)
             self.shapes_and_components.append(shapes)
-        
-        self.solid = cq.Compound.makeCompound([a.solid.val() for a in self.shapes_and_components])
 
     def neutronics_description(self):
         """A descirption of the reactor containing materials and the filenames,

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -95,9 +95,17 @@ class Reactor():
                                   Reactor entries before using this method"
                 )
 
-            Shape_neutronics_description = entry.neutronics_description(
-                stp_filename=entry.stp_filename, material_tag=entry.material_tag
-            )
+            if entry.tet_mesh == None:
+                Shape_neutronics_description = entry.neutronics_description(
+                    stp_filename=entry.stp_filename,
+                    material_tag=entry.material_tag 
+                )
+            else:
+                Shape_neutronics_description = entry.neutronics_description(
+                    stp_filename=entry.stp_filename,
+                    material_tag=entry.material_tag,
+                    tet_mesh=entry.tet_mesh 
+                )
 
             neutronics_description.append(Shape_neutronics_description)
 

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -56,19 +56,17 @@ class Shape:
         self.stp_filename = stp_filename
         self.color = color
         self.name = name
-        self.material_tag = material_tag
+
         self.azimuth_placement_angle = azimuth_placement_angle
         self.workplane = workplane
 
         # neutronics specific properties
-        self.material = None
-        self.neutronics_material = None
-        self.tallies = []
+        self.material_tag = material_tag
+        self.tet_mesh = None
 
         # properties calculated internally by the class
         self.solid = None
         self.render_mesh = None
-        self.mesh = None
         # self.volume = None
 
     @property
@@ -109,6 +107,19 @@ class Shape:
             self._material_tag = value
         else:
             raise ValueError("Shape.material_tag must be a string", value)
+
+    @property
+    def tet_mesh(self):
+        return self._tet_mesh
+
+    @tet_mesh.setter
+    def tet_mesh(self, value):
+        if value is None:
+            self._tet_mesh = value
+        elif type(value) == str:
+            self._tet_mesh = value
+        else:
+            raise ValueError("Shape.tet_mesh must be a string", value)
 
     @property
     def name(self):
@@ -579,13 +590,20 @@ class Shape:
         self.patch = p
         return p
 
-    def neutronics_description(self, stp_filename, material_tag):
+    def neutronics_description(self, stp_filename, material_tag, tet_mesh=None):
         """Returns a neutronics description of the Shape object.
-        This is needed for the geomPipeline.py which imprints and
-        merges the geometry.
+        This is needed for the use with automated neutronics model
+        methods which require linkage between the stp files and
+        materials. If tet meshing of the volume is required then
+        Trelis meshing commands can optinally be specificed as
+        the tet_mesh argument.
 
         :return: a dictionary of the step filename and material name.
         :rtype: dictionary
         """
 
-        return {"material": self.material_tag, "filename": self.stp_filename}
+        neutronics_description = {"material": self.material_tag,
+                                  "filename": self.stp_filename}
+        if self.tet_mesh != None:
+            neutronics_description['tet_mesh'] = self.tet_mesh
+        return neutronics_description

--- a/tests/test_BallReactor.py
+++ b/tests/test_BallReactor.py
@@ -13,17 +13,16 @@ class test_BallReactor(unittest.TestCase):
         """creates blanket from parametric shape and checks a solid is created"""
 
         test_shape = paramak.BallReactor(
-            major_radius=300,
-            minor_radius=100,
-            elongation=2,
-            triangularity=0.9,
-            offset_from_plasma=20,
-            blanket_thickness=100,
-            center_column_shield_outer_radius=180,
-            center_column_shield_inner_radius=120,
-            number_of_tf_coils=16,
-            divertor_width=100,
-            rotation_angle = 180
+                        inner_bore_radial_thickness=50,
+                        inboard_tf_leg_radial_thickness = 200,
+                        center_column_radial_thickness= 50,
+                        inner_plasma_gap_radial_thickness = 200,
+                        plasma_radial_thickness = 100,
+                        outer_plasma_gap_radial_thickness = 50,
+                        blanket_radial_thickness=100,
+                        elongation=2,
+                        triangularity=0.55,
+                        number_of_tf_coils=16,
         )
 
         test_shape.export_stp()

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -242,6 +242,7 @@ class test_object_properties(unittest.TestCase):
         test_shape.rotation_angle = 360
         test_shape.material_tag = "test_material"
         test_shape.stp_filename = "test.stp"
+        test_shape.tet_mesh = "size 60"
         test_reactor = paramak.Reactor()
         test_reactor.add_shape_or_component(test_shape)
         returned_filename = test_reactor.export_neutronics_description(
@@ -255,8 +256,10 @@ class test_object_properties(unittest.TestCase):
         assert len(neutronics_description) == 2
         assert "filename" in neutronics_description[0].keys()
         assert "material" in neutronics_description[0].keys()
+        assert "tet_mesh" in neutronics_description[0].keys()
         assert neutronics_description[0]["material"] == "test_material"
         assert neutronics_description[0]["filename"] == "test.stp"
+        assert neutronics_description[0]["tet_mesh"] == "size 60"
         assert neutronics_description[1]["material"] == "Graveyard"
         assert neutronics_description[1]["filename"] == "Graveyard.stp"
         os.system("rm manifest_test.json")

--- a/tests/test_SubmersionBallReactor.py
+++ b/tests/test_SubmersionBallReactor.py
@@ -20,7 +20,9 @@ class test_SubmersionBallReactor(unittest.TestCase):
                                  center_column_shield_outer_radius=160,
                                  center_column_shield_inner_radius=100,
                                  number_of_tf_coils=16,
-                                 casing_thickness=10
+                                 casing_thickness=10,
+                                 elongation=2,
+                                 triangularity=0.55,
                                  )
 
-        assert len(test_shape.shapes_and_components) == 3
+        assert len(test_shape.shapes_and_components) == 5


### PR DESCRIPTION
This PR adds tet_mesh to the neutronics description and converts the BallReactor arguments into radial thicknesses

The tet_mesh addition allows us to streamline the tet mesh creation for components or shapes in trelis as we can specific the tet mesh command when creating the shape/ component

The new BallReactor arguments make it much harder for users to create reactors that overlap. Previously the user could make reactors where the plasma overlaps the center coulmn but now due to the shift to a radial build approach this is protected against.

The BallReactor still needs improved divertors, magnets etc and the submersion reactor needs to be converted to this linear radial build input form but that can be done in another PR