### PR TITLE
added svg export and tests

### DIFF
--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -4,6 +4,7 @@ from collections import Iterable
 from pathlib import Path
 
 import cadquery as cq
+from cadquery import exporters
 import matplotlib.pyplot as plt
 import numpy as np
 import plotly.graph_objects as go
@@ -176,6 +177,25 @@ class Reactor():
         print("exported stp files ", filenames)
 
         return filenames
+
+    def export_svg(self, filename):
+        """Exports an svg file for the Reactor.solid.
+        If the provided filename doesn't end with .svg it will be added
+
+        :param filename: the filename of the svg
+        :type filename: str
+        """
+
+        Pfilename = Path(filename)
+
+        if Pfilename.suffix != ".svg":
+            Pfilename = Pfilename.with_suffix(".svg")
+
+        Pfilename.parents[0].mkdir(parents=True, exist_ok=True)
+
+        with open(Pfilename, "w") as f:
+            exporters.exportShape(self.solid, "SVG", f)
+        print("Saved file as ", Pfilename)
 
     def export_graveyard(self, filename="Graveyard.stp"):
         """Writes a stp file (CAD geometry) for the reactor graveyard.

--- a/tests/test_BallReactor.py
+++ b/tests/test_BallReactor.py
@@ -28,3 +28,22 @@ class test_BallReactor(unittest.TestCase):
         test_shape.export_stp()
 
         assert len(test_shape.shapes_and_components) == 6
+
+    def test_BallReactor_creation(self):
+        os.system("rm test_ballreactor_image.svg")
+        my_reactor = paramak.BallReactor(
+                                    inner_bore_radial_thickness=50,
+                                    inboard_tf_leg_radial_thickness = 200,
+                                    center_column_radial_thickness= 50,
+                                    inner_plasma_gap_radial_thickness = 200,
+                                    plasma_radial_thickness = 100,
+                                    outer_plasma_gap_radial_thickness = 50,
+                                    blanket_radial_thickness=100,
+                                    elongation=2,
+                                    triangularity=0.55,
+                                    number_of_tf_coils=16,
+        )
+        my_reactor.export_svg('test_ballreactor_image.svg')
+
+        assert Path("test_ballreactor_image.svg").exists() is True
+        os.system("rm test_ballreactor_image.svg")

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -181,6 +181,22 @@ class test_object_properties(unittest.TestCase):
             assert Path(filepath).exists() is True
             os.system("rm " + filepath)
 
+    def test_exported_svg_files_exist(self):
+        """checks that export_stp() creates stp file in the \
+                specified location"""
+
+        test_shape = paramak.RotateStraightShape(
+            points=[(0, 0), (0, 20), (20, 20)])
+        test_shape.rotation_angle = 360
+        os.system("rm test_svg_image.svg")
+        test_reactor = paramak.Reactor()
+        test_reactor.add_shape_or_component(test_shape)
+
+        test_reactor.export_svg("test_svg_image.svg")
+
+        assert Path("test_svg_image.svg").exists() is True
+        os.system("rm test_svg_image.svg")
+
     def test_neutronics_desscription(self):
         def test_neutronics_description_without_material_tag():
             """checks that a ValueError is raised when the neutronics description \


### PR DESCRIPTION
This adds .svg export to parametric reactors, the export_svg doesn't currently support a view orientation so the default is XY which means the svg images are not ideal for the XZ based reactor.

Future solutions for this might come from CADquery or the reactor can be rotated
