### PR TITLE
Building block of FE simulations: look-up table for exporting physical groups

### DIFF
--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -164,7 +164,7 @@ class Reactor():
                                  Shapes before using the export_stp method"
                 )
             filenames.append(str(Path(output_folder) / Path(entry.stp_filename)))
-            entry.export_stp(Path(output_folder) / Path(entry.stp_filename), export_look_up_table=export_look_up_tables)
+            entry.export_stp(Path(output_folder) / Path(entry.stp_filename))
 
         # creates a graveyard (bounding shell volume) which is needed for nuetronics simulations
         self.make_graveyard()

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -146,7 +146,7 @@ class Reactor():
 
         return filename
 
-    def export_stp(self, output_folder="", export_look_up_tables=False):
+    def export_stp(self, output_folder=""):
         """Writes stp files (CAD geometry) for each Shape object in the reactor
 
         :param output_folder: the folder for saving the stp files to

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -177,6 +177,32 @@ class Reactor():
 
         return filenames
 
+    def export_physical_groups(self, output_folder=""):
+        """Exports several JSON files containing a look up table
+        which is useful for identifying faces and volumes. The
+        output file names are generated from .stp_filename properties.
+
+        Args:
+            output_folder (str, optional): directory of outputfiles.
+                Defaults to "".
+
+        Raises:
+            ValueError: if one .stp_filename property is set to None
+
+        Returns:
+            list: list of output file names
+        """
+        filenames = []
+        for entry in self.shapes_and_components:
+            if entry.stp_filename is None:
+                raise ValueError(
+                    "set .stp_filename property for \
+                                 Shapes before using the export_stp method"
+                )
+            filenames.append(str(Path(output_folder) / Path(entry.stp_filename)))
+            entry.export_physical_groups(Path(output_folder) / Path(entry.stp_filename))
+        return filenames
+
     def export_graveyard(self, filename="Graveyard.stp"):
         """Writes a stp file (CAD geometry) for the reactor graveyard.
            Thich is needed for DAGMC simulations

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -146,7 +146,7 @@ class Reactor():
 
         return filename
 
-    def export_stp(self, output_folder=""):
+    def export_stp(self, output_folder="", export_look_up_tables=False):
         """Writes stp files (CAD geometry) for each Shape object in the reactor
 
         :param output_folder: the folder for saving the stp files to
@@ -164,7 +164,7 @@ class Reactor():
                                  Shapes before using the export_stp method"
                 )
             filenames.append(str(Path(output_folder) / Path(entry.stp_filename)))
-            entry.export_stp(Path(output_folder) / Path(entry.stp_filename))
+            entry.export_stp(Path(output_folder) / Path(entry.stp_filename), export_look_up_table=export_look_up_tables)
 
         # creates a graveyard (bounding shell volume) which is needed for nuetronics simulations
         self.make_graveyard()

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -314,7 +314,7 @@ class Shape:
 
         return str(Pfilename)
 
-    def export_stp(self, filename=None, export_look_up_table=False):
+    def export_stp(self, filename=None:
         """Exports an stp file for the Shape.solid.
         If the provided filename doesn't end with
         .stp or .step then .stp will be added. If a

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -71,7 +71,7 @@ class Shape:
         self.render_mesh = None
         # self.volume = None
 
-        self.look_up_table = None
+        self.physical_groups = None
 
     @property
     def workplane(self):
@@ -344,9 +344,9 @@ class Shape:
 
         return str(Pfilename)
 
-    def export_look_up_table(self, filename):
+    def export_physical_groups(self, filename):
         """Exports a JSON file containing a look up table
-        which is useful for identifying faces. If provided
+        which is useful for identifying faces and volumes. If provided
         filename doesn't end with .json then .json will be added.
 
         :param filename: the filename to save the json look up table
@@ -364,9 +364,9 @@ class Shape:
         Pfilename.parents[0].mkdir(parents=True, exist_ok=True)
 
         with open(filename, "w") as outfile:
-            json.dump(self.look_up_table, outfile, indent=4)
+            json.dump(self.physical_groups, outfile, indent=4)
 
-        print("saved geometry description to ", Pfilename)
+        print("Saved physical_groups description to ", Pfilename)
 
         return filename
 

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -315,7 +315,7 @@ class Shape:
 
         return str(Pfilename)
 
-    def export_stp(self, filename=None):
+    def export_stp(self, filename=None, export_look_up_table=False):
         """Exports an stp file for the Shape.solid.
         If the provided filename doesn't end with
         .stp or .step then .stp will be added. If a
@@ -344,13 +344,16 @@ class Shape:
         print("Saved file as ", Pfilename)
 
         # saving look up table
-        if self.look_up_table is not None:
-            if filename.endswith('.stp'):
-                prefix = filename[:-4]
-            json_filename = '{}_lookup_table.json'.format(prefix)
-            with open(json_filename, 'w+') as outfile:
-                json.dump(self.look_up_table, outfile)
-            print("Saved look-up table as {}".format(json_filename))
+        if export_look_up_table:
+            if self.look_up_table is not None:
+                if filename.endswith('.stp'):
+                    prefix = filename[:-4]
+                json_filename = '{}_lookup_table.json'.format(prefix)
+                with open(json_filename, 'w+') as outfile:
+                    json.dump(self.look_up_table, outfile)
+                print("Saved look-up table as {}".format(json_filename))
+            else:
+                print("Look-up table not found for shape {}".format(self.name))
 
         return str(Pfilename)
 

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -13,6 +13,8 @@ import plotly.graph_objects as go
 import pyrender
 import trimesh
 
+import json
+
 
 class Shape:
     """A shape object that represents a 3d volume and can have materials and
@@ -50,6 +52,7 @@ class Shape:
         stp_filename=None,
         azimuth_placement_angle=0,
         workplane="XZ",
+        look_up_table=None,
     ):
 
         self.points = points
@@ -68,6 +71,8 @@ class Shape:
         self.solid = None
         self.render_mesh = None
         # self.volume = None
+
+        self.look_up_table = look_up_table
 
     @property
     def workplane(self):
@@ -337,6 +342,15 @@ class Shape:
         with open(Pfilename, "w") as f:
             exporters.exportShape(self.solid, "STEP", f)
         print("Saved file as ", Pfilename)
+
+        # saving look up table
+        if self.look_up_table is not None:
+            if filename.endswith('.stp'):
+                prefix = filename[:-4]
+            json_filename = '{}_lookup_table.json'.format(prefix)
+            with open(json_filename, 'w+') as outfile:
+                json.dump(self.look_up_table, outfile)
+            print("Saved look-up table as {}".format(json_filename))
 
         return str(Pfilename)
 

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -324,9 +324,6 @@ class Shape:
 
         :param filename: the filename of the stp
         :type filename: str
-        :param export_look_up_table: if set to True, the look up table
-            will be exported. Defaults to False.
-        :type filename: bool
         """
 
         if filename is not None:

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -52,7 +52,6 @@ class Shape:
         stp_filename=None,
         azimuth_placement_angle=0,
         workplane="XZ",
-        look_up_table=None,
     ):
 
         self.points = points
@@ -72,7 +71,7 @@ class Shape:
         self.render_mesh = None
         # self.volume = None
 
-        self.look_up_table = look_up_table
+        self.look_up_table = None
 
     @property
     def workplane(self):

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -342,18 +342,8 @@ class Shape:
             exporters.exportShape(self.solid, "STEP", f)
         print("Saved file as ", Pfilename)
 
-        # saving look up table
         if export_look_up_table:
-            if self.look_up_table is not None:
-                if filename.endswith('.stp'):
-                    prefix = filename[:-4]
-                json_filename = '{}_lookup_table.json'.format(prefix)
-                with open(json_filename, 'w+') as outfile:
-                    json.dump(self.look_up_table, outfile)
-                print("Saved look-up table as {}".format(json_filename))
-            else:
-                print("Look-up table not found for shape {}".format(self.name))
-
+            self.export_look_up_table(filename=Pfilename.with_suffix(".json"))
         return str(Pfilename)
 
     def export_look_up_table(self, filename):

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -345,8 +345,6 @@ class Shape:
             exporters.exportShape(self.solid, "STEP", f)
         print("Saved file as ", Pfilename)
 
-        if export_look_up_table:
-            self.export_look_up_table(filename=Pfilename.with_suffix(".json"))
         return str(Pfilename)
 
     def export_look_up_table(self, filename):

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -319,7 +319,7 @@ class Shape:
         """Exports an stp file for the Shape.solid.
         If the provided filename doesn't end with
         .stp or .step then .stp will be added. If a
-        filename is not provided and the shapes 
+        filename is not provided and the shapes
         stp_filename property is not None the stp_filename
         will be used as the export filename
 
@@ -327,7 +327,7 @@ class Shape:
         :type filename: str
         """
 
-        if filename != None:
+        if filename is not None:
             Pfilename = Path(filename)
 
             if Pfilename.suffix == ".stp" or Pfilename.suffix == ".step":
@@ -336,7 +336,7 @@ class Shape:
                 Pfilename = Pfilename.with_suffix(".stp")
 
             Pfilename.parents[0].mkdir(parents=True, exist_ok=True)
-        elif self.stp_filename != None:
+        elif self.stp_filename is not None:
             Pfilename = Path(self.stp_filename)
 
         with open(Pfilename, "w") as f:

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -314,7 +314,7 @@ class Shape:
 
         return str(Pfilename)
 
-    def export_stp(self, filename=None:
+    def export_stp(self, filename=None):
         """Exports an stp file for the Shape.solid.
         If the provided filename doesn't end with
         .stp or .step then .stp will be added. If a

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -355,7 +355,31 @@ class Shape:
                 print("Look-up table not found for shape {}".format(self.name))
 
         return str(Pfilename)
+    def export_look_up_table(self, filename):
+        """Exports a JSON file containing a look up table
+        which is useful for identifying faces. If provided
+        filename doesn't end with .json then .json will be added.
 
+        :param filename: the filename to save the json look up table
+        :type filename: str
+
+        :param filename: the filename of the json file
+        :type filename: str
+        """
+
+        Pfilename = Path(filename)
+
+        if Pfilename.suffix != ".json":
+            Pfilename = Pfilename.with_suffix(".json")
+
+        Pfilename.parents[0].mkdir(parents=True, exist_ok=True)
+
+        with open(filename, "w") as outfile:
+            json.dump(self.look_up_table(), outfile, indent=4)
+
+        print("saved geometry description to ", Pfilename)
+
+        return filename
     def export_svg(self, filename):
         """Exports an svg file for the Shape.solid.
         If the provided filename doesn't end with .svg it will be added

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -355,6 +355,7 @@ class Shape:
                 print("Look-up table not found for shape {}".format(self.name))
 
         return str(Pfilename)
+
     def export_look_up_table(self, filename):
         """Exports a JSON file containing a look up table
         which is useful for identifying faces. If provided
@@ -375,11 +376,12 @@ class Shape:
         Pfilename.parents[0].mkdir(parents=True, exist_ok=True)
 
         with open(filename, "w") as outfile:
-            json.dump(self.look_up_table(), outfile, indent=4)
+            json.dump(self.look_up_table, outfile, indent=4)
 
         print("saved geometry description to ", Pfilename)
 
         return filename
+
     def export_svg(self, filename):
         """Exports an svg file for the Shape.solid.
         If the provided filename doesn't end with .svg it will be added

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -324,6 +324,9 @@ class Shape:
 
         :param filename: the filename of the stp
         :type filename: str
+        :param export_look_up_table: if set to True, the look up table
+            will be exported. Defaults to False.
+        :type filename: bool
         """
 
         if filename is not None:

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -362,11 +362,14 @@ class Shape:
             Pfilename = Pfilename.with_suffix(".json")
 
         Pfilename.parents[0].mkdir(parents=True, exist_ok=True)
+        if self.physical_groups is not None:
+            with open(filename, "w") as outfile:
+                json.dump(self.physical_groups, outfile, indent=4)
 
-        with open(filename, "w") as outfile:
-            json.dump(self.physical_groups, outfile, indent=4)
-
-        print("Saved physical_groups description to ", Pfilename)
+            print("Saved physical_groups description to ", Pfilename)
+        else:
+            print("Warning: physical_groups attribute is None \
+                for {}".format(self.name))
 
         return filename
 


### PR DESCRIPTION
**This PR aims to introduce ways for exporting information (readable by humans) on physical groups in step files.**

### Current state:
If a user wants to use the generated step file of say a `BlanketConstantThicknessFP()` in a FE program, he/she needs to guess (or trial/error):
- the number of physical groups (physical surfaces and volumes)
- which id (already generated by CADquery) corresponds to which physical group

### This PR:
Classes inheriting from `Shape()` can now have an attribute called `look_up_table` which contains a list of dicts with physical groups infos: 
```python
look_up_table = [
    {"dim": 3, "id": 1, "name": "inside_volume"},
    {"dim": 2, "id": 1, "name": "top_surface"},
    {"dim": 2, "id": 2, "name": "inner_surface"},
    {"dim": 2, "id": 2, "name": "outer_surface"},
]
```

Above, the relations between "id" and "name" have to be determined in `BlanketConstantThicknessFP()` before hand.

This look-up table is exported in a JSON file when the STEP file is generated.
Now a user willing to use the STEP file in a FE program can rely on this table to apply boundary conditions and material properties without having to spend time in trial/error.


### Example usage with GMSH
```python
import gmsh
import json
gmsh.initialize()
gmsh.option.setNumber("General.Terminal", 1)  # for message printing


def generate_mesh(stepfile, lookup_table, meshfile="mesh", directory="."):

    # gmsh.merge(stepfile)
    gmsh.model.occ.importShapes(stepfile)
    gmsh.model.occ.synchronize()
    for group in lookup_table:
        dim = group["dim"]
        id_ = group["id"]
        gmsh.model.addPhysicalGroup(dim, [id_])
        gmsh.model.setPhysicalName(dim, id_, group["name"])

    gmsh.model.mesh.generate(3)

    gmsh.write("{}/{}.msh".format(directory, meshfile))
    gmsh.finalize()
    return


# LOAD LOOK-UP TABLE
with open('step_file_look_up_table.json') as f:
  look_up_table = json.load(f)

# GENERATE MESH
generate_mesh("step_file.stp", lookup_table)

```

### ToDo:
- Create these look-up tables for parametric components (Defaulting to `None` so that it doesn't break any test)
- Discuss this with a super developping team
