### PR TITLE
Physical groups for BlanketConstantThicknessFP

### DIFF
--- a/paramak/parametric_components/blanket_constant_thickness_fp.py
+++ b/paramak/parametric_components/blanket_constant_thickness_fp.py
@@ -246,12 +246,17 @@ class BlanketConstantThicknessFP(RotateMixedShape):
         return points
 
     def create_physical_groups(self):
+        """Creates the physical groups for STP files
+
+        Returns:
+            list: list of dicts containing the physical groups
+        """
+
         def diff_between_angles(a, b):
             c = (b - a) % 360
             if c > 180:
                 c -= 360
             return c
-
         groups = []
         nb_volumes = 1  # only one volume
         nb_surfaces = 2  # inner and outer

--- a/paramak/parametric_components/blanket_constant_thickness_fp.py
+++ b/paramak/parametric_components/blanket_constant_thickness_fp.py
@@ -119,7 +119,8 @@ class BlanketConstantThicknessFP(RotateMixedShape):
 
     @property
     def physical_groups(self):
-        return self.create_physical_groups()
+        self.create_physical_groups()
+        return self._physical_groups
 
     @physical_groups.setter
     def physical_groups(self, physical_groups):
@@ -277,7 +278,7 @@ class BlanketConstantThicknessFP(RotateMixedShape):
             stop_equals_start = True
 
         # rearrange order
-        # TODO: fix issue #86
+        # TODO: fix issue #86 (full coverage)
         if full_rot:
             if stop_equals_start:
                 print("Warning: If start_angle = stop_angle surfaces will not\
@@ -316,4 +317,4 @@ class BlanketConstantThicknessFP(RotateMixedShape):
                 "name": surface_names[i-1]
             }
             groups.append(group)
-        return groups
+        self.physical_groups = groups

--- a/paramak/parametric_components/blanket_constant_thickness_fp.py
+++ b/paramak/parametric_components/blanket_constant_thickness_fp.py
@@ -119,8 +119,7 @@ class BlanketConstantThicknessFP(RotateMixedShape):
 
     @property
     def physical_groups(self):
-        self.create_physical_groups()
-        return self._physical_groups
+        return self.create_physical_groups()
 
     @physical_groups.setter
     def physical_groups(self, physical_groups):

--- a/paramak/parametric_components/blanket_constant_thickness_fp.py
+++ b/paramak/parametric_components/blanket_constant_thickness_fp.py
@@ -114,6 +114,7 @@ class BlanketConstantThicknessFP(RotateMixedShape):
             self.offset_from_plasma = offset_from_plasma
         self.num_points = num_points
         self.points = points
+        self.physical_groups = self.create_physical_groups()
 
     @property
     def points(self):
@@ -190,6 +191,7 @@ class BlanketConstantThicknessFP(RotateMixedShape):
             self.thickness + self.offset_from_plasma, flip=True)
         points = points + outer_points
         points[-2][2] = 'straight'
+
         self.points = points
 
     def create_offset_points(self, thetas, R_fun, Z_fun, R_derivative, Z_derivative, offset, flip=False):
@@ -242,3 +244,47 @@ class BlanketConstantThicknessFP(RotateMixedShape):
             points.append([float(val_R_outer), float(val_Z_outer), 'spline'])
             
         return points
+
+    def create_physical_groups(self):
+        def diff_between_angles(a, b):
+            c = (b - a) % 360
+            if c > 180:
+                c -= 360
+            return c
+
+        groups = []
+        nb_volumes = 1  # only one volume
+        nb_surfaces = 2  # inner and outer
+
+        surface_names = ["inner", "outer"]
+        volumes_names = ["inside"]
+
+        # add two cut sections if they exist
+        if self.rotation_angle != 360:
+            nb_surfaces += 2
+            surface_names += ["left_section", "right_section"]
+
+        # add two surfaces between blanket and div if they exist
+        if diff_between_angles(self.start_angle, self.stop_angle) != 0:
+            nb_surfaces += 2
+            surface_names += ["inner_section", "outer_section"]
+
+        # rearrange order
+        # TODO: make this generic
+        surface_names = ["inner", "inner_section", "outer", "outer_section",
+                         "lef_section", "right_section"]
+        for i in range(1, nb_volumes+1):
+            group = {
+                "dim": 3,
+                "id": i,
+                "name": volumes_names[i-1]
+            }
+            groups.append(group)
+        for i in range(1, nb_surfaces+1):
+            group = {
+                "dim": 2,
+                "id": i,
+                "name": surface_names[i-1]
+            }
+            groups.append(group)
+        return groups

--- a/paramak/parametric_components/blanket_constant_thickness_fp.py
+++ b/paramak/parametric_components/blanket_constant_thickness_fp.py
@@ -114,7 +114,16 @@ class BlanketConstantThicknessFP(RotateMixedShape):
             self.offset_from_plasma = offset_from_plasma
         self.num_points = num_points
         self.points = points
-        self.physical_groups = self.create_physical_groups()
+        self.physical_groups = None
+
+    @property
+    def physical_groups(self):
+        self.create_physical_groups()
+        return self._physical_groups
+
+    @physical_groups.setter
+    def physical_groups(self, physical_groups):
+        self._physical_groups = physical_groups
 
     @property
     def points(self):

--- a/paramak/parametric_components/blanket_constant_thickness_fp.py
+++ b/paramak/parametric_components/blanket_constant_thickness_fp.py
@@ -263,16 +263,44 @@ class BlanketConstantThicknessFP(RotateMixedShape):
         if self.rotation_angle != 360:
             nb_surfaces += 2
             surface_names += ["left_section", "right_section"]
+            full_rot = False
+        else:
+            full_rot = True
 
         # add two surfaces between blanket and div if they exist
         if diff_between_angles(self.start_angle, self.stop_angle) != 0:
             nb_surfaces += 2
             surface_names += ["inner_section", "outer_section"]
+            stop_equals_start = False
+        else:
+            stop_equals_start = True
 
         # rearrange order
-        # TODO: make this generic
-        surface_names = ["inner", "inner_section", "outer", "outer_section",
-                         "lef_section", "right_section"]
+        # TODO: fix issue #86
+        if full_rot:
+            if stop_equals_start:
+                print("Warning: If start_angle = stop_angle surfaces will not\
+                     be handled correctly")
+                new_order = [0, 1, 2, 3]
+            else:
+                # from ["inner", "outer", "inner_section", "outer_section"]
+
+                # to ["inner", "inner_section", "outer", "outer_section"]
+                new_order = [0, 2, 1, 3]
+        else:
+            if stop_equals_start:
+                print("Warning: If start_angle = stop_angle surfaces will not\
+                     be handled correctly")
+                new_order = [0, 1, 2, 3]
+            else:
+                # from ['inner', 'outer', 'left_section', 'right_section',
+                #           'inner_section', 'outer_section']
+
+                # to ["inner", "inner_section", "outer", "outer_section",
+                #         "left_section", "right_section"]
+                new_order = [0, 4,  1, 5, 2, 3]
+        surface_names = [surface_names[i] for i in new_order]
+
         for i in range(1, nb_volumes+1):
             group = {
                 "dim": 3,

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -115,7 +115,9 @@ class test_BlanketConstantThicknessFP(unittest.TestCase):
     def test_BlanketConstantThicknessFP_physical_groups(self):
         """Creates default blanket and checks the exports of physical groups
         """
-        test_shape = paramak.BlanketConstantThicknessFP(100)
+        test_shape = paramak.BlanketConstantThicknessFP(
+            100, stop_angle=90,
+            start_angle=270,)
         test_shape.export_physical_groups('tests/blanket.json')
 
 

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -112,6 +112,13 @@ class test_BlanketConstantThicknessFP(unittest.TestCase):
         assert test_shape.solid is not None
         assert test_shape.volume > 1000
 
+    def test_BlanketConstantThicknessFP_physical_groups(self):
+        """Creates default blanket and checks the exports of physical groups
+        """
+        test_shape = paramak.BlanketConstantThicknessFP(100)
+        test_shape.export_physical_groups('tests/blanket.json')
+
+
 class test_PoloidalFieldCoilCase(unittest.TestCase):
     def test_PoloidalFieldCoilCase_creation(self):
         """creates a poloidal field coil from parametric shape and checks a solid is created"""


### PR DESCRIPTION
This PR includes a new method for adding physical groups (with names) to `paramak.BlanketConstantThicknessFP()`.
The surfaces are labelled as shown below:
![image](https://user-images.githubusercontent.com/40028739/87777369-a2df9f00-c829-11ea-9ee6-6c62dce3e5d9.png)



## Usage

```python
from paramak import BlanketConstantThicknessFP

my_shape = BlanketConstantThicknessFP(100, start_angle=0, stop_angle=180, rotation_angle=180)

my_shape.export_stp('blanket.stp')
my_shape.export_physical_groups('blanket.json')
```

If `rotation_angle` = 360 then `'left_section'` and `'right_section'` don't exist.

These physical groups can then be read in GMSH  as described in #83.

## Known bugs

-  If `start_angle` = `stop_angle` mod 2*k*pi, `inner_section `and `outer_section ` are not be exported since they don't normally exist. Though `inner_section `and `outer_section ` exist due this bug #86 

## ToDo

- [ ]  Find a way to test this

- [x] Reorder the surfaces names in accordance with internal STEP files surfaces ids in a more generic way (2, 4 or 6 surfaces)