### PR TITLE
Full coverage blanket fix: The Revenge

### DIFF
--- a/paramak/parametric_components/blanket_constant_thickness_fp.py
+++ b/paramak/parametric_components/blanket_constant_thickness_fp.py
@@ -171,24 +171,24 @@ class BlanketConstantThicknessFP(RotateMixedShape):
             inner_points_R = R(thetas)
             inner_points_Z = Z(thetas)
 
-            points = [
+            inner_points = [
                 [inner_points_R[i], inner_points_Z[i], 'spline']
                 for i in range(len(thetas))
                 ]
         else:
             # if a plasma is given
-            points = self.create_offset_points(
+            inner_points = self.create_offset_points(
                 thetas, R, Z,
                 R_derivative, Z_derivative,
                 self.offset_from_plasma)
-        points[-1][2] = 'straight'
+        inner_points[-1][2] = 'straight'
 
         # compute outer points
         outer_points = self.create_offset_points(
             thetas, R, Z,
             R_derivative, Z_derivative,
             self.thickness + self.offset_from_plasma, flip=True)
-        points = points + outer_points
+        points = inner_points + outer_points
 
         def diff_between_angles(a, b):
             c = (b - a) % 360

--- a/paramak/parametric_components/blanket_constant_thickness_fp.py
+++ b/paramak/parametric_components/blanket_constant_thickness_fp.py
@@ -28,7 +28,8 @@ class BlanketConstantThicknessFP(RotateMixedShape):
     :type elongation: float
     :param vertical_displacement: the vertical_displacement of the plasma (cm)
     :type vertical_displacement: float
-    :param offset_from_plasma: the distance bettwen the plasma and the blanket (cm)
+    :param offset_from_plasma: the distance bettwen the plasma and the blanket
+        (cm)
     :type offset_from_plasma: float
     :param num_points: number of points that will describe the shape
     :type num_points: int
@@ -184,8 +185,9 @@ class BlanketConstantThicknessFP(RotateMixedShape):
         self.points = points
 
     def create_offset_points(self, thetas, R_fun, Z_fun, offset):
-        """generates a list of points following parametric equations with an offset
-        
+        """generates a list of points following parametric equations with an
+        offset
+
         :param thetas: list of angles (radians)
         :type thetas: list
         :param R_fun: parametric function for R coordinate (cm)
@@ -195,7 +197,8 @@ class BlanketConstantThicknessFP(RotateMixedShape):
         :param offset: offset value (cm). offset=0 will follow the parametric
          equations.
 
-        :return: list of points [[R1, Z1, connection1], [R2, Z2, connection2], ...]
+        :return: list of points [[R1, Z1, connection1], [R2, Z2, connection2],
+            ...]
         :rtype: list
         """
         # create sympy objects and derivatives

--- a/paramak/parametric_components/blanket_constant_thickness_fp.py
+++ b/paramak/parametric_components/blanket_constant_thickness_fp.py
@@ -189,18 +189,9 @@ class BlanketConstantThicknessFP(RotateMixedShape):
             R_derivative, Z_derivative,
             self.thickness + self.offset_from_plasma, flip=True)
 
-        def diff_between_angles(a, b):
-            c = (b - a) % 360
-            if c > 180:
-                c -= 360
-            return c
-        # if full coverage close the shape
-        if diff_between_angles(self.start_angle, self.stop_angle) == 0:
-            points.append(outer_points[0])
-        else:
-            points = inner_points + outer_points
-
-        points[-2][2] = 'straight'
+        points = inner_points + outer_points
+        points[-1][2] = 'straight'
+        points.append(inner_points[0])
         self.points = points
 
     def create_offset_points(self, thetas, R_fun, Z_fun, R_derivative, Z_derivative, offset, flip=False):
@@ -218,10 +209,6 @@ class BlanketConstantThicknessFP(RotateMixedShape):
         :type Z_derivative: sympy.Mul
         :param offset: offset value (cm). offset=0 will follow the parametric
          equations.
-        :type offset: float
-        :param flip: if True thetas will be iterated from the end. Defaults
-         to False.
-        :type flip: bool
 
         :return: list of points [[R1, Z1, connection1], [R2, Z2, connection2], ...]
         :rtype: list
@@ -251,5 +238,4 @@ class BlanketConstantThicknessFP(RotateMixedShape):
             val_Z_outer = Z_fun(theta) + offset*ny
 
             points.append([float(val_R_outer), float(val_Z_outer), 'spline'])
-            
         return points

--- a/paramak/parametric_components/blanket_constant_thickness_fp.py
+++ b/paramak/parametric_components/blanket_constant_thickness_fp.py
@@ -188,7 +188,6 @@ class BlanketConstantThicknessFP(RotateMixedShape):
             thetas, R, Z,
             R_derivative, Z_derivative,
             self.thickness + self.offset_from_plasma, flip=True)
-        points = inner_points + outer_points
 
         def diff_between_angles(a, b):
             c = (b - a) % 360
@@ -198,6 +197,8 @@ class BlanketConstantThicknessFP(RotateMixedShape):
         # if full coverage close the shape
         if diff_between_angles(self.start_angle, self.stop_angle) == 0:
             points.append(outer_points[0])
+        else:
+            points = inner_points + outer_points
 
         points[-2][2] = 'straight'
         self.points = points

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -112,6 +112,23 @@ class test_BlanketConstantThicknessFP(unittest.TestCase):
         assert test_shape.solid is not None
         assert test_shape.volume > 1000
 
+    def test_BlanketConstantThicknessFP_full_cov_stp_export(self):
+        """creates blanket from parametric shape and checks the STP export
+        with full coverage"""
+
+        test_shape = paramak.BlanketConstantThicknessFP(
+            major_radius=300,
+            minor_radius=50,
+            triangularity=0.5,
+            elongation=2,
+            thickness=200,
+            stop_angle=360,
+            start_angle=0,
+        )
+
+        test_shape.export_stp()
+
+
 class test_PoloidalFieldCoilCase(unittest.TestCase):
     def test_PoloidalFieldCoilCase_creation(self):
         """creates a poloidal field coil from parametric shape and checks a solid is created"""

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -126,7 +126,7 @@ class test_BlanketConstantThicknessFP(unittest.TestCase):
             start_angle=0,
         )
 
-        test_shape.export_stp()
+        test_shape.export_stp("test_blanket_full_cov")
 
 
 class test_PoloidalFieldCoilCase(unittest.TestCase):

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -124,9 +124,10 @@ class test_BlanketConstantThicknessFP(unittest.TestCase):
             thickness=200,
             stop_angle=360,
             start_angle=0,
+            rotation_angle=180
         )
 
-        test_shape.export_stp("test_blanket_full_cov")
+        test_shape.export_stp("tests/test_blanket_full_cov")
 
 
 class test_PoloidalFieldCoilCase(unittest.TestCase):


### PR DESCRIPTION
This PR partially fixes issue #86 and a geometry issue in `BlanketConstantThicknessFP()`.

### Old behaviour

![image](https://user-images.githubusercontent.com/40028739/87881053-f05d3700-c9f6-11ea-8387-80b6cabb5190.png)

### New behaviour
![image](https://user-images.githubusercontent.com/40028739/87881223-2818ae80-c9f8-11ea-9edf-311dbb7c1ede.png)

### Minor
- refactoring
- new test

### Known bug
- When applying full coverage (`start_angle` = `stop_angle`) **AND** full rotation (`rotation_angle=360`) method `export_stp()` still crashes #86 