### PR TITLE
added cutting cylinder

### DIFF
--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -126,6 +126,20 @@ class BallReactor(paramak.Reactor):
         tf_coil_height = blanket_rear_wall_end_height * 2
         center_column_shield_height = blanket_rear_wall_end_height * 2
 
+        if self.rotation_angle < 360:
+            max_high = 3 * center_column_shield_height
+            max_width = 3 * blanket_read_wall_end_radius
+            cutting_slice = paramak.RotateStraightShape(points=[
+                    (0,max_high),
+                    (max_width, max_high),
+                    (max_width, -max_high),
+                    (0, -max_high),
+                ],
+                rotation_angle=360-self.rotation_angle,
+                azimuth_placement_angle=360-self.rotation_angle
+            )
+        else:
+            cutting_slice=None
 
         inboard_tf_coils = paramak.InnerTfCoilsCircular(
             height=tf_coil_height,
@@ -135,6 +149,7 @@ class BallReactor(paramak.Reactor):
             gap_size=10,
             stp_filename="inboard_tf_coils.stp",
             material_tag="inboard_tf_coils_material",
+            cut=cutting_slice
         )
 
         self.add_shape_or_component(inboard_tf_coils)


### PR DESCRIPTION
This PR makes sure that all the components created match the reactor ```rotation_angle```.

For the inboard TF coils this option is not yet controllable from the parametric component

Therefore a cylindrical wedge has been added that cuts the offending solid

The before an after screenshots show more clearly what has been fixed

![Screenshot from 2020-07-18 09-04-58](https://user-images.githubusercontent.com/8583900/87848246-32428c00-c8d6-11ea-8458-c4a9e1aee2e6.png)
![Screenshot from 2020-07-18 09-04-35](https://user-images.githubusercontent.com/8583900/87848247-340c4f80-c8d6-11ea-9d61-7737c51c8a8b.png)

This will also come in useful for the TF coils later