### PR TITLE
added optional plasma and tests

### DIFF
--- a/examples/example_parametric_reactors/make_parametric_ball_reactor.py
+++ b/examples/example_parametric_reactors/make_parametric_ball_reactor.py
@@ -20,6 +20,7 @@ def main():
                                     elongation=2,
                                     triangularity=0.55,
                                     number_of_tf_coils=16,
+                                    rotation_angle=180
     )
 
     my_reactor.export_stp()

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -280,6 +280,81 @@ class test_object_properties(unittest.TestCase):
         assert neutronics_description[1]["filename"] == "Graveyard.stp"
         os.system("rm manifest_test.json")
 
+    def test_export_neutronics_description_with_plasma(self):
+        """checks that the neutronics description is exported to a json file with \
+                the correct entries (including the optional plasma)"""
+
+        os.system("rm manifest_test.json")
+
+        test_shape = paramak.RotateStraightShape(
+            points=[(0, 0), (0, 20), (20, 20)],
+            rotation_angle = 360,
+            material_tag = "test_material",
+            stp_filename = "test.stp",
+            tet_mesh = "size 60",)
+        test_plasma = paramak.Plasma(major_radius=500,
+                                     minor_radius=100,
+                                     stp_filename='plasma.stp',
+                                     material_tag='DT_plasma')
+        test_reactor = paramak.Reactor()
+        test_reactor.add_shape_or_component(test_shape)
+        test_reactor.add_shape_or_component(test_plasma)
+        returned_filename = test_reactor.export_neutronics_description(include_plasma=True)
+        with open("manifest.json") as json_file:
+            neutronics_description = json.load(json_file)
+
+        assert returned_filename == "manifest.json"
+        assert Path("manifest.json").exists() is True
+        assert len(neutronics_description) == 3
+        assert "filename" in neutronics_description[0].keys()
+        assert "material" in neutronics_description[0].keys()
+        assert "tet_mesh" in neutronics_description[0].keys()
+        assert "filename" in neutronics_description[1].keys()
+        assert "material" in neutronics_description[1].keys()
+        assert "tet_mesh" not in neutronics_description[1].keys()
+        assert neutronics_description[0]["material"] == "test_material"
+        assert neutronics_description[0]["filename"] == "test.stp"
+        assert neutronics_description[0]["tet_mesh"] == "size 60"
+        assert neutronics_description[1]["material"] == "DT_plasma"
+        assert neutronics_description[1]["filename"] == "plasma.stp"
+        assert neutronics_description[2]["material"] == "Graveyard"
+        assert neutronics_description[2]["filename"] == "Graveyard.stp"
+        os.system("rm manifest.json")
+
+    def test_export_neutronics_description_without_plasma(self):
+        """checks that the neutronics description is exported to a json file with \
+                the correct entries (the optional plasma is not included)"""
+
+        os.system("rm manifest_test.json")
+
+        test_shape = paramak.RotateStraightShape(
+            points=[(0, 0), (0, 20), (20, 20)],
+            rotation_angle = 360,
+            material_tag = "test_material",
+            stp_filename = "test.stp",
+            tet_mesh = "size 60",)
+        test_plasma = paramak.Plasma(major_radius=500,
+                                     minor_radius=100)
+        test_reactor = paramak.Reactor()
+        test_reactor.add_shape_or_component(test_shape)
+        test_reactor.add_shape_or_component(test_plasma)
+        returned_filename = test_reactor.export_neutronics_description()
+        with open("manifest.json") as json_file:
+            neutronics_description = json.load(json_file)
+
+        assert returned_filename == "manifest.json"
+        assert Path("manifest.json").exists() is True
+        assert len(neutronics_description) == 2
+        assert "filename" in neutronics_description[0].keys()
+        assert "material" in neutronics_description[0].keys()
+        assert "tet_mesh" in neutronics_description[0].keys()
+        assert neutronics_description[0]["material"] == "test_material"
+        assert neutronics_description[0]["filename"] == "test.stp"
+        assert neutronics_description[0]["tet_mesh"] == "size 60"
+        assert neutronics_description[1]["material"] == "Graveyard"
+        assert neutronics_description[1]["filename"] == "Graveyard.stp"
+        os.system("rm manifest.json")
+
     def test_export_2d_image(self):
         """checks that export_2d_image() exports a png file with \
                 the correct filename"""


### PR DESCRIPTION
When exporting a neutronics_description (which is needed to make a neutronics model later on) users now have the ability to not export the plasma.

This is useful for the neutronics simulation as the plasma is typically left out of the model as it has negligible impact on the simulation result but has a detrimental impact on simulation speed and model size. This is due to the large number of facetets needed in a plasma shape and the low number density of atoms in a plasma

current behaviour
```export_neutronics_description()```  - this exports every entry (stp filename and material tag)

new behavior
```export_neutronics_description(include_plasma=False)```- this exports every entry (stp filename and material tag) apart from the plasma

tests and docstrings have been updated

The default is to not export the plasma
