### PR TITLE
Reactor refactor

### DIFF
--- a/examples/example_neutronics_simulations/parametric_shape_neutronics_model.py
+++ b/examples/example_neutronics_simulations/parametric_shape_neutronics_model.py
@@ -50,12 +50,8 @@ def make_cad_model_with_paramak():
     )
     blanket.solid
 
-    # creates a reactor object
-    my_reactor = paramak.Reactor()
-
-    # addes parametric shapes to reactor
-    my_reactor.add_shape_or_component(blanket)
-    my_reactor.add_shape_or_component(pf_coil)
+    # creates a reactor object from the two components
+    my_reactor = paramak.Reactor([blanket, pf_coil])
 
     # exports neutronics description and stp files
     my_reactor.export_neutronics_description()

--- a/examples/example_parametric_shapes/make_can_reactor_from_parameters.py
+++ b/examples/example_parametric_shapes/make_can_reactor_from_parameters.py
@@ -112,16 +112,8 @@ def main():
 
 
     # initiates a reactor object
-    myreactor = paramak.Reactor()
-
-    # adds components to the reactor
-    myreactor.add_shape_or_component(plasma)
-    myreactor.add_shape_or_component(blanket)
-    myreactor.add_shape_or_component(core)
-    myreactor.add_shape_or_component(divertor_top)
-    myreactor.add_shape_or_component(divertor_bottom)
-    myreactor.add_shape_or_component(firstwall)
-    myreactor.add_shape_or_component(centre_column)
+    myreactor = paramak.Reactor([plasma, blanket, core, divertor_top,
+                                 divertor_bottom, firstwall, centre_column])
 
     myreactor.export_stp(output_folder="can_reactor_from_parameters")
     myreactor.export_html(filename="can_reactor_from_parameters/reactor.html")

--- a/examples/example_parametric_shapes/make_can_reactor_from_points.py
+++ b/examples/example_parametric_shapes/make_can_reactor_from_points.py
@@ -109,16 +109,8 @@ def main():
     core.stp_filename = "core.stp"
     core.rotation_angle = 180
 
-
-    myreactor = paramak.Reactor()
-
-    myreactor.add_shape_or_component(plasma)
-    myreactor.add_shape_or_component(blanket)
-    myreactor.add_shape_or_component(core)
-    myreactor.add_shape_or_component(divertor_top)
-    myreactor.add_shape_or_component(divertor_bottom)
-    myreactor.add_shape_or_component(firstwall)
-    myreactor.add_shape_or_component(centre_column)
+    myreactor = paramak.Reactor([plasma, blanket, core, divertor_top,
+                                 divertor_bottom, firstwall, centre_column])
 
     myreactor.export_stp(output_folder="can_reactor_from_points")
     myreactor.export_html("can_reactor_from_points/reactor.html")

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -68,10 +68,10 @@ class BallReactor(paramak.Reactor):
         elongation,
         triangularity,
         number_of_tf_coils,
-        rotation_angle = 180
+        rotation_angle = 180,
     ):
 
-        super().__init__()
+        super().__init__([])
 
         self.inner_bore_radial_thickness = inner_bore_radial_thickness
         self.inboard_tf_leg_radial_thickness = inboard_tf_leg_radial_thickness
@@ -104,6 +104,8 @@ class BallReactor(paramak.Reactor):
 
     def create_components(self):
 
+        shapes_or_components = []
+    
         plasma = paramak.Plasma(major_radius=self.major_radius,
                                 minor_radius=self.minor_radius,
                                 elongation=self.elongation,
@@ -111,7 +113,7 @@ class BallReactor(paramak.Reactor):
                                 rotation_angle=self.rotation_angle)
         plasma.create_solid()
 
-        self.add_shape_or_component(plasma)
+        shapes_or_components.append(plasma)
 
 
         # this is the radial build sequence, where one componet stops and another starts
@@ -183,7 +185,7 @@ class BallReactor(paramak.Reactor):
             cut=cutting_slice
         )
 
-        self.add_shape_or_component(inboard_tf_coils)
+        shapes_or_components.append(inboard_tf_coils)
 
 
         center_column_shield = paramak.CenterColumnShieldCylinder(
@@ -195,7 +197,7 @@ class BallReactor(paramak.Reactor):
             stp_filename="center_column_shield.stp",
             material_tag="center_column_material",
         )
-        self.add_shape_or_component(center_column_shield)
+        shapes_or_components.append(center_column_shield)
 
 
         divertor_upper_part = paramak.RotateStraightShape(points=[
@@ -208,12 +210,7 @@ class BallReactor(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             material_tag='divertor_material'
             )
-        self.add_shape_or_component(divertor_upper_part)
-
-        print(            (divertor_start_radius, -divertor_end_height),
-            (divertor_start_radius, -divertor_start_height),
-            (divertor_end_radius, -divertor_start_height),
-            (divertor_end_radius, -divertor_end_height))
+        shapes_or_components.append(divertor_upper_part)
 
         # negative signs used as this is in the negative side of the Z axis 
         divertor_lower_part = paramak.RotateStraightShape(points=[
@@ -226,7 +223,7 @@ class BallReactor(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             material_tag='divertor_material'
             )
-        self.add_shape_or_component(divertor_lower_part)
+        shapes_or_components.append(divertor_lower_part)
 
         space_for_divertor = plasma.high_point[0] - center_column_shield_end_radius
 
@@ -242,7 +239,7 @@ class BallReactor(paramak.Reactor):
                 rotation_angle=self.rotation_angle,
                 stp_filename='extra_blanket_upper.stp',
                 material_tag='blanket_material')
-            self.add_shape_or_component(extra_blanket_upper)
+            shapes_or_components.append(extra_blanket_upper)
 
             extra_firstwall_upper = paramak.RotateStraightShape(points=[
                 (divertor_end_radius, firstwall_start_height),
@@ -253,7 +250,7 @@ class BallReactor(paramak.Reactor):
                 rotation_angle=self.rotation_angle,
                 stp_filename='extra_firstwall_upper.stp',
                 material_tag='firstwall_material')
-            self.add_shape_or_component(extra_firstwall_upper)
+            shapes_or_components.append(extra_firstwall_upper)
 
             extra_blanket_rear_wall_upper = paramak.RotateStraightShape(points=[
                 (divertor_end_radius, blanket_rear_wall_start_height),
@@ -264,7 +261,7 @@ class BallReactor(paramak.Reactor):
                 rotation_angle=self.rotation_angle,
                 stp_filename='extra_blanket_rear_wall_upper.stp',
                 material_tag='blanket_rear_wall_material')
-            self.add_shape_or_component(extra_blanket_rear_wall_upper)
+            shapes_or_components.append(extra_blanket_rear_wall_upper)
 
 
             extra_blanket_lower = paramak.RotateStraightShape(points=[
@@ -276,7 +273,7 @@ class BallReactor(paramak.Reactor):
                 rotation_angle=self.rotation_angle,
                 stp_filename='extra_blanket_lower.stp',
                 material_tag='blanket_material')
-            self.add_shape_or_component(extra_blanket_lower)
+            shapes_or_components.append(extra_blanket_lower)
 
             extra_firstwall_lower = paramak.RotateStraightShape(points=[
                 (divertor_end_radius, -firstwall_start_height),
@@ -287,7 +284,7 @@ class BallReactor(paramak.Reactor):
                 rotation_angle=self.rotation_angle,
                 stp_filename='extra_firstwall_lower.stp',
                 material_tag='firstwall_material')
-            self.add_shape_or_component(extra_firstwall_lower)
+            shapes_or_components.append(extra_firstwall_lower)
 
             extra_blanket_rear_wall_lower = paramak.RotateStraightShape(points=[
                 (divertor_end_radius, -blanket_rear_wall_start_height),
@@ -298,7 +295,7 @@ class BallReactor(paramak.Reactor):
                 rotation_angle=self.rotation_angle,
                 stp_filename='extra_blanket_rear_wall_lower.stp',
                 material_tag='blanket_rear_wall_material')
-            self.add_shape_or_component(extra_blanket_rear_wall_lower)
+            shapes_or_components.append(extra_blanket_rear_wall_lower)
 
         firstwall = paramak.BlanketConstantThicknessArcV(
             inner_mid_point=(firstwall_start_radius, 0),
@@ -308,7 +305,7 @@ class BallReactor(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stp_filename='firstwall.stp'
         )
-        self.add_shape_or_component(firstwall)
+        shapes_or_components.append(firstwall)
 
 
         blanket = paramak.BlanketConstantThicknessArcV(
@@ -318,7 +315,7 @@ class BallReactor(paramak.Reactor):
             thickness=self.blanket_radial_thickness,
             rotation_angle=self.rotation_angle
         )
-        self.add_shape_or_component(blanket)
+        shapes_or_components.append(blanket)
 
 
         blanket_rear_casing = paramak.BlanketConstantThicknessArcV(
@@ -329,5 +326,6 @@ class BallReactor(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stp_filename='blanket_rear_wall.stp'
         )
-        self.add_shape_or_component(blanket_rear_casing)
+        shapes_or_components.append(blanket_rear_casing)
 
+        self.shapes_and_components = shapes_or_components

--- a/paramak/parametric_reactors/submersion_ball_reactor.py
+++ b/paramak/parametric_reactors/submersion_ball_reactor.py
@@ -34,7 +34,7 @@ class SubmersionBallReactor(paramak.Reactor):
         rotation_angle = 180
     ):
 
-        super().__init__()
+        super().__init__([])
 
         self.inner_bore = 30
         self.major_radius = major_radius
@@ -62,8 +62,6 @@ class SubmersionBallReactor(paramak.Reactor):
                                 rotation_angle=self.rotation_angle)
         plasma.create_solid()
 
-        self.add_shape_or_component(plasma)
-
         inboard_firstwall = paramak.BlanketConstantThicknessFP(
             plasma=plasma,
             start_angle=90,
@@ -73,9 +71,6 @@ class SubmersionBallReactor(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stp_filename='inboard_firstwall.stp'
         )
-
-
-        self.add_shape_or_component(inboard_firstwall)
 
         outboard_firstwall = paramak.BlanketConstantThicknessFP(
             plasma=plasma,
@@ -87,8 +82,6 @@ class SubmersionBallReactor(paramak.Reactor):
             stp_filename='outboard_firstwall.stp'
         )
 
-        self.add_shape_or_component(outboard_firstwall)
-
         # The height of this center column is calculated using CadQuery commands
         center_column_shield = paramak.CenterColumnShieldCylinder(
             height=2*(plasma.high_point[1] + self.offset_from_plasma),
@@ -99,7 +92,6 @@ class SubmersionBallReactor(paramak.Reactor):
             stp_filename="center_column_shield.stp",
             material_tag="center_column_material",
         )
-        self.add_shape_or_component(center_column_shield)
 
         inboard_tf_coils = paramak.InnerTfCoilsCircular(
             height=2*(plasma.high_point[1] + self.offset_from_plasma),
@@ -111,7 +103,8 @@ class SubmersionBallReactor(paramak.Reactor):
             material_tag="inboard_tf_coils_material",
         )
 
-        self.add_shape_or_component(inboard_tf_coils)
+        self.shapes_and_components = [center_column_shield, plasma, inboard_firstwall,
+                                      inboard_tf_coils, outboard_firstwall]
 
         # submersion_blanket = paramak.RotateMixedShape(
         #     points=[

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -108,39 +108,6 @@ class Reactor():
     def solid(self, value):
         self._solid = value
 
-    # def add_shapes_or_components(self, shapes):
-    #     """Adds parametric shapes or parametric components to the Reactor 
-    #     object. A list of shapes or components are added to the Reactor
-    #     object so that collective operations can be performed on all the
-    #     shapes in the reactor. When adding a shape or componet the 
-    #     stp_filename for the shape or component should be unique.
-    #     """
-    #     for shape in shapes:
-    #         if shape.stp_filename != None:
-    #             if shape.stp_filename in self.stp_filenames:
-    #                 raise ValueError(
-    #                     "Set Reactor already contains a shape or component \
-    #                             with this stp_filename", shapes.stp_filename
-    #                 )
-    #         self.shapes_and_components.append(shape)
-
-
-    # def add_shape_or_component(self, shapes):
-    #     """Adds a single parametric shape or a parametric component to the Reactor 
-    #     object. An individual shape or component is added to the Reactor object
-    #     so that collective operations can be performed on all the shapes in the
-    #     reactor. When adding a shape or componet the stp_filename for the shape
-    #     or component should be unique.
-    #     """
-    #     if shapes.stp_filename != None:
-    #         if shapes.stp_filename in self.stp_filenames:
-    #             raise ValueError(
-    #                 "Set Reactor already contains a shape or component \
-    #                         with this stp_filename", shapes.stp_filename,
-    #                         self.stp_filenames
-    #             )
-    #     self.shapes_and_components.append(shapes)
-
     def neutronics_description(self, include_plasma=False):
         """A description of the reactor containing materials tags,
         stp filenames, tet mesh instructions. This is can be used

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -623,7 +623,7 @@ class Shape:
         self.patch = p
         return p
 
-    def neutronics_description(self, stp_filename, material_tag, tet_mesh=None):
+    def neutronics_description(self):
         """Returns a neutronics description of the Shape object.
         This is needed for the use with automated neutronics model
         methods which require linkage between the stp files and

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -16,11 +16,9 @@ class test_object_properties(unittest.TestCase):
             material_tag='mat1')
         test_shape.rotation_angle = 360
         test_shape.create_solid()
-        test_reactor = paramak.Reactor()
-        assert len(test_reactor.material_tags) == 0
-        test_reactor.add_shape_or_component(test_shape)
+        test_reactor = paramak.Reactor([test_shape])
         assert len(test_reactor.material_tags) == 1
-        assert test_reactor.material_tags == {'mat1'}
+        assert test_reactor.material_tags[0] == 'mat1'
 
     def test_adding_multiple_shapes_with_material_tag_to_reactor(self):
         """adds a shape to the reactor and checks that the material_tag
@@ -33,14 +31,10 @@ class test_object_properties(unittest.TestCase):
             material_tag='mat2')
         test_shape.rotation_angle = 360
         test_shape.create_solid()
-        test_reactor = paramak.Reactor()
-        assert len(test_reactor.material_tags) == 0
-        test_reactor.add_shape_or_component(test_shape)
-        assert len(test_reactor.material_tags) == 1
-        assert test_reactor.material_tags == {'mat1'}
-        test_reactor.add_shape_or_component(test_shape2)
+        test_reactor = paramak.Reactor([test_shape, test_shape2])
         assert len(test_reactor.material_tags) == 2
-        assert test_reactor.material_tags == {'mat1', 'mat2'}
+        assert test_reactor.material_tags[0] == 'mat1'
+        assert test_reactor.material_tags[1] == 'mat2'
 
     def test_adding_shape_with_stp_filename_to_reactor(self):
         """adds a shape to the reactor and checks that the stp_filename
@@ -50,9 +44,7 @@ class test_object_properties(unittest.TestCase):
             stp_filename='filename.stp')
         test_shape.rotation_angle = 360
         test_shape.create_solid()
-        test_reactor = paramak.Reactor()
-        assert len(test_reactor.stp_filenames) == 0
-        test_reactor.add_shape_or_component(test_shape)
+        test_reactor = paramak.Reactor([test_shape])
         assert len(test_reactor.stp_filenames) == 1
         assert test_reactor.stp_filenames[0] == 'filename.stp'
 
@@ -68,12 +60,7 @@ class test_object_properties(unittest.TestCase):
             stp_filename='filename2.stp')
         test_shape.rotation_angle = 360
         test_shape.create_solid()
-        test_reactor = paramak.Reactor()
-        assert len(test_reactor.stp_filenames) == 0
-        test_reactor.add_shape_or_component(test_shape)
-        assert len(test_reactor.stp_filenames) == 1
-        assert test_reactor.stp_filenames[0] == 'filename.stp'
-        test_reactor.add_shape_or_component(test_shape2)
+        test_reactor = paramak.Reactor([test_shape,test_shape2])
         assert len(test_reactor.stp_filenames) == 2
         assert test_reactor.stp_filenames[0] == 'filename.stp'
         assert test_reactor.stp_filenames[1] == 'filename2.stp'
@@ -83,24 +70,18 @@ class test_object_properties(unittest.TestCase):
 
         """adds a shape to the reactor and checks that the stp_filename
         property works as designed"""
-        test_shape = paramak.RotateStraightShape(
-            points=[(0, 0), (0, 20), (20, 20)],
-            stp_filename='filename.stp')
-        test_shape2 = paramak.RotateSplineShape(
-            points=[(0, 0), (0, 20), (20, 20)],
-            stp_filename='filename.stp')
-        test_shape.rotation_angle = 360
-        test_shape.create_solid()
-        test_reactor = paramak.Reactor()
-        assert len(test_reactor.stp_filenames) == 0
-        test_reactor.add_shape_or_component(test_shape)
-        assert len(test_reactor.stp_filenames) == 1
-        assert test_reactor.stp_filenames[0] == 'filename.stp'
 
         def test_stp_filename_duplication():
             """checks ValueError is raised when an elongation < 0 is specified"""
-
-            test_reactor.add_shape_or_component(test_shape2)
+            test_shape = paramak.RotateStraightShape(
+                points=[(0, 0), (0, 20), (20, 20)],
+                stp_filename='filename.stp')
+            test_shape2 = paramak.RotateSplineShape(
+                points=[(0, 0), (0, 20), (20, 20)],
+                stp_filename='filename.stp')
+            test_shape.rotation_angle = 360
+            test_shape.create_solid()
+            test_reactor = paramak.Reactor([test_shape, test_shape2])
 
         self.assertRaises(ValueError, test_stp_filename_duplication)  
 
@@ -109,7 +90,7 @@ class test_object_properties(unittest.TestCase):
         """creates a Reactor object and checks that it has \
                 no default properties"""
 
-        test_reactor = paramak.Reactor()
+        test_reactor = paramak.Reactor([])
 
         assert test_reactor is not None
 
@@ -121,9 +102,9 @@ class test_object_properties(unittest.TestCase):
             points=[(0, 0), (0, 20), (20, 20)])
         test_shape.rotation_angle = 360
         test_shape.create_solid()
-        test_reactor = paramak.Reactor()
+        test_reactor = paramak.Reactor([])
         assert len(test_reactor.shapes_and_components) == 0
-        test_reactor.add_shape_or_component(test_shape)
+        test_reactor = paramak.Reactor([test_shape])
         assert len(test_reactor.shapes_and_components) == 1
 
     def test_Graveyard_exists(self):
@@ -134,8 +115,7 @@ class test_object_properties(unittest.TestCase):
             points=[(0, 0), (0, 20), (20, 20)])
         test_shape.rotation_angle = 360
         test_shape.create_solid()
-        test_reactor = paramak.Reactor()
-        test_reactor.add_shape_or_component(test_shape)
+        test_reactor = paramak.Reactor([test_shape])
         test_reactor.make_graveyard()
 
         assert type(test_reactor.graveyard) == paramak.Shape
@@ -150,8 +130,7 @@ class test_object_properties(unittest.TestCase):
         os.system("rm my_graveyard.stp")
         os.system("rm Graveyard.stp")
         test_shape.stp_filename = "test_shape.stp"
-        test_reactor = paramak.Reactor()
-        test_reactor.add_shape_or_component(test_shape)
+        test_reactor = paramak.Reactor([test_shape])
 
         test_reactor.export_graveyard()
         test_reactor.export_graveyard(filename="my_graveyard.stp")
@@ -171,8 +150,7 @@ class test_object_properties(unittest.TestCase):
         os.system("rm test_reactor/test_shape.stp")
         os.system("rm test_reactor/Graveyard.stp")
         test_shape.stp_filename = "test_shape.stp"
-        test_reactor = paramak.Reactor()
-        test_reactor.add_shape_or_component(test_shape)
+        test_reactor = paramak.Reactor([test_shape])
 
         test_reactor.export_stp(output_folder="test_reactor")
 
@@ -188,8 +166,7 @@ class test_object_properties(unittest.TestCase):
             points=[(0, 0), (0, 20), (20, 20)])
         test_shape.rotation_angle = 360
         os.system("rm test_svg_image.svg")
-        test_reactor = paramak.Reactor()
-        test_reactor.add_shape_or_component(test_shape)
+        test_reactor = paramak.Reactor([test_shape])
 
         test_reactor.export_svg("test_svg_image.svg")
 
@@ -205,8 +182,7 @@ class test_object_properties(unittest.TestCase):
                 points=[(0, 0), (0, 20), (20, 20)])
             test_shape.rotation_angle = 360
             test_shape.stp_filename = "test.stp"
-            test_reactor = paramak.Reactor()
-            test_reactor.add_shape_or_component(test_shape)
+            test_reactor = paramak.Reactor([test_shape])
             neutronics_description = test_reactor.neutronics_description()
 
         self.assertRaises(ValueError, test_neutronics_description_without_material_tag)
@@ -220,8 +196,7 @@ class test_object_properties(unittest.TestCase):
             test_shape.rotation_angle = 360
             test_shape.material_tag = "test_material"
             test_shape.stp_filename = None
-            test_reactor = paramak.Reactor()
-            test_reactor.add_shape_or_component(test_shape)
+            test_reactor = paramak.Reactor([test_shape])
             neutronics_description = test_reactor.neutronics_description()
 
         self.assertRaises(ValueError, test_neutronics_description_without_stp_filename)
@@ -235,8 +210,7 @@ class test_object_properties(unittest.TestCase):
         test_shape.rotation_angle = 360
         test_shape.material_tag = "test_material"
         test_shape.stp_filename = "test.stp"
-        test_reactor = paramak.Reactor()
-        test_reactor.add_shape_or_component(test_shape)
+        test_reactor = paramak.Reactor([test_shape])
         neutronics_description = test_reactor.neutronics_description()
 
         assert len(neutronics_description) == 2
@@ -259,8 +233,7 @@ class test_object_properties(unittest.TestCase):
         test_shape.material_tag = "test_material"
         test_shape.stp_filename = "test.stp"
         test_shape.tet_mesh = "size 60"
-        test_reactor = paramak.Reactor()
-        test_reactor.add_shape_or_component(test_shape)
+        test_reactor = paramak.Reactor([test_shape])
         returned_filename = test_reactor.export_neutronics_description(
             filename="manifest_test.json"
         )
@@ -296,9 +269,7 @@ class test_object_properties(unittest.TestCase):
                                      minor_radius=100,
                                      stp_filename='plasma.stp',
                                      material_tag='DT_plasma')
-        test_reactor = paramak.Reactor()
-        test_reactor.add_shape_or_component(test_shape)
-        test_reactor.add_shape_or_component(test_plasma)
+        test_reactor = paramak.Reactor([test_shape, test_plasma])
         returned_filename = test_reactor.export_neutronics_description(include_plasma=True)
         with open("manifest.json") as json_file:
             neutronics_description = json.load(json_file)
@@ -335,9 +306,7 @@ class test_object_properties(unittest.TestCase):
         test_shape.tet_mesh = "size 60"
         test_plasma = paramak.Plasma(major_radius=500,
                                      minor_radius=100)
-        test_reactor = paramak.Reactor()
-        test_reactor.add_shape_or_component(test_shape)
-        test_reactor.add_shape_or_component(test_plasma)
+        test_reactor = paramak.Reactor([test_shape, test_plasma])
         returned_filename = test_reactor.export_neutronics_description()
         with open("manifest.json") as json_file:
             neutronics_description = json.load(json_file)
@@ -363,8 +332,7 @@ class test_object_properties(unittest.TestCase):
         test_shape = paramak.RotateStraightShape(
             points=[(0, 0), (0, 20), (20, 20)])
         test_shape.rotation_angle = 360
-        test_reactor = paramak.Reactor()
-        test_reactor.add_shape_or_component(test_shape)
+        test_reactor = paramak.Reactor([test_shape])
         returned_filename = test_reactor.export_2d_image(filename="2d_test_image.png")
 
         assert Path(returned_filename).exists() is True
@@ -378,8 +346,7 @@ class test_object_properties(unittest.TestCase):
         test_shape = paramak.RotateStraightShape(
             points=[(0, 0), (0, 20), (20, 20)])
         test_shape.rotation_angle = 360
-        test_reactor = paramak.Reactor()
-        test_reactor.add_shape_or_component(test_shape)
+        test_reactor = paramak.Reactor([test_shape])
         test_reactor.export_html(filename="test_html.html")
 
         assert Path("test_html.html").exists() is True


### PR DESCRIPTION
This PR allows the shapes and components in a reactor to be set when the reactor is initialized.

The old method was to uses ```add_shape_or_component``` for each entry to be added.

The method allows the shapes_and_componets to be passed as an argument on construction

The Reactor.stp_filenames, Reactor.material_tags, Reactor.tet_meshes have all been moved to getter an setter methods which scan through the components.

The problem with the old method was that users could add shapes directly to the Reactor.shapes_and_components attribute by passing the add_shape_or_component method and therefore getting the stp_filenames and material_tags out of sync with the object. Also the new method saves a line or two of code in some cases.

old method
my_reactor = paramak.Reactor()
my_reactor.add_shape_or_component([blanket, firstwall])

new method
my_reactor = paramak.Reactor([blanket, firstwall])