### PR TITLE
added divertor that curves around if needed

### DIFF
--- a/examples/example_parametric_reactors/make_parametric_ball_reactor.py
+++ b/examples/example_parametric_reactors/make_parametric_ball_reactor.py
@@ -7,26 +7,27 @@ import paramak
 def main():
 
 
-    my_reactor = paramak.BallReactor(
-                                    inner_bore_radial_thickness=50,
-                                    inboard_tf_leg_radial_thickness = 200,
-                                    center_column_shield_radial_thickness= 50,
-                                    divertor_radial_thickness = 50,
-                                    inner_plasma_gap_radial_thickness = 150,
-                                    plasma_radial_thickness = 100,
-                                    outer_plasma_gap_radial_thickness = 50,
-                                    firstwall_radial_thickness=50,
-                                    blanket_radial_thickness=100,
-                                    blanket_rear_wall_radial_thickness=10,
-                                    elongation=2,
-                                    triangularity=0.55,
-                                    number_of_tf_coils=16,
-                                    rotation_angle=180
-    )
+    for blanket_radial_thickness in [10, 75, 150, 300]:
 
-    my_reactor.export_stp()
+        my_reactor = paramak.BallReactor(
+                                            inner_bore_radial_thickness=1,
+                                            inboard_tf_leg_radial_thickness = 30,
+                                            center_column_shield_radial_thickness= 60,
+                                            divertor_radial_thickness=50,
+                                            inner_plasma_gap_radial_thickness = 30,
+                                            plasma_radial_thickness = 300,
+                                            outer_plasma_gap_radial_thickness = 30,
+                                            firstwall_radial_thickness=3,
+                                            blanket_radial_thickness=blanket_radial_thickness,
+                                            blanket_rear_wall_radial_thickness=3,
+                                            elongation=2.75,
+                                            triangularity=0.5,
+                                            number_of_tf_coils=16,
+                                            rotation_angle=180)
 
-    my_reactor.export_neutronics_description()
+        my_reactor.export_stp(str(blanket_radial_thickness))
+
+        # my_reactor.export_neutronics_description()
 
 
 if __name__ == "__main__":

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -175,19 +175,18 @@ class BallReactor(paramak.Reactor):
         else:
             cutting_slice=None
 
-        inboard_tf_coils = paramak.InnerTfCoilsCircular(
+        # shapes_or_components.append(inboard_tf_coils)
+        inboard_tf_coils = paramak.CenterColumnShieldCylinder(
             height=tf_coil_height,
-            inner_radius = inboard_tf_coils_start_radius,
-            outer_radius = inboard_tf_coils_end_radius,
-            number_of_coils = self.number_of_tf_coils,
-            gap_size=10,
+            inner_radius=inboard_tf_coils_start_radius,
+            outer_radius=inboard_tf_coils_end_radius,
+            rotation_angle=self.rotation_angle,
+            # color=centre_column_color,
             stp_filename="inboard_tf_coils.stp",
+            name="inboard_tf_coils",
             material_tag="inboard_tf_coils_mat",
-            cut=cutting_slice
         )
-
         shapes_or_components.append(inboard_tf_coils)
-
 
         center_column_shield = paramak.CenterColumnShieldCylinder(
             height=center_column_shield_height,
@@ -196,6 +195,7 @@ class BallReactor(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             # color=centre_column_color,
             stp_filename="center_column_shield.stp",
+            name="center_column_shield",
             material_tag="center_column_shield_mat",
         )
         shapes_or_components.append(center_column_shield)
@@ -213,6 +213,7 @@ class BallReactor(paramak.Reactor):
                 ],
                 rotation_angle=self.rotation_angle,
                 stp_filename='extra_blanket_upper.stp',
+                name='extra_blanket_upper',
                 material_tag='blanket_mat')
             shapes_or_components.append(extra_blanket_upper)
 
@@ -224,6 +225,7 @@ class BallReactor(paramak.Reactor):
                 ],
                 rotation_angle=self.rotation_angle,
                 stp_filename='extra_firstwall_upper.stp',
+                name='extra_firstwall_upper',
                 material_tag='firstwall_mat')
             shapes_or_components.append(extra_firstwall_upper)
 
@@ -235,6 +237,7 @@ class BallReactor(paramak.Reactor):
                 ],
                 rotation_angle=self.rotation_angle,
                 stp_filename='extra_blanket_rear_wall_upper.stp',
+                name='extra_blanket_rear_wall_upper',
                 material_tag='blanket_rear_wall_mat')
             shapes_or_components.append(extra_blanket_rear_wall_upper)
 
@@ -247,6 +250,7 @@ class BallReactor(paramak.Reactor):
                 ],
                 rotation_angle=self.rotation_angle,
                 stp_filename='extra_blanket_lower.stp',
+                name='extra_blanket_lower',
                 material_tag='blanket_mat')
             shapes_or_components.append(extra_blanket_lower)
 
@@ -258,6 +262,7 @@ class BallReactor(paramak.Reactor):
                 ],
                 rotation_angle=self.rotation_angle,
                 stp_filename='extra_firstwall_lower.stp',
+                name='extra_firstwall_lower',
                 material_tag='firstwall_mat')
             shapes_or_components.append(extra_firstwall_lower)
 
@@ -269,6 +274,7 @@ class BallReactor(paramak.Reactor):
                 ],
                 rotation_angle=self.rotation_angle,
                 stp_filename='extra_blanket_rear_wall_lower.stp',
+                name='extra_blanket_rear_wall_lower',
                 material_tag='blanket_rear_wall_mat')
             shapes_or_components.append(extra_blanket_rear_wall_lower)
 
@@ -279,6 +285,7 @@ class BallReactor(paramak.Reactor):
                 (divertor_end_radius, divertor_end_height),
                 ],
                 stp_filename='divertor_upper.stp',
+                name='divertor_upper',
                 rotation_angle=self.rotation_angle,
                 material_tag='divertor_mat'
                 )
@@ -292,6 +299,7 @@ class BallReactor(paramak.Reactor):
                 (divertor_end_radius, -divertor_end_height),
                 ],
                 stp_filename='divertor_lower.stp',
+                name='divertor_lower',
                 rotation_angle=self.rotation_angle,
                 material_tag='divertor_mat'
                 )
@@ -325,6 +333,7 @@ class BallReactor(paramak.Reactor):
                 (divertor_start_radius+space_for_divertor, divertor_end_height, 'straight'),
                 ],
                 stp_filename='divertor_upper.stp',
+                name='divertor_upper',
                 rotation_angle=self.rotation_angle,
                 material_tag='divertor_mat'
                 )
@@ -342,6 +351,7 @@ class BallReactor(paramak.Reactor):
                 (divertor_start_radius+space_for_divertor, -divertor_end_height, 'straight'),
                 ],
                 stp_filename='divertor_lower.stp',
+                name='divertor_lower',
                 rotation_angle=self.rotation_angle,
                 material_tag='divertor_mat'
                 )
@@ -354,8 +364,9 @@ class BallReactor(paramak.Reactor):
             thickness=self.firstwall_radial_thickness,
             rotation_angle=self.rotation_angle,
             stp_filename='firstwall.stp',
+            name='firstwall',
             material_tag='firstwall_mat',
-            cut=[divertor_lower_part, divertor_upper_part]
+            # cut=[divertor_lower_part, divertor_upper_part]
         )
         shapes_or_components.append(firstwall)
 
@@ -367,8 +378,9 @@ class BallReactor(paramak.Reactor):
             thickness=self.blanket_radial_thickness,
             rotation_angle=self.rotation_angle,
             stp_filename='blanket.stp',
+            name='blanket',
             material_tag='blanket_mat',
-            cut=[divertor_lower_part, divertor_upper_part]
+            # cut=[divertor_lower_part, divertor_upper_part]
         )
         shapes_or_components.append(blanket)
 
@@ -380,6 +392,7 @@ class BallReactor(paramak.Reactor):
             thickness=self.blanket_rear_wall_radial_thickness,
             rotation_angle=self.rotation_angle,
             stp_filename='blanket_rear_wall.stp',
+                  name='blanket_rear_wall',
             material_tag='blanket_rear_wall_mat',
             cut=[divertor_lower_part, divertor_upper_part]
         )

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -22,6 +22,34 @@ def rotate(origin, point, angle):
     qy = oy + math.sin(angle) * (px - ox) + math.cos(angle) * (py - oy)
     return qx, qy
 
+def find_center_point_of_circle(point1, point2, point3):
+    """
+    Calculates the center and the radius of a circle
+    passing throught 3 points.
+
+    Args:
+        point1 (float, float): point 1 coordinates
+        point2 (float, float): point 2 coordinates
+        point3 (float, float): point 3 coordinates
+    Returns:
+        float, float: center of the circle corrdinates or 
+        None if 3 points on a line are input
+    """
+    temp = point2[0] * point2[0] + point2[1] * point2[1]
+    bc = (point1[0] * point1[0] + point1[1] * point1[1] - temp) / 2
+    cd = (temp - point3[0] * point3[0] - point3[1] * point3[1]) / 2
+    det = (point1[0] - point2[0]) * (point2[1] - point3[1]) - (point2[0] - point3[0]) * (point1[1] - point2[1])
+
+    if abs(det) < 1.0e-6:
+        return (None, np.inf)
+
+    # Center of circle
+    cx = (bc*(point2[1] - point3[1]) - cd*(point1[1] - point2[1])) / det
+    cy = ((point1[0] - point2[0]) * cd - (point2[0] - point3[0]) * bc) / det
+
+    radius = np.sqrt((cx - point1[0])**2 + (cy - point1[1])**2)
+
+    return (cx, cy), radius
 
 def extend(A, B, L):
     """Creates a point C in (AB) direction so that |AC| = L


### PR DESCRIPTION
This adds a variation of the divertor to the ball_reactor. In the event that the divertor_radial_thickness is larger than the vertical space between the blanket and the center column then the divertor will curve around on the same arc as the blanket. The blanket, first wall and blanekt rear wall will be cut with the divertor to ensure there is no overlap.

ToDo

Add a regular divertor if the gap is equal to the divertor_radial_thickness

