### PR TITLE
added optional pf and tf coils

### DIFF
--- a/tests/test_BallReactor.py
+++ b/tests/test_BallReactor.py
@@ -77,3 +77,55 @@ class test_BallReactor(unittest.TestCase):
 
         assert Path("test_ballreactor_image.svg").exists() is True
         os.system("rm test_ballreactor_image.svg")
+
+    def test_BallReactor_with_pf_coils(self):
+        test_reactor = paramak.BallReactor(
+                                        inner_bore_radial_thickness=50,
+                                        inboard_tf_leg_radial_thickness = 50,
+                                        center_column_shield_radial_thickness= 50,
+                                        divertor_radial_thickness = 100,
+                                        inner_plasma_gap_radial_thickness = 50,
+                                        plasma_radial_thickness = 200,
+                                        outer_plasma_gap_radial_thickness = 50,
+                                        firstwall_radial_thickness=50,
+                                        blanket_radial_thickness=100,
+                                        blanket_rear_wall_radial_thickness=50,
+                                        elongation=2,
+                                        triangularity=0.55,
+                                        number_of_tf_coils=16,
+                                        rotation_angle=180,
+                                        pf_coil_radial_thicknesses = [50,50,50,50],
+                                        pf_coil_vertical_thicknesses = [50,50,50,50],
+                                        pf_coil_to_rear_blanket_radial_gap=50,
+                                        pf_coil_to_tf_coil_radial_gap = 50,
+            
+        )
+        test_reactor.export_stp()
+        assert len(test_reactor.shapes_and_components) == 12
+
+    def test_BallReactor_with_pf_and_tf_coils(self):
+        test_reactor = paramak.BallReactor(
+                                        inner_bore_radial_thickness=50,
+                                        inboard_tf_leg_radial_thickness = 50,
+                                        center_column_shield_radial_thickness= 50,
+                                        divertor_radial_thickness = 100,
+                                        inner_plasma_gap_radial_thickness = 50,
+                                        plasma_radial_thickness = 200,
+                                        outer_plasma_gap_radial_thickness = 50,
+                                        firstwall_radial_thickness=50,
+                                        blanket_radial_thickness=100,
+                                        blanket_rear_wall_radial_thickness=50,
+                                        elongation=2,
+                                        triangularity=0.55,
+                                        number_of_tf_coils=16,
+                                        rotation_angle=180,
+                                        pf_coil_radial_thicknesses = [50,50,50,50],
+                                        pf_coil_vertical_thicknesses = [50,50,50,50],
+                                        pf_coil_to_rear_blanket_radial_gap=50,
+                                        pf_coil_to_tf_coil_radial_gap = 50,
+                                        tf_coil_radial_thickness = 100,
+                                        tf_coil_poloidal_thickness=50
+            
+        )
+        test_reactor.export_stp()
+        assert len(test_reactor.shapes_and_components) == 13


### PR DESCRIPTION
This PR adds TF and PF coils to the BallReactor parametric reactor class 
Extra BallReactor parameters have been introduced
There are all optional so if the user does not want magnets then the BallReactor will still be made without them

pf_coil_radial_thicknesses = [50,50,50,50],
pf_coil_vertical_thicknesses = [50,50,50,50],
pf_coil_to_rear_blanket_radial_gap=50,
pf_coil_to_tf_coil_radial_gap = 50,
tf_coil_radial_thickness = 100,
tf_coil_poloidal_thickness=50

Docstrings and tests (that check model creation only) have been added

# Before

![Screenshot from 2020-07-29 22-55-57](https://user-images.githubusercontent.com/8583900/88857744-bd812300-d1ee-11ea-8071-55ab7d728050.png)

# After

![Screenshot from 2020-07-29 21-08-13](https://user-images.githubusercontent.com/8583900/88858176-85c6ab00-d1ef-11ea-962d-c62f476f0f22.png)

ToDo

PF coils are automatically positioned by spreading them out evenly in the Z direction. In another pull request the option to allow the user to specify the position would be a nice upgrade