### PR TITLE
More tests for greener badge

### DIFF
--- a/tests/test_BallReactor.py
+++ b/tests/test_BallReactor.py
@@ -129,3 +129,29 @@ class test_BallReactor(unittest.TestCase):
         )
         test_reactor.export_stp()
         assert len(test_reactor.shapes_and_components) == 13
+
+    def test_BallReactor_with_pf_and_tf_coils_export_physical_groups(self):
+        test_reactor = paramak.BallReactor(
+                                        inner_bore_radial_thickness=50,
+                                        inboard_tf_leg_radial_thickness = 50,
+                                        center_column_shield_radial_thickness= 50,
+                                        divertor_radial_thickness = 100,
+                                        inner_plasma_gap_radial_thickness = 50,
+                                        plasma_radial_thickness = 200,
+                                        outer_plasma_gap_radial_thickness = 50,
+                                        firstwall_radial_thickness=50,
+                                        blanket_radial_thickness=100,
+                                        blanket_rear_wall_radial_thickness=50,
+                                        elongation=2,
+                                        triangularity=0.55,
+                                        number_of_tf_coils=16,
+                                        rotation_angle=180,
+                                        pf_coil_radial_thicknesses = [50,50,50,50],
+                                        pf_coil_vertical_thicknesses = [50,50,50,50],
+                                        pf_coil_to_rear_blanket_radial_gap=50,
+                                        pf_coil_to_tf_coil_radial_gap = 50,
+                                        tf_coil_radial_thickness = 100,
+                                        tf_coil_poloidal_thickness=50
+            
+        )
+        test_reactor.export_physical_groups()

--- a/tests/test_BallReactor.py
+++ b/tests/test_BallReactor.py
@@ -155,3 +155,38 @@ class test_BallReactor(unittest.TestCase):
             
         )
         test_reactor.export_physical_groups()
+
+    def test_export_3d_image(self):
+        """Tests the method export_3d_image
+        """
+        test_reactor = paramak.BallReactor(
+                                        inner_bore_radial_thickness=50,
+                                        inboard_tf_leg_radial_thickness = 50,
+                                        center_column_shield_radial_thickness= 50,
+                                        divertor_radial_thickness = 100,
+                                        inner_plasma_gap_radial_thickness = 50,
+                                        plasma_radial_thickness = 200,
+                                        outer_plasma_gap_radial_thickness = 50,
+                                        firstwall_radial_thickness=50,
+                                        blanket_radial_thickness=100,
+                                        blanket_rear_wall_radial_thickness=50,
+                                        elongation=2,
+                                        triangularity=0.55,
+                                        number_of_tf_coils=16,
+                                        rotation_angle=180,
+                                        pf_coil_radial_thicknesses = [50,50,50,50],
+                                        pf_coil_vertical_thicknesses = [50,50,50,50],
+                                        pf_coil_to_rear_blanket_radial_gap=50,
+                                        pf_coil_to_tf_coil_radial_gap = 50,
+                                        tf_coil_radial_thickness = 100,
+                                        tf_coil_poloidal_thickness=50
+            
+        )
+        os.system("rm tests/export_3D.png")
+        test_reactor.export_3d_image("tests/export_3D.png")
+        assert Path("tests/export_3D.png").exists() is True
+        os.system("rm tests/export_3D.png")
+        test_reactor.export_3d_image("tests/export_3D")
+        assert Path("tests/export_3D.png").exists() is True
+        os.system("rm tests/export_3D.png")
+

--- a/tests/test_ExtrudeMixedShape.py
+++ b/tests/test_ExtrudeMixedShape.py
@@ -181,25 +181,31 @@ class test_object_properties(unittest.TestCase):
 
     def test_mixed_shape_with_straight_and_circle(self):
         """tests the construction of a shape with straight and circular edges"""
-        test_shape = ExtrudeMixedShape(points=[(10, 20, 'straight'),
-                                                (10, 10, 'straight'),
-                                                (20, 10, 'circle'),
-                                                (22, 15, 'circle'),
-                                                (20, 20, 'straight'),
-                                                ], distance = 10
-                                        )
+        test_shape = ExtrudeMixedShape(
+            points=[
+                (10, 20, 'straight'),
+                (10, 10, 'straight'),
+                (20, 10, 'circle'),
+                (22, 15, 'circle'),
+                (20, 20, 'straight'),
+                ],
+            distance=10
+            )
         assert test_shape.volume > 10 * 10 * 10
 
     def test_export_3d_image(self):
         """Tests the method test_export_3d_image
         """
-        test_shape = ExtrudeMixedShape(points=[(10, 20, 'straight'),
-                                                (10, 10, 'straight'),
-                                                (20, 10, 'circle'),
-                                                (22, 15, 'circle'),
-                                                (20, 20, 'straight'),
-                                                ], distance = 10
-                                        )
+        test_shape = ExtrudeMixedShape(
+            points=[
+                (10, 20, 'straight'),
+                (10, 10, 'straight'),
+                (20, 10, 'circle'),
+                (22, 15, 'circle'),
+                (20, 20, 'straight'),
+                ],
+            distance=10
+            )
         os.system("rm tests/export_3D.png")
         test_shape.export_3d_image("tests/export_3D.png")
         assert Path("tests/export_3D.png").exists() is True
@@ -211,13 +217,16 @@ class test_object_properties(unittest.TestCase):
     def test_export_stp(self):
         """Tests the method test_export_stp
         """
-        test_shape = ExtrudeMixedShape(points=[(10, 20, 'straight'),
-                                                (10, 10, 'straight'),
-                                                (20, 10, 'circle'),
-                                                (22, 15, 'circle'),
-                                                (20, 20, 'straight'),
-                                                ], distance = 10
-                                        )
+        test_shape = ExtrudeMixedShape(
+            points=[
+                (10, 20, 'straight'),
+                (10, 10, 'straight'),
+                (20, 10, 'circle'),
+                (22, 15, 'circle'),
+                (20, 20, 'straight'),
+                ],
+            distance=10
+            )
         os.system("rm tests/test.stp")
         test_shape.export_stp("tests/test.stp")
         assert Path("tests/test.stp").exists() is True
@@ -231,13 +240,16 @@ class test_object_properties(unittest.TestCase):
     def test_export_stl(self):
         """Tests the method test_export_stl
         """
-        test_shape = ExtrudeMixedShape(points=[(10, 20, 'straight'),
-                                                (10, 10, 'straight'),
-                                                (20, 10, 'circle'),
-                                                (22, 15, 'circle'),
-                                                (20, 20, 'straight'),
-                                                ], distance = 10
-                                        )
+        test_shape = ExtrudeMixedShape(
+            points=[
+                (10, 20, 'straight'),
+                (10, 10, 'straight'),
+                (20, 10, 'circle'),
+                (22, 15, 'circle'),
+                (20, 20, 'straight'),
+                ],
+            distance=10
+            )
         os.system("rm tests/test.stl")
         test_shape.export_stl("tests/test.stl")
         assert Path("tests/test.stl").exists() is True
@@ -249,13 +261,16 @@ class test_object_properties(unittest.TestCase):
     def test_create_render_mesh(self):
         """Tests the method create_render_mesh
         """
-        test_shape = ExtrudeMixedShape(points=[(10, 20, 'straight'),
-                                                (10, 10, 'straight'),
-                                                (20, 10, 'circle'),
-                                                (22, 15, 'circle'),
-                                                (20, 20, 'straight'),
-                                                ], distance = 10
-                                        )
+        test_shape = ExtrudeMixedShape(
+            points=[
+                (10, 20, 'straight'),
+                (10, 10, 'straight'),
+                (20, 10, 'circle'),
+                (22, 15, 'circle'),
+                (20, 20, 'straight'),
+                ],
+            distance=10
+            )
         test_shape._create_render_mesh()
 
 

--- a/tests/test_ExtrudeMixedShape.py
+++ b/tests/test_ExtrudeMixedShape.py
@@ -4,6 +4,8 @@ import unittest
 import pytest
 
 from paramak import ExtrudeMixedShape
+import os
+from pathlib import Path
 
 
 class test_object_properties(unittest.TestCase):
@@ -187,6 +189,75 @@ class test_object_properties(unittest.TestCase):
                                                 ], distance = 10
                                         )
         assert test_shape.volume > 10 * 10 * 10
+
+    def test_export_3d_image(self):
+        """Tests the method test_export_3d_image
+        """
+        test_shape = ExtrudeMixedShape(points=[(10, 20, 'straight'),
+                                                (10, 10, 'straight'),
+                                                (20, 10, 'circle'),
+                                                (22, 15, 'circle'),
+                                                (20, 20, 'straight'),
+                                                ], distance = 10
+                                        )
+        os.system("rm tests/export_3D.png")
+        test_shape.export_3d_image("tests/export_3D.png")
+        assert Path("tests/export_3D.png").exists() is True
+        os.system("rm tests/export_3D.png")
+        test_shape.export_3d_image("tests/export_3D")
+        assert Path("tests/export_3D.png").exists() is True
+        os.system("rm tests/export_3D.png")
+
+    def test_export_stp(self):
+        """Tests the method test_export_stp
+        """
+        test_shape = ExtrudeMixedShape(points=[(10, 20, 'straight'),
+                                                (10, 10, 'straight'),
+                                                (20, 10, 'circle'),
+                                                (22, 15, 'circle'),
+                                                (20, 20, 'straight'),
+                                                ], distance = 10
+                                        )
+        os.system("rm tests/test.stp")
+        test_shape.export_stp("tests/test.stp")
+        assert Path("tests/test.stp").exists() is True
+        os.system("rm tests/test.stp")
+
+        test_shape.stp_filename = ("tests/test.stp")
+        test_shape.export_stp()
+        assert Path("tests/test.stp").exists() is True
+        os.system("rm tests/test.stp")
+
+    def test_export_stl(self):
+        """Tests the method test_export_stl
+        """
+        test_shape = ExtrudeMixedShape(points=[(10, 20, 'straight'),
+                                                (10, 10, 'straight'),
+                                                (20, 10, 'circle'),
+                                                (22, 15, 'circle'),
+                                                (20, 20, 'straight'),
+                                                ], distance = 10
+                                        )
+        os.system("rm tests/test.stl")
+        test_shape.export_stl("tests/test.stl")
+        assert Path("tests/test.stl").exists() is True
+        os.system("rm tests/test.stl")
+        test_shape.export_stl("tests/test")
+        assert Path("tests/test.stl").exists() is True
+        os.system("rm tests/test.stl")
+
+    def test_create_render_mesh(self):
+        """Tests the method create_render_mesh
+        """
+        test_shape = ExtrudeMixedShape(points=[(10, 20, 'straight'),
+                                                (10, 10, 'straight'),
+                                                (20, 10, 'circle'),
+                                                (22, 15, 'circle'),
+                                                (20, 20, 'straight'),
+                                                ], distance = 10
+                                        )
+        test_shape._create_render_mesh()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -351,7 +351,10 @@ class test_object_properties(unittest.TestCase):
 
         assert Path("test_html.html").exists() is True
         os.system("rm test_html.html")
+        test_reactor.export_html(filename="test_html")
 
+        assert Path("test_html.html").exists() is True
+        os.system("rm test_html.html")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_RotateMixedShape.py
+++ b/tests/test_RotateMixedShape.py
@@ -7,6 +7,7 @@ from paramak import RotateMixedShape
 import os
 from pathlib import Path
 
+
 class test_object_properties(unittest.TestCase):
     def test_absolute_shape_volume(self):
         """creates a rotated shape using straight and spline connections and \

--- a/tests/test_RotateMixedShape.py
+++ b/tests/test_RotateMixedShape.py
@@ -244,25 +244,31 @@ class test_object_properties(unittest.TestCase):
 
     def test_mixed_shape_with_straight_and_circle(self):
         """tests the construction of a shape with straight and circular edges"""
-        test_shape = RotateMixedShape(points=[(10, 20, 'straight'),
-                                         (10, 10, 'straight'),
-                                         (20, 10, 'circle'),
-                                         (40, 15, 'circle'),
-                                         (20, 20, 'straight'),
-                                        ], rotation_angle = 10
-                                )
+        test_shape = RotateMixedShape(
+            points=[
+                (10, 20, 'straight'),
+                (10, 10, 'straight'),
+                (20, 10, 'circle'),
+                (40, 15, 'circle'),
+                (20, 20, 'straight'),
+                ],
+            rotation_angle=10
+            )
         assert test_shape.volume > 10 * 10
 
     def test_export_3d_image(self):
         """Tests the method test_export_3d_image
         """
-        test_shape = RotateMixedShape(points=[(10, 20, 'straight'),
-                                         (10, 10, 'straight'),
-                                         (20, 10, 'circle'),
-                                         (40, 15, 'circle'),
-                                         (20, 20, 'straight'),
-                                        ], rotation_angle = 10
-                                )
+        test_shape = RotateMixedShape(
+            points=[
+                (10, 20, 'straight'),
+                (10, 10, 'straight'),
+                (20, 10, 'circle'),
+                (40, 15, 'circle'),
+                (20, 20, 'straight'),
+                ],
+            rotation_angle=10
+            )
         os.system("rm tests/export_3D.png")
         test_shape.export_3d_image("tests/export_3D.png")
         assert Path("tests/export_3D.png").exists() is True
@@ -274,13 +280,16 @@ class test_object_properties(unittest.TestCase):
     def test_export_stp(self):
         """Tests the method test_export_stp
         """
-        test_shape = RotateMixedShape(points=[(10, 20, 'straight'),
-                                         (10, 10, 'straight'),
-                                         (20, 10, 'circle'),
-                                         (40, 15, 'circle'),
-                                         (20, 20, 'straight'),
-                                        ], rotation_angle = 10
-                                )
+        test_shape = RotateMixedShape(
+            points=[
+                (10, 20, 'straight'),
+                (10, 10, 'straight'),
+                (20, 10, 'circle'),
+                (40, 15, 'circle'),
+                (20, 20, 'straight'),
+                ],
+            rotation_angle=10
+            )
         os.system("rm tests/test.stp")
         test_shape.export_stp("tests/test.stp")
         assert Path("tests/test.stp").exists() is True
@@ -294,13 +303,16 @@ class test_object_properties(unittest.TestCase):
     def test_export_stl(self):
         """Tests the method test_export_stl
         """
-        test_shape = RotateMixedShape(points=[(10, 20, 'straight'),
-                                         (10, 10, 'straight'),
-                                         (20, 10, 'circle'),
-                                         (40, 15, 'circle'),
-                                         (20, 20, 'straight'),
-                                        ], rotation_angle = 10
-                                )
+        test_shape = RotateMixedShape(
+            points=[
+                (10, 20, 'straight'),
+                (10, 10, 'straight'),
+                (20, 10, 'circle'),
+                (40, 15, 'circle'),
+                (20, 20, 'straight'),
+                ],
+            rotation_angle=10
+            )
         os.system("rm tests/test.stl")
         test_shape.export_stl("tests/test.stl")
         assert Path("tests/test.stl").exists() is True
@@ -312,13 +324,16 @@ class test_object_properties(unittest.TestCase):
     def test_create_render_mesh(self):
         """Tests the method create_render_mesh
         """
-        test_shape = RotateMixedShape(points=[(10, 20, 'straight'),
-                                         (10, 10, 'straight'),
-                                         (20, 10, 'circle'),
-                                         (40, 15, 'circle'),
-                                         (20, 20, 'straight'),
-                                        ], rotation_angle = 10
-                                )
+        test_shape = RotateMixedShape(
+            points=[
+                (10, 20, 'straight'),
+                (10, 10, 'straight'),
+                (20, 10, 'circle'),
+                (40, 15, 'circle'),
+                (20, 20, 'straight'),
+                ],
+            rotation_angle=10
+            )
         test_shape._create_render_mesh()
 
 if __name__ == "__main__":

--- a/tests/test_RotateMixedShape.py
+++ b/tests/test_RotateMixedShape.py
@@ -4,7 +4,8 @@ import unittest
 import pytest
 
 from paramak import RotateMixedShape
-
+import os
+from pathlib import Path
 
 class test_object_properties(unittest.TestCase):
     def test_absolute_shape_volume(self):
@@ -252,6 +253,73 @@ class test_object_properties(unittest.TestCase):
                                 )
         assert test_shape.volume > 10 * 10
 
+    def test_export_3d_image(self):
+        """Tests the method test_export_3d_image
+        """
+        test_shape = RotateMixedShape(points=[(10, 20, 'straight'),
+                                         (10, 10, 'straight'),
+                                         (20, 10, 'circle'),
+                                         (40, 15, 'circle'),
+                                         (20, 20, 'straight'),
+                                        ], rotation_angle = 10
+                                )
+        os.system("rm tests/export_3D.png")
+        test_shape.export_3d_image("tests/export_3D.png")
+        assert Path("tests/export_3D.png").exists() is True
+        os.system("rm tests/export_3D.png")
+        test_shape.export_3d_image("tests/export_3D")
+        assert Path("tests/export_3D.png").exists() is True
+        os.system("rm tests/export_3D.png")
+
+    def test_export_stp(self):
+        """Tests the method test_export_stp
+        """
+        test_shape = RotateMixedShape(points=[(10, 20, 'straight'),
+                                         (10, 10, 'straight'),
+                                         (20, 10, 'circle'),
+                                         (40, 15, 'circle'),
+                                         (20, 20, 'straight'),
+                                        ], rotation_angle = 10
+                                )
+        os.system("rm tests/test.stp")
+        test_shape.export_stp("tests/test.stp")
+        assert Path("tests/test.stp").exists() is True
+        os.system("rm tests/test.stp")
+
+        test_shape.stp_filename = ("tests/test.stp")
+        test_shape.export_stp()
+        assert Path("tests/test.stp").exists() is True
+        os.system("rm tests/test.stp")
+
+    def test_export_stl(self):
+        """Tests the method test_export_stl
+        """
+        test_shape = RotateMixedShape(points=[(10, 20, 'straight'),
+                                         (10, 10, 'straight'),
+                                         (20, 10, 'circle'),
+                                         (40, 15, 'circle'),
+                                         (20, 20, 'straight'),
+                                        ], rotation_angle = 10
+                                )
+        os.system("rm tests/test.stl")
+        test_shape.export_stl("tests/test.stl")
+        assert Path("tests/test.stl").exists() is True
+        os.system("rm tests/test.stl")
+        test_shape.export_stl("tests/test")
+        assert Path("tests/test.stl").exists() is True
+        os.system("rm tests/test.stl")
+
+    def test_create_render_mesh(self):
+        """Tests the method create_render_mesh
+        """
+        test_shape = RotateMixedShape(points=[(10, 20, 'straight'),
+                                         (10, 10, 'straight'),
+                                         (20, 10, 'circle'),
+                                         (40, 15, 'circle'),
+                                         (20, 20, 'straight'),
+                                        ], rotation_angle = 10
+                                )
+        test_shape._create_render_mesh()
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -105,6 +105,13 @@ class test_object_properties(unittest.TestCase):
         assert Path("filename.html").exists() is True
         os.system("rm filename.html")
 
+    def test_export_stp(self):
+
+        test_shape = Shape()
+        test_shape.points = [(0, 0), (0, 20), (20, 20), (20, 0)]
+        test_shape.export_stp("tests/test.stp")
+        test_shape.export_stp()
+
     def test_export_stl(self):
 
         test_shape = Shape()

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -105,5 +105,17 @@ class test_object_properties(unittest.TestCase):
         assert Path("filename.html").exists() is True
         os.system("rm filename.html")
 
+    def test_export_stl(self):
+
+        test_shape = Shape()
+        test_shape.points = [(0, 0), (0, 20), (20, 20), (20, 0)]
+        test_shape.export_stl("tests/test.stl")
+
+    def test_create_render_mesh(self):
+
+        test_shape = Shape()
+        test_shape.points = [(0, 0), (0, 20), (20, 20), (20, 0)]
+        test_shape._create_render_mesh()
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -77,6 +77,20 @@ class test_object_properties(unittest.TestCase):
         assert Path("filename.png").exists() is True
         os.system("rm filename.png")
 
+    def test_export_3d_image(self):
+        """checks that export_3d_image() exports png files with the \
+                correct suffix"""
+
+        test_shape = Shape()
+        test_shape.points = [(0, 0), (0, 20), (20, 20), (20, 0)]
+        os.system("rm filename.png")
+        test_shape.export_2d_image("filename")
+        assert Path("filename.png").exists() is True
+        os.system("rm filename.png")
+        test_shape.export_2d_image("filename.png")
+        assert Path("filename.png").exists() is True
+        os.system("rm filename.png")
+
     def test_export_html_filename(self):
         """checks that export_html() exports html files with the \
                 correct suffix"""


### PR DESCRIPTION
This PR is related to #136 and increase the coverage above 90% 🚀 💚 .

Tests have been added to : 
- `Shape`
- `ExtrudeMixedShape`
- `RotateMixedShape`
- `Reactor`
- `BallReactor`

Known errors:
- `export_3d_image` method breaks for all objects (shape or reactor)

ToDo:
- methods like `export_3d_image`, `export_stp`, `export_stl` and all should be tested within the `Shape` test suite and not as currently in the `ExtrudeMixedShape` or `RotateMixedShape` test suites