### PR TITLE
Add usage parametric reactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,26 +95,27 @@ optional outer pf and tf coils.
 
 `from paramak import BallReactor`
 
-`my_reactor = BallReactor(`
-    `inner_bore_radial_thickness = 50,`
-    `inboard_tf_leg_radial_thickness = 50,`
-    `center_column_shield_radial_thickness= 50,`
-    `divertor_radial_thickness = 100,`
-    `inner_plasma_gap_radial_thickness = 50,`
-    `plasma_radial_thickness = 200,`
-    `outer_plasma_gap_radial_thickness = 50,`
-    `firstwall_radial_thickness = 50,`
-    `blanket_radial_thickness = 100,`
-    `blanket_rear_wall_radial_thickness = 50,`
-    `elongation = 2,`
-    `triangularity = 0.55,`
-    `number_of_tf_coils = 16,`
-    `rotation_angle = 180`
-`)`
+```python
+my_reactor = BallReactor(
+    inner_bore_radial_thickness = 50,
+    inboard_tf_leg_radial_thickness = 50,
+    center_column_shield_radial_thickness= 50,
+    divertor_radial_thickness = 100,
+    inner_plasma_gap_radial_thickness = 50,
+    plasma_radial_thickness = 200,
+    outer_plasma_gap_radial_thickness = 50,
+    firstwall_radial_thickness = 50,
+    blanket_radial_thickness = 100,
+    blanket_rear_wall_radial_thickness = 50,
+    elongation = 2,
+    triangularity = 0.55,
+    number_of_tf_coils = 16,
+    rotation_angle = 180
 
-`my_reactor.name = 'BallReactor'`
+my_reactor.name = 'BallReactor'
 
-`my_reactor.export_stp()`
+my_reactor.export_stp()
+```
 
 <p align="center"><img src="https://user-images.githubusercontent.com/56687624/89203299-465fdc00-d5ac-11ea-8663-a5b7eecfb584.png" height="300"></p>
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,40 @@ Parametric components are wrapped versions of the eight basic shapes where param
 <p align="center"><img src="https://user-images.githubusercontent.com/56687624/88935871-1ea20880-d27a-11ea-82e1-1afa55ff9ba8.png" height="300"></p>
 
 
+## Usage - Parametric Reactors
+
+Parametric Reactors are wrapped versions of a combination of parametric shapes and components that comprise a particular reactor design. Some parametric reactors include a ball reactor and
+a submersion ball reactor. These allow full reactor models to be constructed by specifying a series of simple parameters. This example shows the construction of a simple ball reactor without the
+optional outer pf and tf coils.
+
+
+`from paramak import BallReactor`
+
+`my_reactor = BallReactor(`
+    `inner_bore_radial_thickness=50,`
+    `inboard_tf_leg_radial_thickness = 50,`
+    `center_column_shield_radial_thickness= 50,`
+    `divertor_radial_thickness = 100,`
+    `inner_plasma_gap_radial_thickness = 50,`
+    `plasma_radial_thickness = 200,`
+    `outer_plasma_gap_radial_thickness = 50,`
+    `firstwall_radial_thickness=50,`
+    `blanket_radial_thickness=100,`
+    `blanket_rear_wall_radial_thickness=50,`
+    `elongation=2,`
+    `triangularity=0.55,`
+    `number_of_tf_coils=16,`
+    `rotation_angle=180`
+`)`
+
+`my_reactor.name = 'BallReactor'`
+
+`my_reactor.export_stp()`
+
+<p align="center"><img src="https://user-images.githubusercontent.com/56687624/89203299-465fdc00-d5ac-11ea-8663-a5b7eecfb584.png" height="300"></p>
+
+
+
 ## Usage - Reactor object
 
 A reactor object provides a container object for all Shape objects created, and allows operations to be performed on the whole collection of Shapes.

--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ Parametric Reactors are wrapped versions of a combination of parametric shapes a
 a submersion ball reactor. These allow full reactor models to be constructed by specifying a series of simple parameters. This example shows the construction of a simple ball reactor without the
 optional outer pf and tf coils.
 
-
-`from paramak import BallReactor`
-
 ```python
+
+from paramak import BallReactor
+
 my_reactor = BallReactor(
     inner_bore_radial_thickness = 50,
     inboard_tf_leg_radial_thickness = 50,

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ optional outer pf and tf coils.
 `from paramak import BallReactor`
 
 `my_reactor = BallReactor(`
-    `inner_bore_radial_thickness=50,`
+    `inner_bore_radial_thickness = 50,`
     `inboard_tf_leg_radial_thickness = 50,`
     `center_column_shield_radial_thickness= 50,`
     `divertor_radial_thickness = 100,`

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ optional outer pf and tf coils.
     `inner_plasma_gap_radial_thickness = 50,`
     `plasma_radial_thickness = 200,`
     `outer_plasma_gap_radial_thickness = 50,`
-    `firstwall_radial_thickness=50,`
-    `blanket_radial_thickness=100,`
-    `blanket_rear_wall_radial_thickness=50,`
-    `elongation=2,`
-    `triangularity=0.55,`
-    `number_of_tf_coils=16,`
-    `rotation_angle=180`
+    `firstwall_radial_thickness = 50,`
+    `blanket_radial_thickness = 100,`
+    `blanket_rear_wall_radial_thickness = 50,`
+    `elongation = 2,`
+    `triangularity = 0.55,`
+    `number_of_tf_coils = 16,`
+    `rotation_angle = 180`
 `)`
 
 `my_reactor.name = 'BallReactor'`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -202,20 +202,20 @@ Parametric Reactors are wrapped versions of a combination of parametric shapes a
    from paramak import BallReactor
 
    my_reactor = paramak.BallReactor(
-      inner_bore_radial_thickness=50,
+      inner_bore_radial_thickness = 50,
       inboard_tf_leg_radial_thickness = 50,
       center_column_shield_radial_thickness= 50,
       divertor_radial_thickness = 100,
       inner_plasma_gap_radial_thickness = 50,
       plasma_radial_thickness = 200,
       outer_plasma_gap_radial_thickness = 50,
-      firstwall_radial_thickness=50,
-      blanket_radial_thickness=100,
-      blanket_rear_wall_radial_thickness=50,
-      elongation=2,
-      triangularity=0.55,
-      number_of_tf_coils=16,
-      rotation_angle=180
+      firstwall_radial_thickness = 50,
+      blanket_radial_thickness = 100,
+      blanket_rear_wall_radial_thickness = 50,
+      elongation = 2,
+      triangularity = 0.55,
+      number_of_tf_coils = 16,
+      rotation_angle = 180
    )
    
    my_reactor.name = 'BallReactor'

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,20 +5,6 @@ The Paramak python package allows rapid production of 3D CAD models of fusion re
 
 Features have been added to address particular needs and the software is by no means a finished product. Contributions are welcome. CadQuery functions provide the majority the features, and incorporating additional capabilities is straight forward for developers with Python knowledge.
 
-.. toctree::
-   :maxdepth: 1
-
-   paramak.parametric_shapes
-   paramak.parametric_components
-   paramak.parametric_reactors
-   paramak.core_modules
-   example_parametric_shapes
-   example_parametric_components
-   example_parametric_reactors
-   example_neutronics_simulations
-   tests
-   
-
 Prerequisites
 -------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,6 +5,19 @@ The Paramak python package allows rapid production of 3D CAD models of fusion re
 
 Features have been added to address particular needs and the software is by no means a finished product. Contributions are welcome. CadQuery functions provide the majority the features, and incorporating additional capabilities is straight forward for developers with Python knowledge.
 
+.. toctree::
+   :maxdepth: 1
+
+   paramak.parametric_shapes
+   paramak.parametric_components
+   paramak.parametric_reactors
+   paramak.core_modules
+   example_parametric_shapes
+   example_parametric_components
+   example_parametric_reactors
+   example_neutronics_simulations
+   tests
+
 Prerequisites
 -------------
 
@@ -209,7 +222,7 @@ Parametric Reactors are wrapped versions of a combination of parametric shapes a
    
    all_reactors.append(my_reactor)
 
-:: image:: https://user-images.githubusercontent.com/56687624/89203299-465fdc00-d5ac-11ea-8663-a5b7eecfb584.png
+.. image:: https://user-images.githubusercontent.com/56687624/89203299-465fdc00-d5ac-11ea-8663-a5b7eecfb584.png
    :width: 350
    :height: 300
    :align: center

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,7 @@ The Paramak python package allows rapid production of 3D CAD models of fusion re
 Features have been added to address particular needs and the software is by no means a finished product. Contributions are welcome. CadQuery functions provide the majority the features, and incorporating additional capabilities is straight forward for developers with Python knowledge.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    paramak.parametric_shapes
    paramak.parametric_components
@@ -193,6 +193,40 @@ Parametric components are wrapped versions of the eight basic shapes where param
    :height: 300
    :align: center
 
+Usage - Parametric Reactors
+---------------------------
+
+Parametric Reactors are wrapped versions of a combination of parametric shapes and components that comprise a particular reactor design. Some parametric reactors include a ball reactor and a submersion ball reactor. These allow full reactor models to be constructed by specifying a series of simple parameters. This example shows the construction of a simple ball reactor without the optional outer pf and tf coils.
+
+::
+
+   from paramak import BallReactor
+
+   my_reactor = paramak.BallReactor(
+      inner_bore_radial_thickness=50,
+      inboard_tf_leg_radial_thickness = 50,
+      center_column_shield_radial_thickness= 50,
+      divertor_radial_thickness = 100,
+      inner_plasma_gap_radial_thickness = 50,
+      plasma_radial_thickness = 200,
+      outer_plasma_gap_radial_thickness = 50,
+      firstwall_radial_thickness=50,
+      blanket_radial_thickness=100,
+      blanket_rear_wall_radial_thickness=50,
+      elongation=2,
+      triangularity=0.55,
+      number_of_tf_coils=16,
+      rotation_angle=180
+   )
+   
+   my_reactor.name = 'BallReactor'
+   
+   all_reactors.append(my_reactor)
+
+:: image:: https://user-images.githubusercontent.com/56687624/89203299-465fdc00-d5ac-11ea-8663-a5b7eecfb584.png
+   :width: 350
+   :height: 300
+   :align: center
 
 Usage - Reactor object
 ----------------------


### PR DESCRIPTION
PR to add description of parametric reactor usage to documentation. Tried to remove the toctree on the title page but this is required. Ideally, need to find a way to remove this from the main landing page but still have the links in the sidebar of readthedocs. This will be dealt with in a future PR.