### PR TITLE
Adding support for union in shape creation

### DIFF
--- a/paramak/parametric_components/blanket_constant_thickness_arc_h.py
+++ b/paramak/parametric_components/blanket_constant_thickness_arc_h.py
@@ -63,7 +63,8 @@ class BlanketConstantThicknessArcH(RotateMixedShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/blanket_constant_thickness_arc_v.py
+++ b/paramak/parametric_components/blanket_constant_thickness_arc_v.py
@@ -63,7 +63,8 @@ class BlanketConstantThicknessArcV(RotateMixedShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/blanket_constant_thickness_fp.py
+++ b/paramak/parametric_components/blanket_constant_thickness_fp.py
@@ -85,7 +85,8 @@ class BlanketConstantThicknessFP(RotateMixedShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/center_column_circular.py
+++ b/paramak/parametric_components/center_column_circular.py
@@ -39,7 +39,8 @@ class CenterColumnShieldCircular(RotateMixedShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/center_column_cylinder.py
+++ b/paramak/parametric_components/center_column_cylinder.py
@@ -34,7 +34,8 @@ class CenterColumnShieldCylinder(RotateStraightShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/center_column_flat_top_circular.py
+++ b/paramak/parametric_components/center_column_flat_top_circular.py
@@ -27,7 +27,8 @@ class CenterColumnShieldFlatTopCircular(RotateMixedShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
         
         for arg in kwargs:

--- a/paramak/parametric_components/center_column_flat_top_hyperbola.py
+++ b/paramak/parametric_components/center_column_flat_top_hyperbola.py
@@ -41,7 +41,8 @@ class CenterColumnShieldFlatTopHyperbola(RotateMixedShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/center_column_hyperbola.py
+++ b/paramak/parametric_components/center_column_hyperbola.py
@@ -38,7 +38,8 @@ class CenterColumnShieldHyperbola(RotateMixedShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/center_column_plasma_dependant.py
+++ b/paramak/parametric_components/center_column_plasma_dependant.py
@@ -50,7 +50,8 @@ class CenterColumnShieldPlasmaHyperbola(RotateMixedShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/divertor_ITER.py
+++ b/paramak/parametric_components/divertor_ITER.py
@@ -90,7 +90,8 @@ class ITERtypeDivertor(RotateMixedShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/divertor_block.py
+++ b/paramak/parametric_components/divertor_block.py
@@ -56,7 +56,8 @@ class DivertorBlock(RotateMixedShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/inner_tf_coils_circular.py
+++ b/paramak/parametric_components/inner_tf_coils_circular.py
@@ -40,7 +40,8 @@ class InnerTfCoilsCircular(ExtrudeMixedShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/inner_tf_coils_flat.py
+++ b/paramak/parametric_components/inner_tf_coils_flat.py
@@ -40,7 +40,8 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/poloidal_field_coil.py
+++ b/paramak/parametric_components/poloidal_field_coil.py
@@ -34,7 +34,8 @@ class PoloidalFieldCoil(RotateStraightShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
         
         for arg in kwargs:

--- a/paramak/parametric_components/poloidal_field_coil_case.py
+++ b/paramak/parametric_components/poloidal_field_coil_case.py
@@ -38,7 +38,8 @@ class PoloidalFieldCoilCase(RotateStraightShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/poloidal_field_coil_case_fc.py
+++ b/paramak/parametric_components/poloidal_field_coil_case_fc.py
@@ -32,7 +32,8 @@ class PoloidalFieldCoilCaseFC(RotateStraightShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/tokamak_plasma.py
+++ b/paramak/parametric_components/tokamak_plasma.py
@@ -60,7 +60,8 @@ class Plasma(RotateSplineShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/tokamak_plasma_from_points.py
+++ b/paramak/parametric_components/tokamak_plasma_from_points.py
@@ -47,7 +47,8 @@ class PlasmaFromPoints(Plasma):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
+++ b/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
@@ -53,7 +53,8 @@ class ToroidalFieldCoilCoatHanger(ExtrudeStraightShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/toroidal_field_coil_rectangle.py
+++ b/paramak/parametric_components/toroidal_field_coil_rectangle.py
@@ -48,7 +48,8 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
                         'solid':None,
                         'hash_value':None,
                         'intersect':None,
-                        'cut':None
+                        'cut':None,
+                        'union':None
         }
 
         for arg in kwargs:

--- a/paramak/parametric_shapes/extruded_circle_shape.py
+++ b/paramak/parametric_shapes/extruded_circle_shape.py
@@ -5,7 +5,7 @@ from hashlib import blake2b
 import cadquery as cq
 
 from paramak import Shape
-from paramak.utils import cut_solid, intersect_solid
+from paramak.utils import cut_solid, intersect_solid, union_solid
 
 
 class ExtrudeCircleShape(Shape):
@@ -48,6 +48,7 @@ class ExtrudeCircleShape(Shape):
         azimuth_placement_angle=0,
         cut=None,
         intersect=None,
+        union=None,
         material_tag=None,
         name=None,
         hash_value=None,
@@ -65,6 +66,7 @@ class ExtrudeCircleShape(Shape):
 
         self.cut = cut
         self.intersect = intersect
+        self.union = union
         self.radius = radius
         self.distance = distance
         self.hash_value = hash_value
@@ -85,6 +87,14 @@ class ExtrudeCircleShape(Shape):
     @intersect.setter
     def intersect(self, value):
         self._intersect = value
+
+    @property
+    def union(self):
+        return self._union
+
+    @union.setter
+    def union(self, value):
+        self._union = value
 
     @property
     def solid(self):
@@ -180,6 +190,10 @@ class ExtrudeCircleShape(Shape):
         # If an intersect is provided then perform a boolean intersect
         if self.intersect is not None:
             solid = intersect_solid(solid, self.intersect)
+
+        # If an intersect is provided then perform a boolean intersect
+        if self.union is not None:
+            solid = union_solid(solid, self.union)
 
         self.solid = solid
 

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -4,7 +4,7 @@ from hashlib import blake2b
 import cadquery as cq
 
 from paramak import Shape
-from paramak.utils import cut_solid, intersect_solid
+from paramak.utils import cut_solid, intersect_solid, union_solid
 
 
 class ExtrudeMixedShape(Shape):
@@ -45,6 +45,7 @@ class ExtrudeMixedShape(Shape):
         azimuth_placement_angle=0,
         cut=None,
         intersect=None,
+        union=None,
         material_tag=None,
         name=None,
         hash_value=None,
@@ -62,6 +63,7 @@ class ExtrudeMixedShape(Shape):
 
         self.cut = cut
         self.intersect = intersect
+        self.union = union
         self.distance = distance
         self.hash_value = hash_value
         self.solid = solid
@@ -81,6 +83,14 @@ class ExtrudeMixedShape(Shape):
     @intersect.setter
     def intersect(self, value):
         self._intersect = value
+
+    @property
+    def union(self):
+        return self._union
+
+    @union.setter
+    def union(self, value):
+        self._union = value
 
     @property
     def solid(self):
@@ -200,6 +210,10 @@ class ExtrudeMixedShape(Shape):
         # If an intersect is provided then perform a boolean intersect
         if self.intersect is not None:
             solid = intersect_solid(solid, self.intersect)
+
+        # If an intersect is provided then perform a boolean intersect
+        if self.union is not None:
+            solid = union_solid(solid, self.union)
 
         self.solid = solid
 

--- a/paramak/parametric_shapes/extruded_spline_shape.py
+++ b/paramak/parametric_shapes/extruded_spline_shape.py
@@ -4,7 +4,7 @@ from hashlib import blake2b
 import cadquery as cq
 
 from paramak import Shape
-from paramak.utils import cut_solid, intersect_solid
+from paramak.utils import cut_solid, intersect_solid, union_solid
 
 
 class ExtrudeSplineShape(Shape):
@@ -43,6 +43,7 @@ class ExtrudeSplineShape(Shape):
         azimuth_placement_angle=0,
         cut=None,
         intersect=None,
+        union=None,
         material_tag=None,
         name=None,
         hash_value=None,
@@ -60,6 +61,7 @@ class ExtrudeSplineShape(Shape):
 
         self.cut = cut
         self.intersect = intersect
+        self.union = union
         self.distance = distance
         self.hash_value = hash_value
         self.solid = solid
@@ -79,6 +81,14 @@ class ExtrudeSplineShape(Shape):
     @intersect.setter
     def intersect(self, value):
         self._intersect = value
+
+    @property
+    def union(self):
+        return self._union
+
+    @union.setter
+    def union(self, value):
+        self._union = value
 
     @property
     def solid(self):
@@ -165,6 +175,10 @@ class ExtrudeSplineShape(Shape):
         # If an intersect is provided then perform a boolean intersect
         if self.intersect is not None:
             solid = intersect_solid(solid, self.intersect)
+
+        # If an intersect is provided then perform a boolean intersect
+        if self.union is not None:
+            solid = union_solid(solid, self.union)
 
         self.solid = solid
 

--- a/paramak/parametric_shapes/extruded_straight_shape.py
+++ b/paramak/parametric_shapes/extruded_straight_shape.py
@@ -5,7 +5,7 @@ from hashlib import blake2b
 import cadquery as cq
 
 from paramak import Shape
-from paramak.utils import cut_solid, intersect_solid
+from paramak.utils import cut_solid, intersect_solid, union_solid
 
 
 class ExtrudeStraightShape(Shape):
@@ -43,6 +43,7 @@ class ExtrudeStraightShape(Shape):
         azimuth_placement_angle=0,
         cut=None,
         intersect=None,
+        union=None,
         material_tag=None,
         name=None,
         hash_value=None,
@@ -60,6 +61,7 @@ class ExtrudeStraightShape(Shape):
 
         self.cut = cut
         self.intersect = intersect
+        self.union = union
         self.distance = distance
         self.hash_value = hash_value
         self.solid = solid
@@ -79,6 +81,14 @@ class ExtrudeStraightShape(Shape):
     @intersect.setter
     def intersect(self, value):
         self._intersect = value
+
+    @property
+    def union(self):
+        return self._union
+
+    @union.setter
+    def union(self, value):
+        self._union = value
 
     @property
     def solid(self):
@@ -165,6 +175,10 @@ class ExtrudeStraightShape(Shape):
         # If an intersect is provided then perform a boolean intersect
         if self.intersect is not None:
             solid = intersect_solid(solid, self.intersect)
+
+        # If an intersect is provided then perform a boolean intersect
+        if self.union is not None:
+            solid = union_solid(solid, self.union)
 
         self.solid = solid
 

--- a/paramak/parametric_shapes/rotate_circle_shape.py
+++ b/paramak/parametric_shapes/rotate_circle_shape.py
@@ -4,7 +4,7 @@ from hashlib import blake2b
 import cadquery as cq
 
 from paramak import Shape
-from paramak.utils import cut_solid, intersect_solid
+from paramak.utils import cut_solid, intersect_solid, union_solid
 
 
 class RotateCircleShape(Shape):
@@ -38,6 +38,7 @@ class RotateCircleShape(Shape):
         rotation_angle=360,
         cut=None,
         intersect=None,
+        union=None,
         material_tag=None,
         name=None,
         hash_value=None,
@@ -55,6 +56,7 @@ class RotateCircleShape(Shape):
 
         self.cut = cut
         self.intersect = intersect
+        self.union = union
         self.radius = radius
         self.rotation_angle = rotation_angle
         self.hash_value = hash_value
@@ -76,6 +78,14 @@ class RotateCircleShape(Shape):
     @intersect.setter
     def intersect(self, value):
         self._intersect = value
+
+    @property
+    def union(self):
+        return self._union
+
+    @union.setter
+    def union(self, value):
+        self._union = value
 
     @property
     def solid(self):
@@ -170,6 +180,10 @@ class RotateCircleShape(Shape):
         # If an intersect is provided then perform a boolean intersect
         if self.intersect is not None:
             solid = intersect_solid(solid, self.intersect)
+
+        # If an intersect is provided then perform a boolean intersect
+        if self.union is not None:
+            solid = union_solid(solid, self.union)
 
         self.solid = solid
 

--- a/paramak/parametric_shapes/rotate_mixed_shape.py
+++ b/paramak/parametric_shapes/rotate_mixed_shape.py
@@ -4,7 +4,7 @@ from hashlib import blake2b
 import cadquery as cq
 
 from paramak import Shape
-from paramak.utils import cut_solid, intersect_solid
+from paramak.utils import cut_solid, intersect_solid, union_solid
 
 
 class RotateMixedShape(Shape):
@@ -40,6 +40,7 @@ class RotateMixedShape(Shape):
         rotation_angle=360,
         cut=None,
         intersect=None,
+        union=None,
         hash_value=None,
     ):
 
@@ -55,6 +56,7 @@ class RotateMixedShape(Shape):
 
         self.cut = cut
         self.intersect = intersect
+        self.union = union
         self.rotation_angle = rotation_angle
         self.hash_value = hash_value
         self.solid = solid
@@ -74,6 +76,14 @@ class RotateMixedShape(Shape):
     @intersect.setter
     def intersect(self, value):
         self._intersect = value
+
+    @property
+    def union(self):
+        return self._union
+
+    @union.setter
+    def union(self, value):
+        self._union = value
 
     @property
     def solid(self):
@@ -191,6 +201,10 @@ class RotateMixedShape(Shape):
         # If an intersect is provided then perform a boolean intersect
         if self.intersect is not None:
             solid = intersect_solid(solid, self.intersect)
+
+        # If an intersect is provided then perform a boolean intersect
+        if self.union is not None:
+            solid = union_solid(solid, self.union)
 
         self.solid = solid
 

--- a/paramak/parametric_shapes/rotate_spline_shape.py
+++ b/paramak/parametric_shapes/rotate_spline_shape.py
@@ -5,7 +5,7 @@ from hashlib import blake2b
 import cadquery as cq
 
 from paramak import Shape
-from paramak.utils import cut_solid, intersect_solid
+from paramak.utils import cut_solid, intersect_solid, union_solid
 
 
 class RotateSplineShape(Shape):
@@ -38,6 +38,7 @@ class RotateSplineShape(Shape):
         rotation_angle=360,
         cut=None,
         intersect=None,
+        union=None,
         hash_value=None,
     ):
 
@@ -53,6 +54,7 @@ class RotateSplineShape(Shape):
 
         self.cut = cut
         self.intersect = intersect
+        self.union = union
         self.rotation_angle = rotation_angle
         self.hash_value = hash_value
         self.solid = solid
@@ -72,6 +74,14 @@ class RotateSplineShape(Shape):
     @intersect.setter
     def intersect(self, value):
         self._intersect = value
+
+    @property
+    def union(self):
+        return self._union
+
+    @union.setter
+    def union(self, value):
+        self._union = value
 
     @property
     def solid(self):
@@ -159,6 +169,10 @@ class RotateSplineShape(Shape):
         # If an intersect is provided then perform a boolean intersect
         if self.intersect is not None:
             solid = intersect_solid(solid, self.intersect)
+
+        # If an intersect is provided then perform a boolean intersect
+        if self.union is not None:
+            solid = union_solid(solid, self.union)
 
         self.solid = solid
 

--- a/paramak/parametric_shapes/rotate_straight_shape.py
+++ b/paramak/parametric_shapes/rotate_straight_shape.py
@@ -5,7 +5,7 @@ from hashlib import blake2b
 import cadquery as cq
 
 from paramak import Shape
-from paramak.utils import cut_solid, intersect_solid
+from paramak.utils import cut_solid, intersect_solid, union_solid
 
 
 class RotateStraightShape(Shape):
@@ -42,6 +42,7 @@ class RotateStraightShape(Shape):
         rotation_angle=360,
         cut=None,
         intersect=None,
+        union=None,
         hash_value=None,
     ):
 
@@ -57,6 +58,7 @@ class RotateStraightShape(Shape):
 
         self.cut = cut
         self.intersect = intersect
+        self.union = union
         self.rotation_angle = rotation_angle
         self.hash_value = hash_value
         self.solid = solid
@@ -76,6 +78,14 @@ class RotateStraightShape(Shape):
     @intersect.setter
     def intersect(self, value):
         self._intersect = value
+
+    @property
+    def union(self):
+        return self._union
+
+    @union.setter
+    def union(self, value):
+        self._union = value
 
     @property
     def solid(self):
@@ -163,6 +173,10 @@ class RotateStraightShape(Shape):
         # If an intersect is provided then perform a boolean intersect
         if self.intersect is not None:
             solid = intersect_solid(solid, self.intersect)
+
+        # If an intersect is provided then perform a boolean intersect
+        if self.union is not None:
+            solid = union_solid(solid, self.union)
 
         self.solid = solid
 

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -3,6 +3,23 @@ from collections import Iterable
 
 import numpy as np
 
+def union_solid(solid, joiner):
+    """
+    Performs a boolean union of a solid with another solid or iterable of solids.
+    
+    Args:
+        solid Shape: the Shape that you want to union from
+        joiner Shape: the Shape(s) that you want to be the unionting object
+    Returns:
+        Shape: the original shape union with the joiner shape(s)
+    """
+    # Allows for multiple unions to be applied
+    if isinstance(joiner, Iterable):
+        for joining_solid in joiner:
+            solid = solid.union(joining_solid.solid)
+    else:
+        solid = solid.union(joiner.solid)
+    return solid
 
 def cut_solid(solid, cutter):
     """

--- a/tests/test_RotateMixedShape.py
+++ b/tests/test_RotateMixedShape.py
@@ -9,6 +9,27 @@ from pathlib import Path
 
 
 class test_object_properties(unittest.TestCase):
+
+    def test_union_volume_addition(self):
+        """ makes two volumes and then remakes the same two volumes as a
+        fused solid. Checks the volumes of these two options are the same.
+        """
+        inner_box = RotateMixedShape(points=[(100,100,'straight'),(100,200,'straight'),
+                                                (200,200,'straight'), (200,100,'straight')],
+                                                rotation_angle=20)
+
+        outer_box = RotateMixedShape(points=[(200,100,'straight'),(200,200,'straight'),
+                                                (500,200,'straight'), (500,100,'straight')],
+                                                rotation_angle=20)
+
+        outer_box_and_inner_box = RotateMixedShape(
+            points=[(200,100,'straight'),(200,200,'straight'),
+                    (500,200,'straight'), (500,100,'straight')],
+            rotation_angle=20, union=inner_box)
+
+        assert inner_box.volume + outer_box.volume == pytest.approx(outer_box_and_inner_box.volume)
+        
+
     def test_absolute_shape_volume(self):
         """creates a rotated shape using straight and spline connections and \
                 checks the volume is correct"""

--- a/tests/test_RotateStraightShape.py
+++ b/tests/test_RotateStraightShape.py
@@ -9,6 +9,26 @@ from paramak import RotateStraightShape
 
 
 class test_object_properties(unittest.TestCase):
+
+    def test_union_volume_addition(self):
+        """ makes two volumes and then remakes the same two volumes as a
+        fused solid. Checks the volumes of these two options are the same.
+        """
+        inner_box = RotateStraightShape(points=[(100,100),(100,200),
+                                                (200,200), (200,100)],
+                                                rotation_angle=20)
+
+        outer_box = RotateStraightShape(points=[(200,100),(200,200),
+                                                (500,200), (500,100)],
+                                                rotation_angle=20)
+
+        outer_box_and_inner_box = RotateStraightShape(
+            points=[(200,100),(200,200),
+                    (500,200), (500,100)],
+            rotation_angle=20, union=inner_box)
+
+        assert inner_box.volume + outer_box.volume == pytest.approx(outer_box_and_inner_box.volume, rel=0.01)
+        
     def test_shape_rotation_angle_default(self):
         """"checks that the default rotation angle for a RotateStraightShape \
                 is 360 degrees"""


### PR DESCRIPTION
This PR allows shapes to be fused / union together during the build process

This adds another keyword arg called union that can accept a shape or list of shapes to fuse / union with the shape being created

Here is an example, 3 shapes can be created and the overlap

```
import paramak
box1 = paramak.RotateMixedShape(points=[(150,100,'straight'),(150,200,'straight'),
                                        (300,300,'straight'), (200,150,'straight')],
                                        rotation_angle=20)

box2 = paramak.RotateStraightShape(points=[(50,50),(50,200), (200,200), (200,50)],
                                   rotation_angle=20)

box3 = paramak.RotateSplineShape(points=[(100,100),(150,200), (100,300), (200,150)],
                                 rotation_angle=20)

m = paramak.Reactor([box1, box2 ,box3])
m.solid
```
Which could be combined in the following manner
![Screenshot from 2020-08-04 15-09-55](https://user-images.githubusercontent.com/8583900/89304706-ab2b3d00-d665-11ea-9ad1-d16767b3c582.png)

```
import paramak
box4 = paramak.RotateMixedShape(points=[(150,100,'straight'),(150,200,'straight'),
                                        (300,300,'straight'), (200,150,'straight')],
                                        rotation_angle=20,
                                union = [box2, box3])
box4.solid
```
![Screenshot from 2020-08-04 15-10-25](https://user-images.githubusercontent.com/8583900/89304683-a4042f00-d665-11ea-85a7-103b28c71f15.png)

