### PR TITLE
added stl duplication filename checks

### DIFF
--- a/paramak/parametric_shapes/extruded_circle_shape.py
+++ b/paramak/parametric_shapes/extruded_circle_shape.py
@@ -68,6 +68,7 @@ class ExtrudeCircleShape(Shape):
             color=color,
             material_tag=material_tag,
             stp_filename=stp_filename,
+            stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
             **default_dict

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -65,6 +65,7 @@ class ExtrudeMixedShape(Shape):
             color=color,
             material_tag=material_tag,
             stp_filename=stp_filename,
+            stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
             **default_dict

--- a/paramak/parametric_shapes/extruded_spline_shape.py
+++ b/paramak/parametric_shapes/extruded_spline_shape.py
@@ -63,6 +63,7 @@ class ExtrudeSplineShape(Shape):
             color=color,
             material_tag=material_tag,
             stp_filename=stp_filename,
+            stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
             **default_dict

--- a/paramak/parametric_shapes/extruded_straight_shape.py
+++ b/paramak/parametric_shapes/extruded_straight_shape.py
@@ -63,6 +63,7 @@ class ExtrudeStraightShape(Shape):
             color=color,
             material_tag=material_tag,
             stp_filename=stp_filename,
+            stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
             **default_dict

--- a/paramak/parametric_shapes/rotate_circle_shape.py
+++ b/paramak/parametric_shapes/rotate_circle_shape.py
@@ -58,6 +58,7 @@ class RotateCircleShape(Shape):
             color=color,
             material_tag=material_tag,
             stp_filename=stp_filename,
+            stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
             **default_dict

--- a/paramak/parametric_shapes/rotate_mixed_shape.py
+++ b/paramak/parametric_shapes/rotate_mixed_shape.py
@@ -58,6 +58,7 @@ class RotateMixedShape(Shape):
             color=color,
             material_tag=material_tag,
             stp_filename=stp_filename,
+            stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
             **default_dict

--- a/paramak/parametric_shapes/rotate_spline_shape.py
+++ b/paramak/parametric_shapes/rotate_spline_shape.py
@@ -56,6 +56,7 @@ class RotateSplineShape(Shape):
             color=color,
             material_tag=material_tag,
             stp_filename=stp_filename,
+            stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
             **default_dict

--- a/paramak/parametric_shapes/rotate_straight_shape.py
+++ b/paramak/parametric_shapes/rotate_straight_shape.py
@@ -60,6 +60,7 @@ class RotateStraightShape(Shape):
             color=color,
             material_tag=material_tag,
             stp_filename=stp_filename,
+            stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
             **default_dict

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -95,13 +95,15 @@ class Reactor():
                         "Set Reactor already contains a shape or component \
                          with this stp_filename", shape.stp_filename
                     )
+                else:
+                    stp_filenames.append(shape.stp_filename)
+            if shape.stl_filename != None:
                 if shape.stl_filename in stl_filenames:
                     raise ValueError(
                         "Set Reactor already contains a shape or component \
                          with this stl_filename", shape.stl_filename
                     )
                 else:
-                    stp_filenames.append(shape.stp_filename)
                     stl_filenames.append(shape.stl_filename)
 
         self._shapes_and_components = value

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -66,13 +66,10 @@ class test_object_properties(unittest.TestCase):
         assert test_reactor.stp_filenames[1] == 'filename2.stp'
 
     def test_adding_shape_with_duplicate_stp_filename_to_reactor(self):
-        """creates a plasma object and checks elongation is type float"""
-
-        """adds a shape to the reactor and checks that the stp_filename
-        property works as designed"""
+        """creates reactor and addes to shapes with the same stp filename"""
 
         def test_stp_filename_duplication():
-            """checks ValueError is raised when an elongation < 0 is specified"""
+            """checks ValueError is raised when a duplicate filename is added"""
             test_shape = paramak.RotateStraightShape(
                 points=[(0, 0), (0, 20), (20, 20)],
                 stp_filename='filename.stp')
@@ -81,13 +78,15 @@ class test_object_properties(unittest.TestCase):
                 stp_filename='filename.stp')
             test_shape.rotation_angle = 360
             test_shape.create_solid()
-            test_reactor = paramak.Reactor([test_shape, test_shape2])
+            paramak.Reactor([test_shape, test_shape2])
 
         self.assertRaises(ValueError, test_stp_filename_duplication)  
 
+    def test_adding_shape_with_duplicate_stl_filename_to_reactor(self):
+        """creates reactor and addes to shapes with the same stl filename"""
 
         def test_stl_filename_duplication():
-            """checks ValueError is raised when an elongation < 0 is specified"""
+            """checks ValueError is raised when a duplicate filename is added"""
             test_shape = paramak.RotateStraightShape(
                 points=[(0, 0), (0, 20), (20, 20)],
                 stl_filename='filename.stl')
@@ -96,7 +95,7 @@ class test_object_properties(unittest.TestCase):
                 stl_filename='filename.stl')
             test_shape.rotation_angle = 360
             test_shape.create_solid()
-            test_reactor = paramak.Reactor([test_shape, test_shape2])
+            paramak.Reactor([test_shape, test_shape2])
 
         self.assertRaises(ValueError, test_stl_filename_duplication)  
 

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -85,9 +85,23 @@ class test_object_properties(unittest.TestCase):
     def test_adding_shape_with_duplicate_stl_filename_to_reactor(self):
         """creates reactor and addes to shapes with the same stl filename"""
 
-        def test_stl_filename_duplication():
+        def test_stl_filename_duplication_rotate_straight():
             """checks ValueError is raised when a duplicate filename is added"""
             test_shape = paramak.RotateStraightShape(
+                points=[(0, 0), (0, 20), (20, 20)],
+                stl_filename='filename.stl')
+            test_shape2 = paramak.RotateStraightShape(
+                points=[(0, 0), (0, 20), (20, 20)],
+                stl_filename='filename.stl')
+            test_shape.rotation_angle = 360
+            test_shape.create_solid()
+            paramak.Reactor([test_shape, test_shape2])
+
+        self.assertRaises(ValueError, test_stl_filename_duplication_rotate_straight)  
+
+        def test_stl_filename_duplication_rotate_spline():
+            """checks ValueError is raised when a duplicate filename is added"""
+            test_shape = paramak.RotateSplineShape(
                 points=[(0, 0), (0, 20), (20, 20)],
                 stl_filename='filename.stl')
             test_shape2 = paramak.RotateSplineShape(
@@ -97,7 +111,105 @@ class test_object_properties(unittest.TestCase):
             test_shape.create_solid()
             paramak.Reactor([test_shape, test_shape2])
 
-        self.assertRaises(ValueError, test_stl_filename_duplication)  
+        self.assertRaises(ValueError, test_stl_filename_duplication_rotate_spline)  
+
+        def test_stl_filename_duplication_rotate_mixed():
+            """checks ValueError is raised when a duplicate filename is added"""
+            test_shape = paramak.RotateMixedShape(
+                points=[(0, 0, 'straight'), (0, 20, 'straight'), (20, 20, 'straight')],
+                stl_filename='filename.stl')
+            test_shape2 = paramak.RotateMixedShape(
+                points=[(0, 0, 'straight'), (0, 20, 'straight'), (20, 20, 'straight')],
+                stl_filename='filename.stl')
+            test_shape.rotation_angle = 360
+            test_shape.create_solid()
+            paramak.Reactor([test_shape, test_shape2])
+
+        self.assertRaises(ValueError, test_stl_filename_duplication_rotate_mixed)
+
+        def test_stl_filename_duplication_Rotate_Circle():
+            """checks ValueError is raised when a duplicate filename is added"""
+            test_shape = paramak.RotateCircleShape(
+                points=[(20, 20)],
+                radius=10,
+                rotation_angle=180,
+                stl_filename='filename.stl')
+            test_shape2 = paramak.RotateCircleShape(
+                points=[(20, 20)],
+                radius=10,
+                rotation_angle=180,
+                stl_filename='filename.stl')
+            test_shape.rotation_angle = 360
+            test_shape.create_solid()
+            paramak.Reactor([test_shape, test_shape2])
+
+        self.assertRaises(ValueError, test_stl_filename_duplication_Rotate_Circle)  
+
+        def test_stl_filename_duplication_Extrude_straight():
+            """checks ValueError is raised when a duplicate filename is added"""
+            test_shape = paramak.ExtrudeStraightShape(
+                points=[(0, 0), (0, 20), (20, 20)],
+                distance=10,
+                stl_filename='filename.stl')
+            test_shape2 = paramak.ExtrudeStraightShape(
+                points=[(0, 0), (0, 20), (20, 20)],
+                distance=10,
+                stl_filename='filename.stl')
+            test_shape.rotation_angle = 360
+            test_shape.create_solid()
+            paramak.Reactor([test_shape, test_shape2])
+
+        self.assertRaises(ValueError, test_stl_filename_duplication_Extrude_straight)  
+
+        def test_stl_filename_duplication_Extrude_spline():
+            """checks ValueError is raised when a duplicate filename is added"""
+            test_shape = paramak.ExtrudeSplineShape(
+                points=[(0, 0), (0, 20), (20, 20)],
+                distance=10,
+                stl_filename='filename.stl')
+            test_shape2 = paramak.ExtrudeSplineShape(
+                points=[(0, 0), (0, 20), (20, 20)],
+                distance=10,
+                stl_filename='filename.stl')
+            test_shape.rotation_angle = 360
+            test_shape.create_solid()
+            paramak.Reactor([test_shape, test_shape2])
+
+        self.assertRaises(ValueError, test_stl_filename_duplication_Extrude_spline)  
+
+        def test_stl_filename_duplication_Extrude_mixed():
+            """checks ValueError is raised when a duplicate filename is added"""
+            test_shape = paramak.ExtrudeMixedShape(
+                points=[(0, 0, 'straight'), (0, 20, 'straight'), (20, 20, 'straight')],
+                distance=10,
+                stl_filename='filename.stl')
+            test_shape2 = paramak.ExtrudeMixedShape(
+                points=[(0, 0, 'straight'), (0, 20, 'straight'), (20, 20, 'straight')],
+                distance=10,
+                stl_filename='filename.stl')
+            test_shape.rotation_angle = 360
+            test_shape.create_solid()
+            paramak.Reactor([test_shape, test_shape2])
+
+        self.assertRaises(ValueError, test_stl_filename_duplication_Extrude_mixed)  
+
+        def test_stl_filename_duplication_Extrude_Circle():
+            """checks ValueError is raised when a duplicate filename is added"""
+            test_shape = paramak.ExtrudeCircleShape(
+                points=[(20, 20)],
+                radius=10,
+                distance=10,
+                stl_filename='filename.stl')
+            test_shape2 = paramak.ExtrudeCircleShape(
+                points=[(20, 20)],
+                radius=10,
+                distance=10,
+                stl_filename='filename.stl')
+            test_shape.rotation_angle = 360
+            test_shape.create_solid()
+            paramak.Reactor([test_shape, test_shape2])
+
+        self.assertRaises(ValueError, test_stl_filename_duplication_Extrude_Circle)  
 
 
     def test_reactor_creation_with_default_properties(self):


### PR DESCRIPTION
This fixes a few mistakes from an earlier PR.

The addition of another test showed that duplicate stl_filenames were not being detected

This PR adds a simple test that checks for duplicate stl filenames the different parametric shapes are added