### PR TITLE
Update hash value

### DIFF
--- a/paramak/parametric_components/blanket_constant_thickness_arc_h.py
+++ b/paramak/parametric_components/blanket_constant_thickness_arc_h.py
@@ -61,7 +61,6 @@ class BlanketConstantThicknessArcH(RotateMixedShape):
         default_dict = {'points':None,
                         'workplane':"XZ",
                         'solid':None,
-                        'hash_value':None,
                         'intersect':None,
                         'cut':None,
                         'union':None,
@@ -79,6 +78,7 @@ class BlanketConstantThicknessArcH(RotateMixedShape):
             stp_filename=stp_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             rotation_angle=rotation_angle,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/blanket_constant_thickness_arc_v.py
+++ b/paramak/parametric_components/blanket_constant_thickness_arc_v.py
@@ -61,7 +61,6 @@ class BlanketConstantThicknessArcV(RotateMixedShape):
         default_dict = {'points':None,
                         'workplane':"XZ",
                         'solid':None,
-                        'hash_value':None,
                         'intersect':None,
                         'cut':None,
                         'union':None,
@@ -79,6 +78,7 @@ class BlanketConstantThicknessArcV(RotateMixedShape):
             stp_filename=stp_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             rotation_angle=rotation_angle,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -88,7 +88,6 @@ class BlanketFP(RotateMixedShape):
         default_dict = {'points':None,
                         'workplane':"XZ",
                         'solid':None,
-                        'hash_value':None,
                         'intersect':None,
                         'cut':None,
                         'union':None,
@@ -106,6 +105,7 @@ class BlanketFP(RotateMixedShape):
             stp_filename=stp_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             rotation_angle=rotation_angle,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/center_column_circular.py
+++ b/paramak/parametric_components/center_column_circular.py
@@ -37,7 +37,6 @@ class CenterColumnShieldCircular(RotateMixedShape):
         default_dict = {'points':None,
                         'workplane':"XZ",
                         'solid':None,
-                        'hash_value':None,
                         'intersect':None,
                         'cut':None,
                         'union':None,
@@ -55,6 +54,7 @@ class CenterColumnShieldCircular(RotateMixedShape):
             stp_filename=stp_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             rotation_angle=rotation_angle,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/center_column_cylinder.py
+++ b/paramak/parametric_components/center_column_cylinder.py
@@ -32,7 +32,6 @@ class CenterColumnShieldCylinder(RotateStraightShape):
         default_dict = {'points':None,
                         'workplane':"XZ",
                         'solid':None,
-                        'hash_value':None,
                         'intersect':None,
                         'cut':None,
                         'union':None,
@@ -50,6 +49,7 @@ class CenterColumnShieldCylinder(RotateStraightShape):
             stp_filename=stp_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             rotation_angle=rotation_angle,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/center_column_flat_top_circular.py
+++ b/paramak/parametric_components/center_column_flat_top_circular.py
@@ -25,7 +25,6 @@ class CenterColumnShieldFlatTopCircular(RotateMixedShape):
         default_dict = {'points':None,
                         'workplane':"XZ",
                         'solid':None,
-                        'hash_value':None,
                         'intersect':None,
                         'cut':None,
                         'union':None,
@@ -43,6 +42,7 @@ class CenterColumnShieldFlatTopCircular(RotateMixedShape):
             stp_filename=stp_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             rotation_angle=rotation_angle,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/center_column_flat_top_hyperbola.py
+++ b/paramak/parametric_components/center_column_flat_top_hyperbola.py
@@ -39,7 +39,6 @@ class CenterColumnShieldFlatTopHyperbola(RotateMixedShape):
         default_dict = {'points':None,
                         'workplane':"XZ",
                         'solid':None,
-                        'hash_value':None,
                         'intersect':None,
                         'cut':None,
                         'union':None,
@@ -57,6 +56,7 @@ class CenterColumnShieldFlatTopHyperbola(RotateMixedShape):
             stp_filename=stp_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             rotation_angle=rotation_angle,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/center_column_hyperbola.py
+++ b/paramak/parametric_components/center_column_hyperbola.py
@@ -36,7 +36,6 @@ class CenterColumnShieldHyperbola(RotateMixedShape):
         default_dict = {'points':None,
                         'workplane':"XZ",
                         'solid':None,
-                        'hash_value':None,
                         'intersect':None,
                         'cut':None,
                         'union':None,
@@ -54,6 +53,7 @@ class CenterColumnShieldHyperbola(RotateMixedShape):
             stp_filename=stp_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             rotation_angle=rotation_angle,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/center_column_plasma_dependant.py
+++ b/paramak/parametric_components/center_column_plasma_dependant.py
@@ -48,7 +48,6 @@ class CenterColumnShieldPlasmaHyperbola(RotateMixedShape):
         default_dict = {'points':None,
                         'workplane':"XZ",
                         'solid':None,
-                        'hash_value':None,
                         'intersect':None,
                         'cut':None,
                         'union':None,
@@ -66,6 +65,7 @@ class CenterColumnShieldPlasmaHyperbola(RotateMixedShape):
             stp_filename=stp_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             rotation_angle=rotation_angle,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/inner_tf_coils_circular.py
+++ b/paramak/parametric_components/inner_tf_coils_circular.py
@@ -38,7 +38,6 @@ class InnerTfCoilsCircular(ExtrudeMixedShape):
         default_dict = {'points':None,
                         'workplane':"XY",
                         'solid':None,
-                        'hash_value':None,
                         'intersect':None,
                         'cut':None,
                         'union':None,
@@ -56,6 +55,7 @@ class InnerTfCoilsCircular(ExtrudeMixedShape):
             azimuth_placement_angle=azimuth_placement_angle,
             material_tag=material_tag,
             name=name,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/inner_tf_coils_flat.py
+++ b/paramak/parametric_components/inner_tf_coils_flat.py
@@ -38,7 +38,6 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
         default_dict = {'points':None,
                         'workplane':"XY",
                         'solid':None,
-                        'hash_value':None,
                         'intersect':None,
                         'cut':None,
                         'union':None,
@@ -56,6 +55,7 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
             azimuth_placement_angle=azimuth_placement_angle,
             material_tag=material_tag,
             name=name,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/poloidal_field_coil.py
+++ b/paramak/parametric_components/poloidal_field_coil.py
@@ -32,7 +32,6 @@ class PoloidalFieldCoil(RotateStraightShape):
         default_dict = {'points':None,
                         'workplane':"XZ",
                         'solid':None,
-                        'hash_value':None,
                         'intersect':None,
                         'cut':None,
                         'union':None,
@@ -50,6 +49,7 @@ class PoloidalFieldCoil(RotateStraightShape):
             stp_filename=stp_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             rotation_angle=rotation_angle,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/poloidal_field_coil_case.py
+++ b/paramak/parametric_components/poloidal_field_coil_case.py
@@ -36,7 +36,6 @@ class PoloidalFieldCoilCase(RotateStraightShape):
         default_dict = {'points':None,
                         'workplane':"XZ",
                         'solid':None,
-                        'hash_value':None,
                         'intersect':None,
                         'cut':None,
                         'union':None,
@@ -54,6 +53,7 @@ class PoloidalFieldCoilCase(RotateStraightShape):
             stp_filename=stp_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             rotation_angle=rotation_angle,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/poloidal_field_coil_case_fc.py
+++ b/paramak/parametric_components/poloidal_field_coil_case_fc.py
@@ -30,7 +30,6 @@ class PoloidalFieldCoilCaseFC(RotateStraightShape):
         default_dict = {'points':None,
                         'workplane':"XZ",
                         'solid':None,
-                        'hash_value':None,
                         'intersect':None,
                         'cut':None,
                         'union':None,
@@ -48,6 +47,7 @@ class PoloidalFieldCoilCaseFC(RotateStraightShape):
             stp_filename=stp_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             rotation_angle=rotation_angle,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/tokamak_plasma.py
+++ b/paramak/parametric_components/tokamak_plasma.py
@@ -80,7 +80,6 @@ class Plasma(RotateSplineShape):
         default_dict = {'points': None,
                         'workplane': "XZ",
                         'solid': None,
-                        'hash_value': None,
                         'intersect': None,
                         'cut': None,
                         'union': None,
@@ -98,6 +97,7 @@ class Plasma(RotateSplineShape):
             stp_filename=stp_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             rotation_angle=rotation_angle,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/tokamak_plasma_from_points.py
+++ b/paramak/parametric_components/tokamak_plasma_from_points.py
@@ -45,7 +45,6 @@ class PlasmaFromPoints(Plasma):
         default_dict = {'points':None,
                         'workplane':"XZ",
                         'solid':None,
-                        'hash_value':None,
                         'intersect':None,
                         'cut':None,
                         'union':None,
@@ -76,6 +75,7 @@ class PlasmaFromPoints(Plasma):
             color=None,
             rotation_angle=rotation_angle,
             azimuth_placement_angle=azimuth_placement_angle,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/tokamak_plasma_plasmaboundaries.py
+++ b/paramak/parametric_components/tokamak_plasma_plasmaboundaries.py
@@ -64,7 +64,6 @@ class PlasmaBoundaries(Plasma):
         default_dict = {'points': None,
                         'workplane': "XZ",
                         'solid': None,
-                        'hash_value': None,
                         'intersect': None,
                         'cut': None,
                         'tet_mesh':None,
@@ -81,6 +80,7 @@ class PlasmaBoundaries(Plasma):
             stp_filename=stp_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             rotation_angle=rotation_angle,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
+++ b/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
@@ -51,7 +51,6 @@ class ToroidalFieldCoilCoatHanger(ExtrudeStraightShape):
         default_dict = {'points':None,
                         'workplane':"XZ",
                         'solid':None,
-                        'hash_value':None,
                         'intersect':None,
                         'cut':None,
                         'union':None,
@@ -69,6 +68,7 @@ class ToroidalFieldCoilCoatHanger(ExtrudeStraightShape):
             azimuth_placement_angle=azimuth_placement_angle,
             material_tag=material_tag,
             name=name,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_components/toroidal_field_coil_rectangle.py
+++ b/paramak/parametric_components/toroidal_field_coil_rectangle.py
@@ -46,7 +46,6 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
         default_dict = {'points':None,
                         'workplane':"XZ",
                         'solid':None,
-                        'hash_value':None,
                         'intersect':None,
                         'cut':None,
                         'union':None,
@@ -64,6 +63,7 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
             azimuth_placement_angle=azimuth_placement_angle,
             material_tag=material_tag,
             name=name,
+            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_shapes/extruded_circle_shape.py
+++ b/paramak/parametric_shapes/extruded_circle_shape.py
@@ -51,7 +51,6 @@ class ExtrudeCircleShape(Shape):
         union=None,
         material_tag=None,
         name=None,
-        hash_value=None,
         **kwargs
     ):
 
@@ -77,7 +76,7 @@ class ExtrudeCircleShape(Shape):
         self.union = union
         self.radius = radius
         self.distance = distance
-        self.hash_value = hash_value
+        self.hash_value = None
         self.solid = solid
 
     @property
@@ -140,18 +139,12 @@ class ExtrudeCircleShape(Shape):
 
     def get_hash(self):
         hash_object = blake2b()
-        hash_object.update(
-            str(self.points).encode("utf-8")
-            + str(self.distance).encode("utf-8")
-            + str(self.radius).encode("utf-8")
-            + str(self.workplane).encode("utf-8")
-            + str(self.name).encode("utf-8")
-            + str(self.color).encode("utf-8")
-            + str(self.material_tag).encode("utf-8")
-            + str(self.stp_filename).encode("utf-8")
-            + str(self.azimuth_placement_angle).encode("utf-8")
-            + str(self.cut).encode("utf-8")
-        )
+        shape_dict = dict(self.__dict__)
+        # set _solid and _hash_value to None to prevent unnecessary reconstruction
+        shape_dict['_solid'] = None
+        shape_dict['_hash_value'] = None
+
+        hash_object.update(str(list(shape_dict.values())).encode("utf-8"))
         value = hash_object.hexdigest()
         return value
 
@@ -163,10 +156,7 @@ class ExtrudeCircleShape(Shape):
         :rtype: a cadquery solid
         """
 
-        # print('create_solid() has been called')
-
-        # Creates hash value for current solid
-        self.hash_value = self.get_hash()
+        print('create_solid() has been called')
 
         # Creates a cadquery solid from points and revolves
         solid = (
@@ -204,5 +194,8 @@ class ExtrudeCircleShape(Shape):
             solid = union_solid(solid, self.union)
 
         self.solid = solid
+
+        # Calculate hash value for current solid
+        self.hash_value = self.get_hash()
 
         return solid

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -48,7 +48,6 @@ class ExtrudeMixedShape(Shape):
         union=None,
         material_tag=None,
         name=None,
-        hash_value=None,
         **kwargs
     ):
 
@@ -73,7 +72,7 @@ class ExtrudeMixedShape(Shape):
         self.intersect = intersect
         self.union = union
         self.distance = distance
-        self.hash_value = hash_value
+        self.hash_value = None
         self.solid = solid
 
     @property
@@ -128,17 +127,12 @@ class ExtrudeMixedShape(Shape):
 
     def get_hash(self):
         hash_object = blake2b()
-        hash_object.update(
-            str(self.points).encode("utf-8")
-            + str(self.workplane).encode("utf-8")
-            + str(self.name).encode("utf-8")
-            + str(self.color).encode("utf-8")
-            + str(self.material_tag).encode("utf-8")
-            + str(self.stp_filename).encode("utf-8")
-            + str(self.azimuth_placement_angle).encode("utf-8")
-            + str(self.distance).encode("utf-8")
-            + str(self.cut).encode("utf-8")
-        )
+        shape_dict = dict(self.__dict__)
+        # set _solid and _hash_value to None to prevent unnecessary reconstruction
+        shape_dict['_solid'] = None
+        shape_dict['_hash_value'] = None
+
+        hash_object.update(str(list(shape_dict.values())).encode("utf-8"))
         value = hash_object.hexdigest()
         return value
 
@@ -150,10 +144,7 @@ class ExtrudeMixedShape(Shape):
         :rtype: a cadquery solid
         """
 
-        # print('create_solid() has been called')
-
-        # Creates hash value for current solid
-        self.hash_value = self.get_hash()
+        print('create_solid() has been called')
 
         # obtains the first two values of the points list
         XZ_points = [(p[0], p[1]) for p in self.points]
@@ -224,5 +215,8 @@ class ExtrudeMixedShape(Shape):
             solid = union_solid(solid, self.union)
 
         self.solid = solid
+
+        # Calculate hash value for current solid
+        self.hash_value = self.get_hash()
 
         return solid

--- a/paramak/parametric_shapes/extruded_spline_shape.py
+++ b/paramak/parametric_shapes/extruded_spline_shape.py
@@ -46,7 +46,6 @@ class ExtrudeSplineShape(Shape):
         union=None,
         material_tag=None,
         name=None,
-        hash_value=None,
         **kwargs
     ):
 
@@ -71,7 +70,7 @@ class ExtrudeSplineShape(Shape):
         self.intersect = intersect
         self.union = union
         self.distance = distance
-        self.hash_value = hash_value
+        self.hash_value = None
         self.solid = solid
 
     @property
@@ -126,17 +125,12 @@ class ExtrudeSplineShape(Shape):
 
     def get_hash(self):
         hash_object = blake2b()
-        hash_object.update(
-            str(self.points).encode("utf-8")
-            + str(self.workplane).encode("utf-8")
-            + str(self.name).encode("utf-8")
-            + str(self.color).encode("utf-8")
-            + str(self.material_tag).encode("utf-8")
-            + str(self.stp_filename).encode("utf-8")
-            + str(self.azimuth_placement_angle).encode("utf-8")
-            + str(self.distance).encode("utf-8")
-            + str(self.cut).encode("utf-8")
-        )
+        shape_dict = dict(self.__dict__)
+        # set _solid and _hash_value to None to prevent unnecessary reconstruction
+        shape_dict['_solid'] = None
+        shape_dict['_hash_value'] = None
+
+        hash_object.update(str(list(shape_dict.values())).encode("utf-8"))
         value = hash_object.hexdigest()
         return value
 
@@ -148,10 +142,7 @@ class ExtrudeSplineShape(Shape):
         :rtype: a cadquery solid
         """
 
-        # print('create_solid() has been called')
-
-        # Creates hash value for current solid
-        self.hash_value = self.get_hash()
+        print('create_solid() has been called')
 
         # Creates a cadquery solid from points and extrudes
         solid = (
@@ -189,5 +180,8 @@ class ExtrudeSplineShape(Shape):
             solid = union_solid(solid, self.union)
 
         self.solid = solid
+
+        # Calculate hash value for current solid
+        self.hash_value = self.get_hash()
 
         return solid

--- a/paramak/parametric_shapes/extruded_straight_shape.py
+++ b/paramak/parametric_shapes/extruded_straight_shape.py
@@ -46,7 +46,6 @@ class ExtrudeStraightShape(Shape):
         union=None,
         material_tag=None,
         name=None,
-        hash_value=None,
         **kwargs
     ):
 
@@ -71,7 +70,7 @@ class ExtrudeStraightShape(Shape):
         self.intersect = intersect
         self.union = union
         self.distance = distance
-        self.hash_value = hash_value
+        self.hash_value = None
         self.solid = solid
 
     @property
@@ -126,17 +125,12 @@ class ExtrudeStraightShape(Shape):
 
     def get_hash(self):
         hash_object = blake2b()
-        hash_object.update(
-            str(self.points).encode("utf-8")
-            + str(self.workplane).encode("utf-8")
-            + str(self.name).encode("utf-8")
-            + str(self.color).encode("utf-8")
-            + str(self.material_tag).encode("utf-8")
-            + str(self.stp_filename).encode("utf-8")
-            + str(self.azimuth_placement_angle).encode("utf-8")
-            + str(self.distance).encode("utf-8")
-            + str(self.cut).encode("utf-8")
-        )
+        shape_dict = dict(self.__dict__)
+        # set _solid and _hash_value to None to prevent unnecessary reconstruction
+        shape_dict['_solid'] = None
+        shape_dict['_hash_value'] = None
+
+        hash_object.update(str(list(shape_dict.values())).encode("utf-8"))
         value = hash_object.hexdigest()
         return value
 
@@ -148,10 +142,7 @@ class ExtrudeStraightShape(Shape):
            A CadQuery solid: A 3D solid volume
         """
 
-        # print('create_solid() has been called')
-
-        # Creates hash value for current solid
-        self.hash_value = self.get_hash()
+        print('create_solid() has been called')
 
         # Creates a cadquery solid from points and revolves
         solid = (
@@ -189,5 +180,8 @@ class ExtrudeStraightShape(Shape):
             solid = union_solid(solid, self.union)
 
         self.solid = solid
+
+        # Calculate hash value for current solid
+        self.hash_value = self.get_hash()
 
         return solid

--- a/paramak/parametric_shapes/rotate_circle_shape.py
+++ b/paramak/parametric_shapes/rotate_circle_shape.py
@@ -41,7 +41,6 @@ class RotateCircleShape(Shape):
         union=None,
         material_tag=None,
         name=None,
-        hash_value=None,
         **kwargs
     ):
 
@@ -67,7 +66,7 @@ class RotateCircleShape(Shape):
         self.union = union
         self.radius = radius
         self.rotation_angle = rotation_angle
-        self.hash_value = hash_value
+        self.hash_value = None
         self.solid = solid
 
     @property
@@ -131,18 +130,12 @@ class RotateCircleShape(Shape):
 
     def get_hash(self):
         hash_object = blake2b()
-        hash_object.update(
-            str(self.points).encode("utf-8")
-            + str(self.radius).encode("utf-8")
-            + str(self.workplane).encode("utf-8")
-            + str(self.name).encode("utf-8")
-            + str(self.color).encode("utf-8")
-            + str(self.material_tag).encode("utf-8")
-            + str(self.stp_filename).encode("utf-8")
-            + str(self.azimuth_placement_angle).encode("utf-8")
-            + str(self.rotation_angle).encode("utf-8")
-            + str(self.cut).encode("utf-8")
-        )
+        shape_dict = dict(self.__dict__)
+        # set _solid and _hash_value to None to prevent unnecessary reconstruction
+        shape_dict['_solid'] = None
+        shape_dict['_hash_value'] = None
+
+        hash_object.update(str(list(shape_dict.values())).encode("utf-8"))
         value = hash_object.hexdigest()
         return value
 
@@ -154,10 +147,7 @@ class RotateCircleShape(Shape):
               A CadQuery solid: A 3D solid volume
         """
 
-        # print('create_solid() has been called')
-
-        # Creates hash value for current solid
-        self.hash_value = self.get_hash()
+        print('create_solid() has been called')
 
         solid = (
             cq.Workplane(self.workplane)
@@ -194,5 +184,8 @@ class RotateCircleShape(Shape):
             solid = union_solid(solid, self.union)
 
         self.solid = solid
+
+        # Calculate hash value for current solid
+        self.hash_value = self.get_hash()
 
         return solid

--- a/paramak/parametric_shapes/rotate_mixed_shape.py
+++ b/paramak/parametric_shapes/rotate_mixed_shape.py
@@ -41,7 +41,6 @@ class RotateMixedShape(Shape):
         cut=None,
         intersect=None,
         union=None,
-        hash_value=None,
         **kwargs
     ):
 
@@ -66,7 +65,7 @@ class RotateMixedShape(Shape):
         self.intersect = intersect
         self.union = union
         self.rotation_angle = rotation_angle
-        self.hash_value = hash_value
+        self.hash_value = None
         self.solid = solid
 
     @property
@@ -121,17 +120,12 @@ class RotateMixedShape(Shape):
 
     def get_hash(self):
         hash_object = blake2b()
-        hash_object.update(
-            str(self.points).encode("utf-8")
-            + str(self.workplane).encode("utf-8")
-            + str(self.name).encode("utf-8")
-            + str(self.color).encode("utf-8")
-            + str(self.material_tag).encode("utf-8")
-            + str(self.stp_filename).encode("utf-8")
-            + str(self.azimuth_placement_angle).encode("utf-8")
-            + str(self.rotation_angle).encode("utf-8")
-            + str(self.cut).encode("utf-8")
-        )
+        shape_dict = dict(self.__dict__)
+        # set _solid and _hash_value to None to prevent unnecessary reconstruction
+        shape_dict['_solid'] = None
+        shape_dict['_hash_value'] = None
+
+        hash_object.update(str(list(shape_dict.values())).encode("utf-8"))
         value = hash_object.hexdigest()
         return value
 
@@ -143,10 +137,7 @@ class RotateMixedShape(Shape):
               A CadQuery solid: A 3D solid volume
         """
 
-        # print('create_solid() has been called')
-
-        # Creates hash value for current solid
-        self.hash_value = self.get_hash()
+        print('create_solid() has been called')
 
         # obtains the first two values of the points list
         XZ_points = [(p[0], p[1]) for p in self.points]
@@ -215,5 +206,8 @@ class RotateMixedShape(Shape):
             solid = union_solid(solid, self.union)
 
         self.solid = solid
+
+        # Calculate hash value for current solid
+        self.hash_value = self.get_hash()
 
         return solid

--- a/paramak/parametric_shapes/rotate_spline_shape.py
+++ b/paramak/parametric_shapes/rotate_spline_shape.py
@@ -39,7 +39,6 @@ class RotateSplineShape(Shape):
         cut=None,
         intersect=None,
         union=None,
-        hash_value=None,
         **kwargs
     ):
 
@@ -64,7 +63,7 @@ class RotateSplineShape(Shape):
         self.intersect = intersect
         self.union = union
         self.rotation_angle = rotation_angle
-        self.hash_value = hash_value
+        self.hash_value = None
         self.solid = solid
 
     @property
@@ -119,18 +118,12 @@ class RotateSplineShape(Shape):
 
     def get_hash(self):
         hash_object = blake2b()
-        hash_object.update(
-            str(self.points).encode("utf-8")
-            + str(self.workplane).encode("utf-8")
-            + str(self.name).encode("utf-8")
-            + str(self.color).encode("utf-8")
-            + str(self.material_tag).encode("utf-8")
-            + str(self.stp_filename).encode("utf-8")
-            + str(self.azimuth_placement_angle).encode("utf-8")
-            + str(self.rotation_angle).encode("utf-8")
-            + str(self.cut).encode("utf-8")
-            + str(self.intersect).encode("utf-8")
-        )
+        shape_dict = dict(self.__dict__)
+        # set _solid and _hash_value to None to prevent unnecessary reconstruction
+        shape_dict['_solid'] = None
+        shape_dict['_hash_value'] = None
+
+        hash_object.update(str(list(shape_dict.values())).encode("utf-8"))
         value = hash_object.hexdigest()
         return value
 
@@ -142,10 +135,7 @@ class RotateSplineShape(Shape):
               A CadQuery solid: A 3D solid volume
         """
 
-        # print('create_solid() has been called')
-
-        # Creates hash value for current solid
-        self.hash_value = self.get_hash()
+        print('create_solid() has been called')
 
         # Creates a cadquery solid from points and revolves
         solid = (
@@ -183,5 +173,8 @@ class RotateSplineShape(Shape):
             solid = union_solid(solid, self.union)
 
         self.solid = solid
+
+        # Calculate hash value for current solid
+        self.hash_value = self.get_hash()
 
         return solid

--- a/paramak/parametric_shapes/rotate_straight_shape.py
+++ b/paramak/parametric_shapes/rotate_straight_shape.py
@@ -43,7 +43,6 @@ class RotateStraightShape(Shape):
         cut=None,
         intersect=None,
         union=None,
-        hash_value=None,
         **kwargs
     ):
 
@@ -68,7 +67,7 @@ class RotateStraightShape(Shape):
         self.intersect = intersect
         self.union = union
         self.rotation_angle = rotation_angle
-        self.hash_value = hash_value
+        self.hash_value = None
         self.solid = solid
 
     @property
@@ -123,18 +122,12 @@ class RotateStraightShape(Shape):
 
     def get_hash(self):
         hash_object = blake2b()
-        hash_object.update(
-            str(self.points).encode("utf-8")
-            + str(self.workplane).encode("utf-8")
-            + str(self.name).encode("utf-8")
-            + str(self.color).encode("utf-8")
-            + str(self.material_tag).encode("utf-8")
-            + str(self.stp_filename).encode("utf-8")
-            + str(self.azimuth_placement_angle).encode("utf-8")
-            + str(self.rotation_angle).encode("utf-8")
-            + str(self.cut).encode("utf-8")
-            + str(self.intersect).encode("utf-8")
-        )
+        shape_dict = dict(self.__dict__)
+        # set _solid and _hash_value to None to prevent unnecessary reconstruction
+        shape_dict['_solid'] = None
+        shape_dict['_hash_value'] = None
+
+        hash_object.update(str(list(shape_dict.values())).encode("utf-8"))
         value = hash_object.hexdigest()
         return value
 
@@ -146,10 +139,7 @@ class RotateStraightShape(Shape):
               A CadQuery solid: A 3D solid volume
         """
 
-        # print('create_solid() has been called')
-
-        # Creates hash value for current solid
-        self.hash_value = self.get_hash()
+        print('create_solid() has been called')
 
         # Creates a cadquery solid from points and revolves
         solid = (
@@ -187,5 +177,8 @@ class RotateStraightShape(Shape):
             solid = union_solid(solid, self.union)
 
         self.solid = solid
+
+        # Calculate hash value for current solid
+        self.hash_value = self.get_hash()
 
         return solid


### PR DESCRIPTION
PR to update hash_value calculation to use automatically identified class parameters. hash_value parameter has also been removed from the default_dict to prevent specification by a user upon construction.
Resolves #171 