### PR TITLE
Adding body of the Reactor.export_h5m method

### DIFF
--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -14,10 +14,6 @@ import plotly.graph_objects as go
 import pyrender
 from paramak.shape import Shape
 
-try:
-    from pymoab import core, types
-except:
-    print('PyMoab not found, Reactor.export_h5m method not available')
 
 class Reactor():
 
@@ -286,6 +282,11 @@ class Reactor():
         Returns:
             filename: output h5m filename
         """
+
+        try:
+            from pymoab import core, types
+        except ImportError as err:
+            raise err('PyMoab not found, Reactor.export_h5m method not available')
 
         Pfilename = Path(filename)
 

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -297,6 +297,25 @@ class Reactor():
         self.export_stl(tolerance=tolerance)
         material_dict = self.neutronics_description()
 
+        # create pymoab instance
+        mb = core.Core()
+
+        tags = dict()
+
+        SENSE_TAG_NAME = "GEOM_SENSE_2"
+        SENSE_TAG_SIZE = 2
+        tags['surf_sense'] = mb.tag_get_handle(SENSE_TAG_NAME, SENSE_TAG_SIZE, types.MB_TYPE_HANDLE, types.MB_TAG_SPARSE, create_if_missing=True)
+
+        tags['category'] = mb.tag_get_handle(types.CATEGORY_TAG_NAME, types.CATEGORY_TAG_SIZE, types.MB_TYPE_OPAQUE, types.MB_TAG_SPARSE, create_if_missing=True)
+        tags['name'] = mb.tag_get_handle(types.NAME_TAG_NAME, types.NAME_TAG_SIZE, types.MB_TYPE_OPAQUE, types.MB_TAG_SPARSE, create_if_missing=True)
+        tags['geom_dimension'] = mb.tag_get_handle(types.GEOM_DIMENSION_TAG_NAME, 1, types.MB_TYPE_INTEGER, types.MB_TAG_DENSE, create_if_missing=True)
+
+        # Global ID is a default tag, just need the name to retrieve
+        tags['global_id']= mb.tag_get_handle(types.GLOBAL_ID_TAG_NAME)
+
+        surface_id = 1
+        volume_id = 1
+
         for item in material_dict:
 
             stl_filename = item['stl_filename']

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -271,7 +271,7 @@ class Reactor():
         return filenames
 
     def export_h5m(self, filename='dagmc.h5m', skip_graveyard=False, tolerance=0.001):
-        """Converts stl files into DAGMC compatible h5m file using PyMoab.
+        """Converts stl files into DAGMC compatible h5m file using PyMOAB.
         The DAGMC file produced has not been imprinted and merged unlike the other supported
         method which uses Trelis to produce an imprinted and merged DAGMC geometry
         If the provided filename doesn't end with .h5m it will be added
@@ -297,7 +297,7 @@ class Reactor():
         self.export_stl(tolerance=tolerance)
         material_dict = self.neutronics_description
 
-        for item in manifest:
+        for item in material_dict:
 
             stl_filename = item['stl_filename']
 
@@ -355,7 +355,6 @@ class Reactor():
         mb.write_file(filename)
 
         return filename
-
 
     def export_physical_groups(self, output_folder=""):
         """Exports several JSON files containing a look up table

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -295,7 +295,7 @@ class Reactor():
         Pfilename.parents[0].mkdir(parents=True, exist_ok=True)
 
         self.export_stl(tolerance=tolerance)
-        material_dict = self.neutronics_description
+        material_dict = self.neutronics_description()
 
         for item in material_dict:
 


### PR DESCRIPTION
Added in the body of the gist. I took the liberty of moving the attempted PyMOAB import into that method. With the import at the top, the method would return the error "core not found" which is a little esoteric. Now the method will raise an `ImportError` if called when PyMOAB is not installed. 

As I mentioned on slack, PyMOAB isn't in the CI so I haven't been able to verify the test you've added. I'd be happy to add it into the CI image before merging to make sure it works though. Just let me know!