### PR TITLE
Update physical groups

### DIFF
--- a/paramak/parametric_components/blanket_constant_thickness_arc_h.py
+++ b/paramak/parametric_components/blanket_constant_thickness_arc_h.py
@@ -66,6 +66,7 @@ class BlanketConstantThicknessArcH(RotateMixedShape):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/blanket_constant_thickness_arc_v.py
+++ b/paramak/parametric_components/blanket_constant_thickness_arc_v.py
@@ -66,6 +66,7 @@ class BlanketConstantThicknessArcV(RotateMixedShape):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -93,6 +93,7 @@ class BlanketFP(RotateMixedShape):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/center_column_circular.py
+++ b/paramak/parametric_components/center_column_circular.py
@@ -42,6 +42,7 @@ class CenterColumnShieldCircular(RotateMixedShape):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/center_column_cylinder.py
+++ b/paramak/parametric_components/center_column_cylinder.py
@@ -37,6 +37,7 @@ class CenterColumnShieldCylinder(RotateStraightShape):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/center_column_flat_top_circular.py
+++ b/paramak/parametric_components/center_column_flat_top_circular.py
@@ -30,6 +30,7 @@ class CenterColumnShieldFlatTopCircular(RotateMixedShape):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
         
         for arg in kwargs:

--- a/paramak/parametric_components/center_column_flat_top_hyperbola.py
+++ b/paramak/parametric_components/center_column_flat_top_hyperbola.py
@@ -44,6 +44,7 @@ class CenterColumnShieldFlatTopHyperbola(RotateMixedShape):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/center_column_hyperbola.py
+++ b/paramak/parametric_components/center_column_hyperbola.py
@@ -41,6 +41,7 @@ class CenterColumnShieldHyperbola(RotateMixedShape):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/center_column_plasma_dependant.py
+++ b/paramak/parametric_components/center_column_plasma_dependant.py
@@ -53,6 +53,7 @@ class CenterColumnShieldPlasmaHyperbola(RotateMixedShape):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/divertor_ITER.py
+++ b/paramak/parametric_components/divertor_ITER.py
@@ -94,6 +94,7 @@ class ITERtypeDivertor(RotateMixedShape):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/inner_tf_coils_circular.py
+++ b/paramak/parametric_components/inner_tf_coils_circular.py
@@ -43,6 +43,7 @@ class InnerTfCoilsCircular(ExtrudeMixedShape):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/inner_tf_coils_flat.py
+++ b/paramak/parametric_components/inner_tf_coils_flat.py
@@ -43,6 +43,7 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/poloidal_field_coil.py
+++ b/paramak/parametric_components/poloidal_field_coil.py
@@ -37,6 +37,7 @@ class PoloidalFieldCoil(RotateStraightShape):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
         
         for arg in kwargs:

--- a/paramak/parametric_components/poloidal_field_coil_case.py
+++ b/paramak/parametric_components/poloidal_field_coil_case.py
@@ -41,6 +41,7 @@ class PoloidalFieldCoilCase(RotateStraightShape):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/poloidal_field_coil_case_fc.py
+++ b/paramak/parametric_components/poloidal_field_coil_case_fc.py
@@ -35,6 +35,7 @@ class PoloidalFieldCoilCaseFC(RotateStraightShape):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/tokamak_plasma.py
+++ b/paramak/parametric_components/tokamak_plasma.py
@@ -85,6 +85,7 @@ class Plasma(RotateSplineShape):
                         'cut': None,
                         'union': None,
                         'tet_mesh':None,
+                        'physical_groups':None,
                         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/tokamak_plasma_from_points.py
+++ b/paramak/parametric_components/tokamak_plasma_from_points.py
@@ -49,6 +49,7 @@ class PlasmaFromPoints(Plasma):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/tokamak_plasma_plasmaboundaries.py
+++ b/paramak/parametric_components/tokamak_plasma_plasmaboundaries.py
@@ -67,6 +67,7 @@ class PlasmaBoundaries(Plasma):
                         'intersect': None,
                         'cut': None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
+++ b/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
@@ -56,6 +56,7 @@ class ToroidalFieldCoilCoatHanger(ExtrudeStraightShape):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
 
         for arg in kwargs:

--- a/paramak/parametric_components/toroidal_field_coil_rectangle.py
+++ b/paramak/parametric_components/toroidal_field_coil_rectangle.py
@@ -51,6 +51,7 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
                         'cut':None,
                         'union':None,
                         'tet_mesh':None,
+                        'physical_groups':None,
         }
 
         for arg in kwargs:

--- a/paramak/parametric_shapes/extruded_circle_shape.py
+++ b/paramak/parametric_shapes/extruded_circle_shape.py
@@ -55,7 +55,8 @@ class ExtrudeCircleShape(Shape):
         **kwargs
     ):
 
-        default_dict = {'tet_mesh':None}
+        default_dict = {'tet_mesh':None,
+                        'physical_groups':None}
 
         for arg in kwargs:
             if arg in default_dict:

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -52,7 +52,8 @@ class ExtrudeMixedShape(Shape):
         **kwargs
     ):
 
-        default_dict = {'tet_mesh':None}
+        default_dict = {'tet_mesh':None,
+                        'physical_groups':None}
 
         for arg in kwargs:
             if arg in default_dict:

--- a/paramak/parametric_shapes/extruded_spline_shape.py
+++ b/paramak/parametric_shapes/extruded_spline_shape.py
@@ -50,7 +50,8 @@ class ExtrudeSplineShape(Shape):
         **kwargs
     ):
 
-        default_dict = {'tet_mesh':None}
+        default_dict = {'tet_mesh':None,
+                        'physical_groups':None}
 
         for arg in kwargs:
             if arg in default_dict:

--- a/paramak/parametric_shapes/extruded_straight_shape.py
+++ b/paramak/parametric_shapes/extruded_straight_shape.py
@@ -50,7 +50,8 @@ class ExtrudeStraightShape(Shape):
         **kwargs
     ):
 
-        default_dict = {'tet_mesh':None}
+        default_dict = {'tet_mesh':None,
+                        'physical_gropus':None}
 
         for arg in kwargs:
             if arg in default_dict:

--- a/paramak/parametric_shapes/extruded_straight_shape.py
+++ b/paramak/parametric_shapes/extruded_straight_shape.py
@@ -51,7 +51,7 @@ class ExtrudeStraightShape(Shape):
     ):
 
         default_dict = {'tet_mesh':None,
-                        'physical_gropus':None}
+                        'physical_groups':None}
 
         for arg in kwargs:
             if arg in default_dict:

--- a/paramak/parametric_shapes/rotate_circle_shape.py
+++ b/paramak/parametric_shapes/rotate_circle_shape.py
@@ -45,7 +45,8 @@ class RotateCircleShape(Shape):
         **kwargs
     ):
 
-        default_dict = {'tet_mesh':None}
+        default_dict = {'tet_mesh':None,
+                        'physical_groups':None}
 
         for arg in kwargs:
             if arg in default_dict:

--- a/paramak/parametric_shapes/rotate_mixed_shape.py
+++ b/paramak/parametric_shapes/rotate_mixed_shape.py
@@ -45,7 +45,8 @@ class RotateMixedShape(Shape):
         **kwargs
     ):
 
-        default_dict = {'tet_mesh':None}
+        default_dict = {'tet_mesh':None,
+                        'physical_groups':None}
 
         for arg in kwargs:
             if arg in default_dict:

--- a/paramak/parametric_shapes/rotate_spline_shape.py
+++ b/paramak/parametric_shapes/rotate_spline_shape.py
@@ -43,7 +43,8 @@ class RotateSplineShape(Shape):
         **kwargs
     ):
 
-        default_dict = {'tet_mesh':None}
+        default_dict = {'tet_mesh':None,
+                        'physical_groups':None}
 
         for arg in kwargs:
             if arg in default_dict:

--- a/paramak/parametric_shapes/rotate_straight_shape.py
+++ b/paramak/parametric_shapes/rotate_straight_shape.py
@@ -47,7 +47,8 @@ class RotateStraightShape(Shape):
         **kwargs
     ):
 
-        default_dict = {'tet_mesh':None}
+        default_dict = {'tet_mesh':None,
+                        'physical_groups':None}
 
         for arg in kwargs:
             if arg in default_dict:

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -54,6 +54,7 @@ class Shape:
         azimuth_placement_angle=0,
         workplane="XZ",
         tet_mesh=None,
+        physical_groups=None,
     ):
 
         self.points = points
@@ -69,13 +70,14 @@ class Shape:
         self.material_tag = material_tag
         self.tet_mesh = tet_mesh
                 
+        self.physical_groups = physical_groups
 
         # properties calculated internally by the class
         self.solid = None
         self.render_mesh = None
         # self.volume = None
 
-        self.physical_groups = None
+        
 
     @property
     def workplane(self):


### PR DESCRIPTION
PR which allows physical_groups to be specified upon construction, but adds it to the default_dict so that it is hidden from users.
Resolves #172 