### PR TITLE
added newline character

### DIFF
--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -14,7 +14,7 @@ jobs:
         id: autopep8
         uses: peter-evans/autopep8@v1
         with:
-          args: --exit-code --recursive --in-place --aggressive --aggressive .
+          args: --exclude="make_faceteted_neutronics_model.py" --exit-code --recursive --in-place --aggressive --aggressive .
       - name: Commit autopep8 changes
         if: steps.autopep8.outputs.exit-code == 2
         run: |

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -14,7 +14,7 @@ jobs:
         id: autopep8
         uses: peter-evans/autopep8@v1
         with:
-          args: --exclude="make_faceteted_neutronics_model.py" --exit-code --recursive --in-place --aggressive --aggressive .
+          args: --exit-code --recursive --in-place --aggressive --aggressive .
       - name: Commit autopep8 changes
         if: steps.autopep8.outputs.exit-code == 2
         run: |

--- a/examples/example_neutronics_simulations/make_faceteted_neutronics_model.py
+++ b/examples/example_neutronics_simulations/make_faceteted_neutronics_model.py
@@ -100,7 +100,7 @@ with open("manifest.json") as f:
     geometry_details = byteify(json.load(f))
 
 
-geometry_details = find_number_of_volumes_in_each_step_file(
+geometry_details = find_number_of_volumes_in_each_step_file( \
     geometry_details, os.path.abspath("."))
 
 tag_geometry_with_mats(geometry_details)

--- a/examples/example_neutronics_simulations/make_faceteted_neutronics_model.py
+++ b/examples/example_neutronics_simulations/make_faceteted_neutronics_model.py
@@ -100,7 +100,7 @@ with open("manifest.json") as f:
     geometry_details = byteify(json.load(f))
 
 
-geometry_details = find_number_of_volumes_in_each_step_file( \
+geometry_details = find_number_of_volumes_in_each_step_file(
     geometry_details, os.path.abspath("."))
 
 tag_geometry_with_mats(geometry_details)

--- a/examples/example_neutronics_simulations/make_faceteted_neutronics_model.py
+++ b/examples/example_neutronics_simulations/make_faceteted_neutronics_model.py
@@ -100,9 +100,8 @@ with open("manifest.json") as f:
     geometry_details = byteify(json.load(f))
 
 
-geometry_details = find_number_of_volumes_in_each_step_file(
-    geometry_details, str(os.path.abspath("."))
-)
+geometry_details = find_number_of_volumes_in_each_step_file( \
+    geometry_details, os.path.abspath("."))
 
 tag_geometry_with_mats(geometry_details)
 


### PR DESCRIPTION
This is an alternative solution to #187 for fixing the trelis make_faceteted_neutronics_model.py script. This does not require a rollback of the autopep8 formatting. Resolves #186 