### PR TITLE
added trelis file to be ignored

### DIFF
--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -14,7 +14,7 @@ jobs:
         id: autopep8
         uses: peter-evans/autopep8@v1
         with:
-          args: --exit-code --recursive --in-place --aggressive --aggressive .
+          args: --exit-code --recursive --in-place --exclude="examples/example_neutronics_simulations/make_faceteted_neutronics_model.py" --aggressive --aggressive .
       - name: Commit autopep8 changes
         if: steps.autopep8.outputs.exit-code == 2
         run: |


### PR DESCRIPTION
PR to add make_faceteted_neutronics_model.py to the list of files to be ignored by autopep8. This resolves #186 