### PR TITLE
fixed trelis script exclusion filepath

### DIFF
--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -14,7 +14,7 @@ jobs:
         id: autopep8
         uses: peter-evans/autopep8@v1
         with:
-          args: --exit-code --recursive --in-place --exclude="examples/example_neutronics_simulations/make_faceteted_neutronics_model.py" --aggressive --aggressive .
+          args: --exclude="make_faceteted_neutronics_model.py" --exit-code --recursive --in-place --aggressive --aggressive .
       - name: Commit autopep8 changes
         if: steps.autopep8.outputs.exit-code == 2
         run: |


### PR DESCRIPTION
PR #189 used the full filepath of the trelis script from the base directory of the paramak. Through local testing it was found that only the filename was required