### PR TITLE
Add single null design

### DIFF
--- a/examples/example_parametric_reactors/make_all_parametric_reactors.py
+++ b/examples/example_parametric_reactors/make_all_parametric_reactors.py
@@ -49,7 +49,7 @@ def main():
         pf_coil_vertical_thicknesses=[50, 50, 50, 50],
         pf_coil_to_rear_blanket_radial_gap=50,
         pf_coil_to_tf_coil_radial_gap=50,
-        tf_coil_radial_thickness=100,
+        outboard_tf_coil_radial_thickness=100,
         tf_coil_poloidal_thickness=50,
     )
     my_reactor.name = "BallReactor_with_pf_tf_coils"
@@ -101,6 +101,75 @@ def main():
     )
 
     my_reactor.name = "SubmersionTokamak_with_pf_tf_coils"
+    all_reactors.append(my_reactor)
+
+    my_reactor = paramak.SingleNullReactor(
+        inner_bore_radial_thickness=50,
+        inboard_tf_leg_radial_thickness=50,
+        center_column_shield_radial_thickness=50,
+        divertor_radial_thickness=100,
+        inner_plasma_gap_radial_thickness=50,
+        plasma_radial_thickness=200,
+        outer_plasma_gap_radial_thickness=50,
+        firstwall_radial_thickness=50,
+        blanket_radial_thickness=100,
+        blanket_rear_wall_radial_thickness=50,
+        elongation=2,
+        triangularity=0.55,
+        number_of_tf_coils=16,
+        rotation_angle=180,
+        divertor_position="upper"
+    )
+
+    my_reactor.name = "SingleNullReactor_upper_divertor"
+    all_reactors.append(my_reactor)
+
+    my_reactor = paramak.SingleNullReactor(
+        inner_bore_radial_thickness=50,
+        inboard_tf_leg_radial_thickness=50,
+        center_column_shield_radial_thickness=50,
+        divertor_radial_thickness=100,
+        inner_plasma_gap_radial_thickness=50,
+        plasma_radial_thickness=200,
+        outer_plasma_gap_radial_thickness=50,
+        firstwall_radial_thickness=50,
+        blanket_radial_thickness=100,
+        blanket_rear_wall_radial_thickness=50,
+        elongation=2,
+        triangularity=0.55,
+        number_of_tf_coils=16,
+        rotation_angle=180,
+        divertor_position="lower"
+    )
+
+    my_reactor.name = "SingleNullReactor_lower_divertor"
+    all_reactors.append(my_reactor)
+
+    my_reactor = paramak.SingleNullReactor(
+        inner_bore_radial_thickness=50,
+        inboard_tf_leg_radial_thickness=50,
+        center_column_shield_radial_thickness=50,
+        divertor_radial_thickness=100,
+        inner_plasma_gap_radial_thickness=50,
+        plasma_radial_thickness=200,
+        outer_plasma_gap_radial_thickness=50,
+        firstwall_radial_thickness=50,
+        blanket_radial_thickness=100,
+        blanket_rear_wall_radial_thickness=50,
+        elongation=2,
+        triangularity=0.55,
+        number_of_tf_coils=16,
+        rotation_angle=180,
+        divertor_position="lower",
+        outboard_tf_coil_radial_thickness=50,
+        pf_coil_to_rear_blanket_radial_gap=50,
+        tf_coil_poloidal_thickness=70,
+        pf_coil_vertical_thicknesses=[50, 50, 50, 50, 50],
+        pf_coil_radial_thicknesses=[40, 40, 40, 40, 40],
+        pf_coil_to_tf_coil_radial_gap=50,
+    )
+
+    my_reactor.name = "SingleNullReactor_with_pf_tf_coils"
     all_reactors.append(my_reactor)
 
     return all_reactors

--- a/examples/example_parametric_reactors/make_parametric_single_null_reactor.py
+++ b/examples/example_parametric_reactors/make_parametric_single_null_reactor.py
@@ -1,0 +1,40 @@
+"""
+This example creates a single null reactor using the SingleNullReactor shape
+"""
+
+import paramak
+
+
+def main():
+
+    my_reactor = paramak.SingleNullReactor(
+        inner_bore_radial_thickness=50,
+        inboard_tf_leg_radial_thickness=50,
+        center_column_shield_radial_thickness=50,
+        divertor_radial_thickness=100,
+        inner_plasma_gap_radial_thickness=50,
+        plasma_radial_thickness=200,
+        outer_plasma_gap_radial_thickness=50,
+        firstwall_radial_thickness=50,
+        blanket_radial_thickness=100,
+        blanket_rear_wall_radial_thickness=50,
+        elongation=2,
+        triangularity=0.55,
+        number_of_tf_coils=16,
+        rotation_angle=180,
+        divertor_position="lower",
+        outboard_tf_coil_radial_thickness=50,
+        pf_coil_to_rear_blanket_radial_gap=50,
+        tf_coil_poloidal_thickness=70,
+        pf_coil_vertical_thicknesses=[50, 50, 50, 50, 50],
+        pf_coil_radial_thicknesses=[40, 40, 40, 40, 40],
+        pf_coil_to_tf_coil_radial_gap=50,
+    )
+
+    my_reactor.export_stp()
+
+    my_reactor.export_neutronics_description()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/example_parametric_reactors/make_parametric_single_null_reactor.py
+++ b/examples/example_parametric_reactors/make_parametric_single_null_reactor.py
@@ -23,12 +23,6 @@ def main():
         number_of_tf_coils=16,
         rotation_angle=180,
         divertor_position="lower",
-        outboard_tf_coil_radial_thickness=50,
-        pf_coil_to_rear_blanket_radial_gap=50,
-        tf_coil_poloidal_thickness=70,
-        pf_coil_vertical_thicknesses=[50, 50, 50, 50, 50],
-        pf_coil_radial_thicknesses=[40, 40, 40, 40, 40],
-        pf_coil_to_tf_coil_radial_gap=50,
     )
 
     my_reactor.export_stp()

--- a/paramak/__init__.py
+++ b/paramak/__init__.py
@@ -54,6 +54,7 @@ from .parametric_components.inner_tf_coils_flat import InnerTfCoilsFlat
 
 from .parametric_reactors.ball_reactor import BallReactor
 from .parametric_reactors.submersion_reactor import SubmersionTokamak
+from .parametric_reactors.single_null_reactor import SingleNullReactor
 
 from .parametric_components.toroidal_field_coil_coat_hanger import (
     ToroidalFieldCoilCoatHanger,

--- a/paramak/parametric_reactors/single_null_reactor.py
+++ b/paramak/parametric_reactors/single_null_reactor.py
@@ -1,0 +1,520 @@
+import math
+import operator
+
+import cadquery as cq
+
+import paramak
+
+
+class SingleNullReactor(paramak.Reactor):
+    """Insert description
+
+    :param inner_bore_radial_thickness: the radial thickness of
+     the inner bore (cm)
+    :type inner_bore_radial_thickness: float
+    :inboard_tf_leg_radial_thickness: the radial thickness of the
+     inner leg of the toroidal field coils (cm)
+    :type inboard_tf_leg_radial_thickness: float
+    :center_column_shield_radial_thickness: the radial thickness
+     of the center column shield (cm)
+    :type center_column_shield_radial_thickness: float
+    :divertor_radial_thickness: the radial thickness of the divertor
+     (cm), this fills the gap between the center column shield and blanket
+    :type divertor_radial_thickness: float
+    :inner_plasma_gap_radial_thickness: the radial thickness of the
+     inboard gap between the plasma and the center column shield (cm)
+    :type inner_plasma_gap_radial_thickness: float
+    :plasma_radial_thickness: the radial thickness of the plasma (cm),
+     this is double the minor radius
+    :type plasma_radial_thickness: float
+    :outer_plasma_gap_radial_thickness: the radial thickness of the
+     outboard gap between the plasma and the firstwall (cm)
+    :type outer_plasma_gap_radial_thickness: float
+    :firstwall_radial_thickness: the radial thickness of the first wall (cm)
+    :type firstwall_radial_thickness: float
+    :blanket_radial_thickness: the radial thickness of the blanket (cm)
+    :type blanket_radial_thickness: float
+    :blanket_rear_wall_radial_thickness: the radial thickness of the rear wall
+     of the blanket (cm)
+    :type blanket_rear_wall_radial_thickness: float
+    :elongation: the elongation of the plasma
+    :type elongation: float
+    :triangularity: the triangularity of the plasma
+    :type triangularity: float
+    :number_of_tf_coils: the number of tf coils
+    :type number_of_tf_coils: int
+    :pf_coil_to_rear_blanket_radial_gap: the radial distance between the rear
+     blanket and the closest poloidal field coil (optional)
+    :type pf_coil_to_rear_blanket_radial_gap: float
+    :pf_coil_radial_thicknesses: the radial thickness of each poloidal field
+     coil (optional)
+    :type pf_coil_radial_thicknesses: list of floats
+    :pf_coil_vertical_thicknesses: the vertical thickness of each poloidal
+     field coil (optional)
+    :type pf_coil_vertical_thicknesses: list of floats
+    :pf_coil_to_tf_coil_radial_gap: the radial distance between the rear of
+     the poloidal field coil and the toroidal field coil (optional)
+    :type pf_coil_to_tf_coil_radial_gap: float
+    :outboard_tf_coil_radial_thickness: the radial thickness of the toroidal field
+     coil (optional)
+    :type outboard_tf_coil_radial_thickness: float
+    :tf_coil_poloidal_thickness: the poloidal thickness of the toroidal field
+     coil (optional)
+    :type tf_coil_poloidal_thickness: float
+    :rotation_angle: the angle of the sector that is desired
+    :type rotation_angle: int
+    
+    :divertor_position: divertor position, either "upper" or "lower"
+    :type divertor_position: str
+
+    :return: a Reactor object that has generic functionality
+    :rtype: paramak shape object
+    """
+
+    def __init__(
+        self,
+        inner_bore_radial_thickness,
+        inboard_tf_leg_radial_thickness,
+        center_column_shield_radial_thickness,
+        divertor_radial_thickness,
+        inner_plasma_gap_radial_thickness,
+        plasma_radial_thickness,
+        outer_plasma_gap_radial_thickness,
+        firstwall_radial_thickness,
+        blanket_radial_thickness,
+        blanket_rear_wall_radial_thickness,
+        elongation,
+        triangularity,
+        number_of_tf_coils,
+        pf_coil_to_rear_blanket_radial_gap=None,
+        pf_coil_radial_thicknesses=None,
+        pf_coil_vertical_thicknesses=None,
+        pf_coil_to_tf_coil_radial_gap=None,
+        outboard_tf_coil_radial_thickness=None,
+        tf_coil_poloidal_thickness=None,
+        divertor_position="upper",   # need getter and setter
+        rotation_angle=360,
+    ):
+
+        super().__init__([])
+
+        self.inner_bore_radial_thickness = inner_bore_radial_thickness
+        self.inboard_tf_leg_radial_thickness = inboard_tf_leg_radial_thickness
+        self.center_column_shield_radial_thickness = (
+            center_column_shield_radial_thickness
+        )
+        self.divertor_radial_thickness = divertor_radial_thickness
+        self.inner_plasma_gap_radial_thickness = inner_plasma_gap_radial_thickness
+        self.plasma_radial_thickness = plasma_radial_thickness
+        self.outer_plasma_gap_radial_thickness = outer_plasma_gap_radial_thickness
+        self.firstwall_radial_thickness = firstwall_radial_thickness
+        self.blanket_radial_thickness = blanket_radial_thickness
+        self.blanket_rear_wall_radial_thickness = blanket_rear_wall_radial_thickness
+        self.pf_coil_to_rear_blanket_radial_gap = pf_coil_to_rear_blanket_radial_gap
+        self.pf_coil_radial_thicknesses = pf_coil_radial_thicknesses
+        self.pf_coil_vertical_thicknesses = pf_coil_vertical_thicknesses
+        self.pf_coil_to_tf_coil_radial_gap = pf_coil_to_tf_coil_radial_gap
+        self.outboard_tf_coil_radial_thickness = outboard_tf_coil_radial_thickness
+        self.tf_coil_poloidal_thickness = tf_coil_poloidal_thickness
+        self.divertor_position = divertor_position
+
+        # sets major radius and minor radius from equatorial_points to allow a radial build
+        # this helps avoid the plasma overlapping the center column and such
+        # things
+        inner_equatorial_point = (
+            inner_bore_radial_thickness
+            + inboard_tf_leg_radial_thickness
+            + center_column_shield_radial_thickness
+            + inner_plasma_gap_radial_thickness
+        )
+        outer_equatorial_point = inner_equatorial_point + plasma_radial_thickness
+        self.major_radius = (
+            inner_equatorial_point + plasma_radial_thickness + inner_equatorial_point) / 2
+        self.minor_radius = (
+            (outer_equatorial_point + inner_equatorial_point) / 2
+        ) - inner_equatorial_point
+
+        self.elongation = elongation
+        self.triangularity = triangularity
+
+        self.number_of_tf_coils = number_of_tf_coils
+        self.rotation_angle = rotation_angle
+
+        self.create_components()
+
+    @property
+    def divertor_position(self):
+        return self._divertor_position
+
+    @divertor_position.setter
+    def divertor_position(self, value):
+        acceptable_values = ["upper", "lower"]
+        if value in acceptable_values:
+            self._divertor_position = value
+        else:
+            raise ValueError("divertor position must be 'upper' or 'lower'")
+
+    def create_components(self):
+
+        shapes_or_components = []
+
+        plasma = paramak.Plasma(
+            major_radius=self.major_radius,
+            minor_radius=self.minor_radius,
+            elongation=self.elongation,
+            triangularity=self.triangularity,
+            rotation_angle=self.rotation_angle,
+            stl_filename="plasma.stl",
+        )
+        plasma.create_solid()
+
+        shapes_or_components.append(plasma)
+
+        # this is the radial build sequence, where one component stops and
+        # another starts
+        inner_bore_start_radius = 0
+        inner_bore_end_radius = (
+            inner_bore_start_radius + self.inner_bore_radial_thickness
+        )
+
+        inboard_tf_coils_start_radius = inner_bore_end_radius
+        inboard_tf_coils_end_radius = (
+            inboard_tf_coils_start_radius +
+            self.inboard_tf_leg_radial_thickness)
+
+        center_column_shield_start_radius = inboard_tf_coils_end_radius
+        center_column_shield_end_radius = (
+            center_column_shield_start_radius
+            + self.center_column_shield_radial_thickness
+        )
+
+        divertor_start_radius = center_column_shield_end_radius
+        divertor_end_radius = (
+            center_column_shield_end_radius + self.divertor_radial_thickness
+        )
+
+        firstwall_start_radius = (
+            center_column_shield_end_radius
+            + self.inner_plasma_gap_radial_thickness
+            + self.plasma_radial_thickness
+            + self.outer_plasma_gap_radial_thickness
+        )
+        firstwall_end_radius = firstwall_start_radius + self.firstwall_radial_thickness
+
+        blanket_start_radius = firstwall_end_radius
+        blanket_end_radius = blanket_start_radius + self.blanket_radial_thickness
+
+        blanket_read_wall_start_radius = blanket_end_radius
+        blanket_read_wall_end_radius = (
+            blanket_read_wall_start_radius +
+            self.blanket_rear_wall_radial_thickness)
+
+        # this is the vertical build sequence, componets build on each other in
+        # a similar manner to the radial build
+
+        firstwall_start_height = (
+            plasma.high_point[1] + self.outer_plasma_gap_radial_thickness
+        )
+        firstwall_end_height = firstwall_start_height + self.firstwall_radial_thickness
+
+        blanket_start_height = firstwall_end_height
+        blanket_end_height = blanket_start_height + self.blanket_radial_thickness
+
+        blanket_rear_wall_start_height = blanket_end_height
+        blanket_rear_wall_end_height = (
+            blanket_rear_wall_start_height +
+            self.blanket_rear_wall_radial_thickness)
+
+        tf_coil_height = blanket_rear_wall_end_height
+        center_column_shield_height = blanket_rear_wall_end_height * 2
+
+        if (
+            self.pf_coil_vertical_thicknesses is not None
+            and self.pf_coil_radial_thicknesses is not None
+            and self.pf_coil_to_rear_blanket_radial_gap is not None
+        ):
+            number_of_pf_coils = len(self.pf_coil_vertical_thicknesses)
+
+            y_position_step = (
+                2
+                * (
+                    blanket_rear_wall_end_height
+                    + self.pf_coil_to_rear_blanket_radial_gap
+                )
+            ) / (number_of_pf_coils + 1)
+
+            pf_coils_y_values = []
+            pf_coils_x_values = []
+            # adds in coils with equal spacing strategy, should be updated to
+            # allow user positions
+            for i in range(number_of_pf_coils):
+                y_value = (
+                    blanket_rear_wall_end_height
+                    + self.pf_coil_to_rear_blanket_radial_gap
+                    - y_position_step * (i + 1)
+                )
+                x_value = (
+                    blanket_read_wall_end_radius
+                    + self.pf_coil_to_rear_blanket_radial_gap
+                    + 0.5 * self.pf_coil_radial_thicknesses[i]
+                )
+                pf_coils_y_values.append(y_value)
+                pf_coils_x_values.append(x_value)
+
+            pf_coil_start_radius = (
+                blanket_read_wall_end_radius +
+                self.pf_coil_to_rear_blanket_radial_gap)
+            pf_coil_end_radius = pf_coil_start_radius + max(
+                self.pf_coil_radial_thicknesses
+            )
+
+            if (
+                self.pf_coil_to_tf_coil_radial_gap is not None
+                and self.outboard_tf_coil_radial_thickness is not None
+            ):
+                tf_coil_start_radius = (
+                    pf_coil_end_radius +
+                    self.pf_coil_to_rear_blanket_radial_gap)
+                tf_coil_end_radius = (
+                    tf_coil_start_radius +
+                    self.outboard_tf_coil_radial_thickness)
+
+        # makes a large cylinder that is used to cut the TF coils when the
+        # rotation angle is less than 360
+        if self.rotation_angle < 360:
+            max_high = 3 * center_column_shield_height
+            max_width = 3 * blanket_read_wall_end_radius
+            cutting_slice = paramak.RotateStraightShape(
+                points=[
+                    (0, max_high),
+                    (max_width, max_high),
+                    (max_width, -max_high),
+                    (0, -max_high),
+                ],
+                rotation_angle=360 - self.rotation_angle,
+                azimuth_placement_angle=360 - self.rotation_angle,
+            )
+        else:
+            cutting_slice = None
+
+        inboard_tf_coils = paramak.CenterColumnShieldCylinder(
+            height=tf_coil_height * 2,
+            inner_radius=inboard_tf_coils_start_radius,
+            outer_radius=inboard_tf_coils_end_radius,
+            rotation_angle=self.rotation_angle,
+            # color=centre_column_color,
+            stp_filename="inboard_tf_coils.stp",
+            stl_filename="inboard_tf_coils.stl",
+            name="inboard_tf_coils",
+            material_tag="inboard_tf_coils_mat",
+        )
+        shapes_or_components.append(inboard_tf_coils)
+
+        center_column_shield = paramak.CenterColumnShieldCylinder(
+            height=center_column_shield_height,
+            inner_radius=center_column_shield_start_radius,
+            outer_radius=center_column_shield_end_radius,
+            rotation_angle=self.rotation_angle,
+            # color=centre_column_color,
+            stp_filename="center_column_shield.stp",
+            stl_filename="center_column_shield.stl",
+            name="center_column_shield",
+            material_tag="center_column_shield_mat",
+        )
+        shapes_or_components.append(center_column_shield)
+
+        extra_blanket_upper = paramak.RotateStraightShape(
+            points=[
+                (center_column_shield_end_radius, blanket_start_height),
+                (center_column_shield_end_radius, blanket_end_height),
+                (plasma.high_point[0], blanket_end_height),
+                (plasma.high_point[0], blanket_start_height),
+            ],
+            rotation_angle=self.rotation_angle,
+        )
+
+        extra_firstwall_upper = paramak.RotateStraightShape(
+            points=[
+                (center_column_shield_end_radius, firstwall_start_height),
+                (center_column_shield_end_radius, firstwall_end_height),
+                (plasma.high_point[0], firstwall_end_height),
+                (plasma.high_point[0], firstwall_start_height),
+            ],
+            rotation_angle=self.rotation_angle,
+        )
+
+        extra_blanket_rear_wall_upper = paramak.RotateStraightShape(
+            points=[
+                (center_column_shield_end_radius, blanket_rear_wall_start_height),
+                (center_column_shield_end_radius, blanket_rear_wall_end_height),
+                (plasma.high_point[0], blanket_rear_wall_end_height),
+                (plasma.high_point[0], blanket_rear_wall_start_height),
+            ],
+            rotation_angle=self.rotation_angle,
+        )
+
+        extra_blanket_lower = paramak.RotateStraightShape(
+            points=[
+                (center_column_shield_end_radius, -blanket_start_height),
+                (center_column_shield_end_radius, -blanket_end_height),
+                (plasma.high_point[0], -blanket_end_height),
+                (plasma.high_point[0], -blanket_start_height),
+            ],
+            rotation_angle=self.rotation_angle,
+        )
+
+        extra_firstwall_lower = paramak.RotateStraightShape(
+            points=[
+                (center_column_shield_end_radius, -firstwall_start_height),
+                (center_column_shield_end_radius, -firstwall_end_height),
+                (plasma.high_point[0], -firstwall_end_height),
+                (plasma.high_point[0], -firstwall_start_height),
+            ],
+            rotation_angle=self.rotation_angle,
+        )
+
+        extra_blanket_rear_wall_lower = paramak.RotateStraightShape(
+            points=[
+                (center_column_shield_end_radius, -blanket_rear_wall_start_height),
+                (center_column_shield_end_radius, -blanket_rear_wall_end_height),
+                (plasma.high_point[0], -blanket_rear_wall_end_height),
+                (plasma.high_point[0], -blanket_rear_wall_start_height),
+            ],
+            rotation_angle=self.rotation_angle,
+        )
+
+        firstwall = paramak.BlanketConstantThicknessArcV(
+            inner_mid_point=(firstwall_start_radius, 0),
+            inner_upper_point=(plasma.high_point[0], firstwall_start_height),
+            inner_lower_point=(plasma.low_point[0], -firstwall_start_height),
+            thickness=self.firstwall_radial_thickness,
+            rotation_angle=self.rotation_angle,
+            stp_filename="firstwall.stp",
+            stl_filename="firstwall.stl",
+            name="firstwall",
+            material_tag="firstwall_mat",
+            union=[extra_firstwall_upper, extra_firstwall_lower],
+        )
+
+        blanket = paramak.BlanketConstantThicknessArcV(
+            inner_mid_point=(blanket_start_radius, 0),
+            inner_upper_point=(plasma.high_point[0], blanket_start_height),
+            inner_lower_point=(plasma.low_point[0], -blanket_start_height),
+            thickness=self.blanket_radial_thickness,
+            rotation_angle=self.rotation_angle,
+            stp_filename="blanket.stp",
+            stl_filename="blanket.stl",
+            name="blanket",
+            material_tag="blanket_mat",
+            union=[extra_blanket_upper, extra_blanket_lower],
+        )
+
+        blanket_rear_casing = paramak.BlanketConstantThicknessArcV(
+            inner_mid_point=(blanket_read_wall_start_radius, 0),
+            inner_upper_point=(plasma.high_point[0], blanket_rear_wall_start_height),
+            inner_lower_point=(plasma.low_point[0], -blanket_rear_wall_start_height),
+            thickness=self.blanket_rear_wall_radial_thickness,
+            rotation_angle=self.rotation_angle,
+            stp_filename="blanket_rear_wall.stp",
+            stl_filename="blanket_rear_wall.stl",
+            name="blanket_rear_wall",
+            material_tag="blanket_rear_wall_mat",
+            union=[extra_blanket_rear_wall_upper, extra_blanket_rear_wall_lower],
+        )
+
+        blanket_fw_rear_wall_envelope = paramak.BlanketConstantThicknessArcV(
+            inner_mid_point=(firstwall_start_radius, 0),
+            inner_upper_point=(plasma.high_point[0], firstwall_start_height),
+            inner_lower_point=(plasma.low_point[0], -firstwall_start_height),
+            thickness=self.firstwall_radial_thickness
+            + self.blanket_radial_thickness
+            + self.blanket_rear_wall_radial_thickness,
+            rotation_angle=self.rotation_angle,
+            union=[
+                extra_blanket_upper,
+                extra_firstwall_upper,
+                extra_blanket_rear_wall_upper,
+                extra_blanket_lower,
+                extra_firstwall_lower,
+                extra_blanket_rear_wall_lower,
+            ],
+            stp_filename="test.stp",
+        )
+
+        if self.divertor_position == "upper":
+            divertor_height = blanket_rear_wall_end_height
+        elif self.divertor_position == "lower":
+            divertor_height = -blanket_rear_wall_end_height
+
+        divertor = paramak.RotateStraightShape(
+            points=[
+                (divertor_start_radius, 0),
+                (divertor_end_radius, 0),
+                (divertor_end_radius, divertor_height),
+                (divertor_start_radius, divertor_height)
+            ],
+            intersect=blanket_fw_rear_wall_envelope,
+            stp_filename="divertor.stp",
+            stl_filename="divertor.stl",
+            name="divertor",
+            material_tag="divertor_mat"
+        )
+        
+        shapes_or_components.append(divertor)
+
+        firstwall.solid = firstwall.solid.cut(divertor.solid)
+        blanket.solid = blanket.solid.cut(divertor.solid)
+        blanket_rear_casing.solid = blanket_rear_casing.solid.cut(
+            divertor.solid)
+        shapes_or_components.append(firstwall)
+        shapes_or_components.append(blanket)
+        shapes_or_components.append(blanket_rear_casing)
+
+        if (
+            self.pf_coil_vertical_thicknesses is not None
+            and self.pf_coil_radial_thicknesses is not None
+            and self.pf_coil_to_rear_blanket_radial_gap is not None
+        ):
+
+            for i, (rt, vt, y_value, x_value) in enumerate(
+                zip(
+                    self.pf_coil_radial_thicknesses,
+                    self.pf_coil_vertical_thicknesses,
+                    pf_coils_y_values,
+                    pf_coils_x_values,
+                )
+            ):
+
+                pf_coil = paramak.PoloidalFieldCoil(
+                    width=rt,
+                    height=vt,
+                    center_point=(x_value, y_value),
+                    rotation_angle=self.rotation_angle,
+                    stp_filename="pf_coil_" + str(i) + ".stp",
+                    stl_filename="pf_coil_" + str(i) + ".stl",
+                    name="pf_coil",
+                    material_tag="pf_coil_mat",
+                )
+                shapes_or_components.append(pf_coil)
+
+            if (
+                self.pf_coil_to_tf_coil_radial_gap is not None
+                and self.outboard_tf_coil_radial_thickness is not None
+            ):
+                tf_coil = paramak.ToroidalFieldCoilRectangle(
+                    inner_upper_point=(inboard_tf_coils_start_radius, tf_coil_height),
+                    inner_lower_point=(inboard_tf_coils_start_radius, -tf_coil_height),
+                    inner_mid_point=(tf_coil_start_radius, 0),
+                    thickness=self.outboard_tf_coil_radial_thickness,
+                    number_of_coils=self.number_of_tf_coils,
+                    distance=self.tf_coil_poloidal_thickness,
+                    stp_filename="tf_coil.stp",
+                    name="tf_coil",
+                    material_tag="tf_coil_mat",
+                    stl_filename="tf_coil.stl",
+                    cut=cutting_slice,
+                )
+
+                shapes_or_components.append(tf_coil)
+
+        self.shapes_and_components = shapes_or_components

--- a/paramak/parametric_reactors/single_null_reactor.py
+++ b/paramak/parametric_reactors/single_null_reactor.py
@@ -63,7 +63,7 @@ class SingleNullReactor(paramak.Reactor):
     :type tf_coil_poloidal_thickness: float
     :rotation_angle: the angle of the sector that is desired
     :type rotation_angle: int
-    
+
     :divertor_position: divertor position, either "upper" or "lower"
     :type divertor_position: str
 
@@ -459,7 +459,7 @@ class SingleNullReactor(paramak.Reactor):
             name="divertor",
             material_tag="divertor_mat"
         )
-        
+
         shapes_or_components.append(divertor)
 
         firstwall.solid = firstwall.solid.cut(divertor.solid)

--- a/tests/test_BallReactor.py
+++ b/tests/test_BallReactor.py
@@ -171,7 +171,7 @@ class test_BallReactor(unittest.TestCase):
     def test_export_3d_image(self):
         """creates a BallReactor using a parametric reactor and checks that a 3D image
         of the reactor can be exported using the export_3d_image() method"""
-        
+
         test_reactor = paramak.BallReactor(
             inner_bore_radial_thickness=50,
             inboard_tf_leg_radial_thickness=50,

--- a/tests/test_BallReactor.py
+++ b/tests/test_BallReactor.py
@@ -9,7 +9,8 @@ import paramak
 
 class test_BallReactor(unittest.TestCase):
     def test_BallReactor_creation_with_narrow_divertor(self):
-        """creates blanket from parametric shape and checks a solid is created"""
+        """creates a BallReactor with a narrow divertor using a parametric reactor
+        and checks that all components are created"""
 
         test_reactor = paramak.BallReactor(
             inner_bore_radial_thickness=50,
@@ -31,8 +32,9 @@ class test_BallReactor(unittest.TestCase):
 
         assert len(test_reactor.shapes_and_components) == 7
 
-    def test_BallReactor_creation_without_wide_divertor(self):
-        """creates blanket from parametric shape and checks a solid is created"""
+    def test_BallReactor_creation_with_wide_divertor(self):
+        """creates a BallReactor with a wide divertor using a parametric reactor
+        and checks that all components are created"""
 
         test_reactor = paramak.BallReactor(
             inner_bore_radial_thickness=50,
@@ -55,9 +57,12 @@ class test_BallReactor(unittest.TestCase):
         assert len(test_reactor.shapes_and_components) == 7
 
     def test_BallReactor_svg_creation(self):
+        """creates a BallReactor using a parametric reactor and checks that an
+        svg image of the reactor can be exported"""
+
         os.system("rm test_ballreactor_image.svg")
 
-        my_reactor = paramak.BallReactor(
+        test_reactor = paramak.BallReactor(
             inner_bore_radial_thickness=50,
             inboard_tf_leg_radial_thickness=200,
             center_column_shield_radial_thickness=50,
@@ -72,12 +77,15 @@ class test_BallReactor(unittest.TestCase):
             triangularity=0.55,
             number_of_tf_coils=16,
         )
-        my_reactor.export_svg("test_ballreactor_image.svg")
+        test_reactor.export_svg("test_ballreactor_image.svg")
 
         assert Path("test_ballreactor_image.svg").exists() is True
         os.system("rm test_ballreactor_image.svg")
 
     def test_BallReactor_with_pf_coils(self):
+        """creates a BallReactor with pf coils using a parametric reactor and
+        checks that all components are created"""
+
         test_reactor = paramak.BallReactor(
             inner_bore_radial_thickness=50,
             inboard_tf_leg_radial_thickness=50,
@@ -102,6 +110,9 @@ class test_BallReactor(unittest.TestCase):
         assert len(test_reactor.shapes_and_components) == 11
 
     def test_BallReactor_with_pf_and_tf_coils(self):
+        """creates a BallReactor with pf and tf coils using a parametric reactor and
+        checks that all components are created"""
+
         test_reactor = paramak.BallReactor(
             inner_bore_radial_thickness=50,
             inboard_tf_leg_radial_thickness=50,
@@ -128,6 +139,9 @@ class test_BallReactor(unittest.TestCase):
         assert len(test_reactor.shapes_and_components) == 12
 
     def test_BallReactor_with_pf_and_tf_coils_export_physical_groups(self):
+        """creates a BallReactor with pf and tf coils using a parametric reactor and checks
+        that the export_physical_groups() method works correctly"""
+
         test_reactor = paramak.BallReactor(
             inner_bore_radial_thickness=50,
             inboard_tf_leg_radial_thickness=50,
@@ -151,10 +165,13 @@ class test_BallReactor(unittest.TestCase):
             tf_coil_poloidal_thickness=50,
         )
         test_reactor.export_physical_groups()
+        # physical group attribute must be specified individually for each component
+        # parametric reactors cause physical_groups = None for all components
 
     def test_export_3d_image(self):
-        """Tests the method export_3d_image
-        """
+        """creates a BallReactor using a parametric reactor and checks that a 3D image
+        of the reactor can be exported using the export_3d_image() method"""
+        
         test_reactor = paramak.BallReactor(
             inner_bore_radial_thickness=50,
             inboard_tf_leg_radial_thickness=50,

--- a/tests/test_SingleNullReactor.py
+++ b/tests/test_SingleNullReactor.py
@@ -125,7 +125,7 @@ class test_SingleNullReactor(unittest.TestCase):
     def test_SingleNullReactor_svg_creation(self):
         """creates a SingleNullReactor using a parametric reactor and checks that an
         svg image of the reactor can be exported"""
-        
+
         os.system("rm test_singlenullreactor_image.svg")
 
         test_reactor = paramak.SingleNullReactor(
@@ -153,5 +153,5 @@ class test_SingleNullReactor(unittest.TestCase):
         )
         test_reactor.export_svg("test_singlenullreactor_image.svg")
 
-        assert Path("test_singlenullreactor_image.svg").exists() is True 
+        assert Path("test_singlenullreactor_image.svg").exists() is True
         os.system("rm test_singlenullreactor_image.svg")

--- a/tests/test_SingleNullReactor.py
+++ b/tests/test_SingleNullReactor.py
@@ -1,0 +1,157 @@
+import os
+import unittest
+from pathlib import Path
+
+import pytest
+
+import paramak
+
+
+class test_SingleNullReactor(unittest.TestCase):
+    def test_SingleNullReactor_creation_upper_divertor(self):
+        """creates a SingleNullReactor using a parametric reactor with an upper divertor
+        and checks all components are created"""
+
+        test_reactor = paramak.SingleNullReactor(
+            inner_bore_radial_thickness=50,
+            inboard_tf_leg_radial_thickness=50,
+            center_column_shield_radial_thickness=50,
+            divertor_radial_thickness=100,
+            inner_plasma_gap_radial_thickness=50,
+            plasma_radial_thickness=200,
+            outer_plasma_gap_radial_thickness=50,
+            firstwall_radial_thickness=50,
+            blanket_radial_thickness=100,
+            blanket_rear_wall_radial_thickness=50,
+            elongation=2,
+            triangularity=0.55,
+            number_of_tf_coils=16,
+            rotation_angle=180,
+            divertor_position="upper",
+        )
+
+        test_reactor.export_stp()
+
+        assert len(test_reactor.shapes_and_components) == 7
+
+    def test_SingleNullReactor_creation_lower_divertor(self):
+        """creates a SingleNullReactor using a parametric reactor with a lower divertor
+        and checks all components are created"""
+
+        test_reactor = paramak.SingleNullReactor(
+            inner_bore_radial_thickness=50,
+            inboard_tf_leg_radial_thickness=50,
+            center_column_shield_radial_thickness=50,
+            divertor_radial_thickness=100,
+            inner_plasma_gap_radial_thickness=50,
+            plasma_radial_thickness=200,
+            outer_plasma_gap_radial_thickness=50,
+            firstwall_radial_thickness=50,
+            blanket_radial_thickness=100,
+            blanket_rear_wall_radial_thickness=50,
+            elongation=2,
+            triangularity=0.55,
+            number_of_tf_coils=16,
+            rotation_angle=180,
+            divertor_position="lower",
+        )
+
+        test_reactor.export_stp()
+
+        assert len(test_reactor.shapes_and_components) == 7
+
+    def test_SingleNullReactor_creation_with_pf_coils(self):
+        """creates a SingleNullReactor using a parametric reactor with pf coils and
+        checks all components are created"""
+
+        test_reactor = paramak.SingleNullReactor(
+            inner_bore_radial_thickness=50,
+            inboard_tf_leg_radial_thickness=50,
+            center_column_shield_radial_thickness=50,
+            divertor_radial_thickness=100,
+            inner_plasma_gap_radial_thickness=50,
+            plasma_radial_thickness=200,
+            outer_plasma_gap_radial_thickness=50,
+            firstwall_radial_thickness=50,
+            blanket_radial_thickness=100,
+            blanket_rear_wall_radial_thickness=50,
+            elongation=2,
+            triangularity=0.55,
+            number_of_tf_coils=16,
+            rotation_angle=180,
+            divertor_position="lower",
+            pf_coil_to_rear_blanket_radial_gap=50,
+            pf_coil_vertical_thicknesses=[50, 50, 50, 50, 50],
+            pf_coil_radial_thicknesses=[40, 40, 40, 40, 40],
+            pf_coil_to_tf_coil_radial_gap=50,
+        )
+
+        test_reactor.export_stp()
+
+        assert len(test_reactor.shapes_and_components) == 12
+
+    def test_SingleNullReactor_creation_with_pf_tf_coils(self):
+        """creates a SingleNullReactor using a parametric reactor with pf and tf coils
+        and checks all components are created"""
+
+        test_reactor = paramak.SingleNullReactor(
+            inner_bore_radial_thickness=50,
+            inboard_tf_leg_radial_thickness=50,
+            center_column_shield_radial_thickness=50,
+            divertor_radial_thickness=100,
+            inner_plasma_gap_radial_thickness=50,
+            plasma_radial_thickness=200,
+            outer_plasma_gap_radial_thickness=50,
+            firstwall_radial_thickness=50,
+            blanket_radial_thickness=100,
+            blanket_rear_wall_radial_thickness=50,
+            elongation=2,
+            triangularity=0.55,
+            number_of_tf_coils=16,
+            rotation_angle=180,
+            divertor_position="lower",
+            outboard_tf_coil_radial_thickness=50,
+            pf_coil_to_rear_blanket_radial_gap=50,
+            tf_coil_poloidal_thickness=70,
+            pf_coil_vertical_thicknesses=[50, 50, 50, 50, 50],
+            pf_coil_radial_thicknesses=[40, 40, 40, 40, 40],
+            pf_coil_to_tf_coil_radial_gap=50,
+        )
+
+        test_reactor.export_stp()
+
+        assert len(test_reactor.shapes_and_components) == 13
+
+    def test_SingleNullReactor_svg_creation(self):
+        """creates a SingleNullReactor using a parametric reactor and checks that an
+        svg image of the reactor can be exported"""
+        
+        os.system("rm test_singlenullreactor_image.svg")
+
+        test_reactor = paramak.SingleNullReactor(
+            inner_bore_radial_thickness=50,
+            inboard_tf_leg_radial_thickness=50,
+            center_column_shield_radial_thickness=50,
+            divertor_radial_thickness=100,
+            inner_plasma_gap_radial_thickness=50,
+            plasma_radial_thickness=200,
+            outer_plasma_gap_radial_thickness=50,
+            firstwall_radial_thickness=50,
+            blanket_radial_thickness=100,
+            blanket_rear_wall_radial_thickness=50,
+            elongation=2,
+            triangularity=0.55,
+            number_of_tf_coils=16,
+            rotation_angle=180,
+            divertor_position="lower",
+            outboard_tf_coil_radial_thickness=50,
+            pf_coil_to_rear_blanket_radial_gap=50,
+            tf_coil_poloidal_thickness=70,
+            pf_coil_vertical_thicknesses=[50, 50, 50, 50, 50],
+            pf_coil_radial_thicknesses=[40, 40, 40, 40, 40],
+            pf_coil_to_tf_coil_radial_gap=50,
+        )
+        test_reactor.export_svg("test_singlenullreactor_image.svg")
+
+        assert Path("test_singlenullreactor_image.svg").exists() is True 
+        os.system("rm test_singlenullreactor_image.svg")


### PR DESCRIPTION
PR which adds a single null parametric reactor.
The reactor is based on the BallReactor, but takes an additional argument of divertor_position = ["upper", "lower"] which specifies the divertor location.
Adds examples and tests for SingleNullReactor and updates docstrings for BallReactor tests