### PR TITLE
Convert to self

### DIFF
--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -124,120 +124,18 @@ class BallReactor(paramak.Reactor):
 
     def create_components(self):
 
-        # this calls each method for constructing the reactor components by passing the
-        # relevant parameters/objects to each method which return more objects
+        # this calls each method for constructing the reactor components
 
         shapes_or_components = []
 
-        plasma = self.make_plasma(shapes_or_components)
-
-        (
-            inner_bore_start_radius,
-            inner_bore_end_radius,
-            inboard_tf_coils_start_radius,
-            inboard_tf_coils_end_radius,
-            center_column_shield_start_radius,
-            center_column_shield_end_radius,
-            divertor_start_radius,
-            divertor_end_radius,
-            firstwall_start_radius,
-            firstwall_end_radius,
-            blanket_start_radius,
-            blanket_end_radius,
-            blanket_rear_wall_start_radius,
-            blanket_read_wall_end_radius,
-        ) = self.make_radial_build(shapes_or_components)
-
-        (
-            firstwall_start_height,
-            firstwall_end_height,
-            blanket_start_height,
-            blanket_end_height,
-            blanket_rear_wall_start_height,
-            blanket_rear_wall_end_height,
-            tf_coil_height,
-            center_column_shield_height,
-            pf_coil_start_radius,
-            pf_coil_end_radius,
-            pf_coils_y_values,
-            pf_coils_x_values,
-            tf_coil_start_radius,
-            tf_coil_end_radius,
-        ) = self.make_vertical_build(
-            shapes_or_components, plasma, blanket_read_wall_end_radius
-        )
-
-        inboard_tf_coils, cutting_slice = self.make_inboard_tf_coils(
-            shapes_or_components,
-            center_column_shield_height,
-            blanket_read_wall_end_radius,
-            tf_coil_height,
-            inboard_tf_coils_start_radius,
-            inboard_tf_coils_end_radius
-        )
-
-        center_column_shield = self.make_center_column_shield(
-            shapes_or_components,
-            center_column_shield_height,
-            center_column_shield_start_radius,
-            center_column_shield_end_radius,
-        )
-
-        (
-            firstwall,
-            blanket,
-            blanket_rear_casing,
-            extra_blanket_upper,
-            extra_firstwall_upper,
-            extra_blanket_rear_wall_upper,
-            extra_blanket_lower,
-            extra_firstwall_lower,
-            extra_blanket_rear_wall_lower,
-        ) = self.make_blanket_and_firstwall(
-            shapes_or_components,
-            center_column_shield_end_radius,
-            blanket_start_height,
-            blanket_end_height,
-            firstwall_start_height,
-            firstwall_end_height,
-            blanket_rear_wall_start_height,
-            blanket_rear_wall_end_height,
-            plasma,
-            firstwall_start_radius,
-            blanket_start_radius,
-            blanket_rear_wall_start_radius,
-        )
-
-        blanket_fw_rear_wall_envelope, divertor = self.make_divertor(
-            shapes_or_components,
-            firstwall_start_radius,
-            firstwall_start_height,
-            extra_blanket_upper,
-            extra_firstwall_upper,
-            extra_blanket_rear_wall_upper,
-            extra_blanket_lower,
-            extra_firstwall_lower,
-            extra_blanket_rear_wall_lower,
-            plasma,
-            blanket_rear_wall_end_height,
-            divertor_start_radius,
-            divertor_end_radius,
-        )
-
-        self.make_component_cuts(
-            shapes_or_components,
-            firstwall,
-            blanket,
-            blanket_rear_casing,
-            divertor,
-            pf_coils_y_values,
-            pf_coils_x_values,
-            inboard_tf_coils_start_radius,
-            inboard_tf_coils_end_radius,
-            tf_coil_height,
-            tf_coil_start_radius,
-            cutting_slice,
-        )
+        self.make_plasma(shapes_or_components)
+        self.make_radial_build(shapes_or_components)
+        self.make_vertical_build(shapes_or_components)
+        self.make_inboard_tf_coils(shapes_or_components)
+        self.make_center_column_shield(shapes_or_components)
+        self.make_blanket_and_firstwall(shapes_or_components)
+        self.make_divertor(shapes_or_components)
+        self.make_component_cuts(shapes_or_components)
 
         self.shapes_and_components = shapes_or_components
 
@@ -255,92 +153,71 @@ class BallReactor(paramak.Reactor):
 
         shapes_or_components.append(plasma)
 
-        return plasma
+        self._plasma = plasma
 
     def make_radial_build(self, shapes_or_components):
 
         # this is the radial build sequence, where one component stops and
         # another starts
 
-        inner_bore_start_radius = 0
-        inner_bore_end_radius = (
-            inner_bore_start_radius + self.inner_bore_radial_thickness
+        self._inner_bore_start_radius = 0
+        self._inner_bore_end_radius = (
+            self._inner_bore_start_radius + self.inner_bore_radial_thickness
         )
 
-        inboard_tf_coils_start_radius = inner_bore_end_radius
-        inboard_tf_coils_end_radius = (
-            inboard_tf_coils_start_radius +
+        self._inboard_tf_coils_start_radius = self._inner_bore_end_radius
+        self._inboard_tf_coils_end_radius = (
+            self._inboard_tf_coils_start_radius +
             self.inboard_tf_leg_radial_thickness)
 
-        center_column_shield_start_radius = inboard_tf_coils_end_radius
-        center_column_shield_end_radius = (
-            center_column_shield_start_radius
+        self._center_column_shield_start_radius = self._inboard_tf_coils_end_radius
+        self._center_column_shield_end_radius = (
+            self._center_column_shield_start_radius
             + self.center_column_shield_radial_thickness
         )
 
-        divertor_start_radius = center_column_shield_end_radius
-        divertor_end_radius = (
-            center_column_shield_end_radius + self.divertor_radial_thickness
+        self._divertor_start_radius = self._center_column_shield_end_radius
+        self._divertor_end_radius = (
+            self._center_column_shield_end_radius + self.divertor_radial_thickness
         )
 
-        firstwall_start_radius = (
-            center_column_shield_end_radius
+        self._firstwall_start_radius = (
+            self._center_column_shield_end_radius
             + self.inner_plasma_gap_radial_thickness
             + self.plasma_radial_thickness
             + self.outer_plasma_gap_radial_thickness
         )
-        firstwall_end_radius = firstwall_start_radius + self.firstwall_radial_thickness
+        self._firstwall_end_radius = self._firstwall_start_radius + self.firstwall_radial_thickness
 
-        blanket_start_radius = firstwall_end_radius
-        blanket_end_radius = blanket_start_radius + self.blanket_radial_thickness
+        self._blanket_start_radius = self._firstwall_end_radius
+        self._blanket_end_radius = self._blanket_start_radius + self.blanket_radial_thickness
 
-        blanket_rear_wall_start_radius = blanket_end_radius
-        blanket_read_wall_end_radius = (
-            blanket_rear_wall_start_radius +
+        self._blanket_rear_wall_start_radius = self._blanket_end_radius
+        self._blanket_read_wall_end_radius = (
+            self._blanket_rear_wall_start_radius +
             self.blanket_rear_wall_radial_thickness)
 
-        return (
-            inner_bore_start_radius,
-            inner_bore_end_radius,
-            inboard_tf_coils_start_radius,
-            inboard_tf_coils_end_radius,
-            center_column_shield_start_radius,
-            center_column_shield_end_radius,
-            divertor_start_radius,
-            divertor_end_radius,
-            firstwall_start_radius,
-            firstwall_end_radius,
-            blanket_start_radius,
-            blanket_end_radius,
-            blanket_rear_wall_start_radius,
-            blanket_read_wall_end_radius,
-        )
 
-    def make_vertical_build(
-        self,
-        shapes_or_components,
-        plasma,
-        blanket_read_wall_end_radius
-    ):
+    def make_vertical_build(self, shapes_or_components):
 
         # this is the vertical build sequence, components build on each other in
         # a similar manner to the radial build
 
-        firstwall_start_height = (
-            plasma.high_point[1] + self.outer_plasma_gap_radial_thickness
+        self._firstwall_start_height = (
+            self._plasma.high_point[1] + self.outer_plasma_gap_radial_thickness
         )
-        firstwall_end_height = firstwall_start_height + self.firstwall_radial_thickness
+        self._firstwall_end_height = self._firstwall_start_height + self.firstwall_radial_thickness
 
-        blanket_start_height = firstwall_end_height
-        blanket_end_height = blanket_start_height + self.blanket_radial_thickness
+        self._blanket_start_height = self._firstwall_end_height
+        self._blanket_end_height = self._blanket_start_height + self.blanket_radial_thickness
 
-        blanket_rear_wall_start_height = blanket_end_height
-        blanket_rear_wall_end_height = (
-            blanket_rear_wall_start_height +
+        self._blanket_rear_wall_start_height = self._blanket_end_height
+        self._blanket_rear_wall_end_height = (
+            self._blanket_rear_wall_start_height +
             self.blanket_rear_wall_radial_thickness)
 
-        tf_coil_height = blanket_rear_wall_end_height
-        center_column_shield_height = blanket_rear_wall_end_height * 2
+        self._tf_coil_height = self._blanket_rear_wall_end_height
+        self._center_column_shield_height = self._blanket_rear_wall_end_height * 2
 
         if (
             self.pf_coil_vertical_thicknesses is not None
@@ -352,33 +229,33 @@ class BallReactor(paramak.Reactor):
             y_position_step = (
                 2
                 * (
-                    blanket_rear_wall_end_height
+                    self._blanket_rear_wall_end_height
                     + self.pf_coil_to_rear_blanket_radial_gap
                 )
             ) / (number_of_pf_coils + 1)
 
-            pf_coils_y_values = []
-            pf_coils_x_values = []
+            self._pf_coils_y_values = []
+            self._pf_coils_x_values = []
             # adds in coils with equal spacing strategy, should be updated to
             # allow user positions
             for i in range(number_of_pf_coils):
                 y_value = (
-                    blanket_rear_wall_end_height
+                    self._blanket_rear_wall_end_height
                     + self.pf_coil_to_rear_blanket_radial_gap
                     - y_position_step * (i + 1)
                 )
                 x_value = (
-                    blanket_read_wall_end_radius
+                    self._blanket_read_wall_end_radius
                     + self.pf_coil_to_rear_blanket_radial_gap
                     + 0.5 * self.pf_coil_radial_thicknesses[i]
                 )
-                pf_coils_y_values.append(y_value)
-                pf_coils_x_values.append(x_value)
+                self._pf_coils_y_values.append(y_value)
+                self._pf_coils_x_values.append(x_value)
 
-            pf_coil_start_radius = (
-                blanket_read_wall_end_radius +
+            self._pf_coil_start_radius = (
+                self._blanket_read_wall_end_radius +
                 self.pf_coil_to_rear_blanket_radial_gap)
-            pf_coil_end_radius = pf_coil_start_radius + max(
+            self._pf_coil_end_radius = self._pf_coil_start_radius + max(
                 self.pf_coil_radial_thicknesses
             )
 
@@ -386,58 +263,33 @@ class BallReactor(paramak.Reactor):
                 self.pf_coil_to_tf_coil_radial_gap is not None
                 and self.outboard_tf_coil_radial_thickness is not None
             ):
-                tf_coil_start_radius = (
-                    pf_coil_end_radius +
+                self._tf_coil_start_radius = (
+                    self._pf_coil_end_radius +
                     self.pf_coil_to_rear_blanket_radial_gap)
-                tf_coil_end_radius = (
-                    tf_coil_start_radius +
+                self._tf_coil_end_radius = (
+                    self._tf_coil_start_radius +
                     self.outboard_tf_coil_radial_thickness)
 
             else:
-                tf_coil_start_radius = None
-                tf_coil_end_radius = None
+                self._tf_coil_start_radius = None
+                self._tf_coil_end_radius = None
 
         else:
-            pf_coil_start_radius = None
-            pf_coil_end_radius = None
-            pf_coils_y_values = None
-            pf_coils_x_values = None
-            tf_coil_start_radius = None
-            tf_coil_end_radius = None
+            self._pf_coil_start_radius = None
+            self._pf_coil_end_radius = None
+            self._pf_coils_y_values = None
+            self._pf_coils_x_values = None
+            self._tf_coil_start_radius = None
+            self._tf_coil_end_radius = None
 
-        return (
-            firstwall_start_height,
-            firstwall_end_height,
-            blanket_start_height,
-            blanket_end_height,
-            blanket_rear_wall_start_height,
-            blanket_rear_wall_end_height,
-            tf_coil_height,
-            center_column_shield_height,
-            pf_coil_start_radius,
-            pf_coil_end_radius,
-            pf_coils_y_values,
-            pf_coils_x_values,
-            tf_coil_start_radius,
-            tf_coil_end_radius,
-        )
-
-    def make_inboard_tf_coils(
-        self,
-        shapes_or_components,
-        center_column_shield_height,
-        blanket_read_wall_end_radius,
-        tf_coil_height,
-        inboard_tf_coils_start_radius,
-        inboard_tf_coils_end_radius,
-    ):
+    def make_inboard_tf_coils(self, shapes_or_components):
 
         # makes a large cylinder that is used to cut the TF coils when the
         # rotation angle is less than 360
         if self.rotation_angle < 360:
-            max_high = 3 * center_column_shield_height
-            max_width = 3 * blanket_read_wall_end_radius
-            cutting_slice = paramak.RotateStraightShape(
+            max_high = 3 * self._center_column_shield_height
+            max_width = 3 * self._blanket_read_wall_end_radius
+            self._cutting_slice = paramak.RotateStraightShape(
                 points=[
                     (0, max_high),
                     (max_width, max_high),
@@ -448,12 +300,12 @@ class BallReactor(paramak.Reactor):
                 azimuth_placement_angle=360 - self.rotation_angle,
             )
         else:
-            cutting_slice = None
+            self._cutting_slice = None
 
-        inboard_tf_coils = paramak.CenterColumnShieldCylinder(
-            height=tf_coil_height * 2,
-            inner_radius=inboard_tf_coils_start_radius,
-            outer_radius=inboard_tf_coils_end_radius,
+        self._inboard_tf_coils = paramak.CenterColumnShieldCylinder(
+            height=self._tf_coil_height * 2,
+            inner_radius=self._inboard_tf_coils_start_radius,
+            outer_radius=self._inboard_tf_coils_end_radius,
             rotation_angle=self.rotation_angle,
             # color=centre_column_color,
             stp_filename="inboard_tf_coils.stp",
@@ -461,22 +313,14 @@ class BallReactor(paramak.Reactor):
             name="inboard_tf_coils",
             material_tag="inboard_tf_coils_mat",
         )
-        shapes_or_components.append(inboard_tf_coils)
+        shapes_or_components.append(self._inboard_tf_coils)
 
-        return inboard_tf_coils, cutting_slice
+    def make_center_column_shield(self, shapes_or_components):
 
-    def make_center_column_shield(
-        self,
-        shapes_or_components,
-        center_column_shield_height,
-        center_column_shield_start_radius,
-        center_column_shield_end_radius,
-    ):
-
-        center_column_shield = paramak.CenterColumnShieldCylinder(
-            height=center_column_shield_height,
-            inner_radius=center_column_shield_start_radius,
-            outer_radius=center_column_shield_end_radius,
+        self._center_column_shield = paramak.CenterColumnShieldCylinder(
+            height=self._center_column_shield_height,
+            inner_radius=self._center_column_shield_start_radius,
+            outer_radius=self._center_column_shield_end_radius,
             rotation_angle=self.rotation_angle,
             # color=centre_column_color,
             stp_filename="center_column_shield.stp",
@@ -484,209 +328,151 @@ class BallReactor(paramak.Reactor):
             name="center_column_shield",
             material_tag="center_column_shield_mat",
         )
-        shapes_or_components.append(center_column_shield)
+        shapes_or_components.append(self._center_column_shield)
 
-        return center_column_shield
+    def make_blanket_and_firstwall(self, shapes_or_components):
 
-    def make_blanket_and_firstwall(
-        self,
-        shapes_or_components,
-        center_column_shield_end_radius,
-        blanket_start_height,
-        blanket_end_height,
-        firstwall_start_height,
-        firstwall_end_height,
-        blanket_rear_wall_start_height,
-        blanket_rear_wall_end_height,
-        plasma,
-        firstwall_start_radius,
-        blanket_start_radius,
-        blanket_rear_wall_start_radius,
-    ):
-
-        extra_blanket_upper = paramak.RotateStraightShape(
+        self._extra_blanket_upper = paramak.RotateStraightShape(
             points=[
-                (center_column_shield_end_radius, blanket_start_height),
-                (center_column_shield_end_radius, blanket_end_height),
-                (plasma.high_point[0], blanket_end_height),
-                (plasma.high_point[0], blanket_start_height),
+                (self._center_column_shield_end_radius, self._blanket_start_height),
+                (self._center_column_shield_end_radius, self._blanket_end_height),
+                (self._plasma.high_point[0], self._blanket_end_height),
+                (self._plasma.high_point[0], self._blanket_start_height),
             ],
             rotation_angle=self.rotation_angle,
         )
 
-        extra_firstwall_upper = paramak.RotateStraightShape(
+        self._extra_firstwall_upper = paramak.RotateStraightShape(
             points=[
-                (center_column_shield_end_radius, firstwall_start_height),
-                (center_column_shield_end_radius, firstwall_end_height),
-                (plasma.high_point[0], firstwall_end_height),
-                (plasma.high_point[0], firstwall_start_height),
+                (self._center_column_shield_end_radius, self._firstwall_start_height),
+                (self._center_column_shield_end_radius, self._firstwall_end_height),
+                (self._plasma.high_point[0], self._firstwall_end_height),
+                (self._plasma.high_point[0], self._firstwall_start_height),
             ],
             rotation_angle=self.rotation_angle,
         )
 
-        extra_blanket_rear_wall_upper = paramak.RotateStraightShape(
+        self._extra_blanket_rear_wall_upper = paramak.RotateStraightShape(
             points=[
-                (center_column_shield_end_radius, blanket_rear_wall_start_height),
-                (center_column_shield_end_radius, blanket_rear_wall_end_height),
-                (plasma.high_point[0], blanket_rear_wall_end_height),
-                (plasma.high_point[0], blanket_rear_wall_start_height),
+                (self._center_column_shield_end_radius, self._blanket_rear_wall_start_height),
+                (self._center_column_shield_end_radius, self._blanket_rear_wall_end_height),
+                (self._plasma.high_point[0], self._blanket_rear_wall_end_height),
+                (self._plasma.high_point[0], self._blanket_rear_wall_start_height),
             ],
             rotation_angle=self.rotation_angle,
         )
 
-        extra_blanket_lower = paramak.RotateStraightShape(
+        self._extra_blanket_lower = paramak.RotateStraightShape(
             points=[
-                (center_column_shield_end_radius, -blanket_start_height),
-                (center_column_shield_end_radius, -blanket_end_height),
-                (plasma.high_point[0], -blanket_end_height),
-                (plasma.high_point[0], -blanket_start_height),
+                (self._center_column_shield_end_radius, -self._blanket_start_height),
+                (self._center_column_shield_end_radius, -self._blanket_end_height),
+                (self._plasma.high_point[0], -self._blanket_end_height),
+                (self._plasma.high_point[0], -self._blanket_start_height),
             ],
             rotation_angle=self.rotation_angle,
         )
 
-        extra_firstwall_lower = paramak.RotateStraightShape(
+        self._extra_firstwall_lower = paramak.RotateStraightShape(
             points=[
-                (center_column_shield_end_radius, -firstwall_start_height),
-                (center_column_shield_end_radius, -firstwall_end_height),
-                (plasma.high_point[0], -firstwall_end_height),
-                (plasma.high_point[0], -firstwall_start_height),
+                (self._center_column_shield_end_radius, -self._firstwall_start_height),
+                (self._center_column_shield_end_radius, -self._firstwall_end_height),
+                (self._plasma.high_point[0], -self._firstwall_end_height),
+                (self._plasma.high_point[0], -self._firstwall_start_height),
             ],
             rotation_angle=self.rotation_angle,
         )
 
-        extra_blanket_rear_wall_lower = paramak.RotateStraightShape(
+        self._extra_blanket_rear_wall_lower = paramak.RotateStraightShape(
             points=[
-                (center_column_shield_end_radius, -blanket_rear_wall_start_height),
-                (center_column_shield_end_radius, -blanket_rear_wall_end_height),
-                (plasma.high_point[0], -blanket_rear_wall_end_height),
-                (plasma.high_point[0], -blanket_rear_wall_start_height),
+                (self._center_column_shield_end_radius, -self._blanket_rear_wall_start_height),
+                (self._center_column_shield_end_radius, -self._blanket_rear_wall_end_height),
+                (self._plasma.high_point[0], -self._blanket_rear_wall_end_height),
+                (self._plasma.high_point[0], -self._blanket_rear_wall_start_height),
             ],
             rotation_angle=self.rotation_angle,
         )
 
-        firstwall = paramak.BlanketConstantThicknessArcV(
-            inner_mid_point=(firstwall_start_radius, 0),
-            inner_upper_point=(plasma.high_point[0], firstwall_start_height),
-            inner_lower_point=(plasma.low_point[0], -firstwall_start_height),
+        self._firstwall = paramak.BlanketConstantThicknessArcV(
+            inner_mid_point=(self._firstwall_start_radius, 0),
+            inner_upper_point=(self._plasma.high_point[0], self._firstwall_start_height),
+            inner_lower_point=(self._plasma.low_point[0], -self._firstwall_start_height),
             thickness=self.firstwall_radial_thickness,
             rotation_angle=self.rotation_angle,
             stp_filename="firstwall.stp",
             stl_filename="firstwall.stl",
             name="firstwall",
             material_tag="firstwall_mat",
-            union=[extra_firstwall_upper, extra_firstwall_lower],
+            union=[self._extra_firstwall_upper, self._extra_firstwall_lower],
         )
 
-        blanket = paramak.BlanketConstantThicknessArcV(
-            inner_mid_point=(blanket_start_radius, 0),
-            inner_upper_point=(plasma.high_point[0], blanket_start_height),
-            inner_lower_point=(plasma.low_point[0], -blanket_start_height),
+        self._blanket = paramak.BlanketConstantThicknessArcV(
+            inner_mid_point=(self._blanket_start_radius, 0),
+            inner_upper_point=(self._plasma.high_point[0], self._blanket_start_height),
+            inner_lower_point=(self._plasma.low_point[0], -self._blanket_start_height),
             thickness=self.blanket_radial_thickness,
             rotation_angle=self.rotation_angle,
             stp_filename="blanket.stp",
             stl_filename="blanket.stl",
             name="blanket",
             material_tag="blanket_mat",
-            union=[extra_blanket_upper, extra_blanket_lower],
+            union=[self._extra_blanket_upper, self._extra_blanket_lower],
         )
 
-        blanket_rear_casing = paramak.BlanketConstantThicknessArcV(
-            inner_mid_point=(blanket_rear_wall_start_radius, 0),
-            inner_upper_point=(plasma.high_point[0], blanket_rear_wall_start_height),
-            inner_lower_point=(plasma.low_point[0], -blanket_rear_wall_start_height),
+        self._blanket_rear_casing = paramak.BlanketConstantThicknessArcV(
+            inner_mid_point=(self._blanket_rear_wall_start_radius, 0),
+            inner_upper_point=(self._plasma.high_point[0], self._blanket_rear_wall_start_height),
+            inner_lower_point=(self._plasma.low_point[0], -self._blanket_rear_wall_start_height),
             thickness=self.blanket_rear_wall_radial_thickness,
             rotation_angle=self.rotation_angle,
             stp_filename="blanket_rear_wall.stp",
             stl_filename="blanket_rear_wall.stl",
             name="blanket_rear_wall",
             material_tag="blanket_rear_wall_mat",
-            union=[extra_blanket_rear_wall_upper, extra_blanket_rear_wall_lower],
+            union=[self._extra_blanket_rear_wall_upper, self._extra_blanket_rear_wall_lower],
         )
 
-        return (
-            firstwall,
-            blanket,
-            blanket_rear_casing,
-            extra_blanket_upper,
-            extra_firstwall_upper,
-            extra_blanket_rear_wall_upper,
-            extra_blanket_lower,
-            extra_firstwall_lower,
-            extra_blanket_rear_wall_lower,
-        )
-
-    def make_divertor(
-        self,
-        shapes_or_components,
-        firstwall_start_radius,
-        firstwall_start_height,
-        extra_blanket_upper,
-        extra_firstwall_upper,
-        extra_blanket_rear_wall_upper,
-        extra_blanket_lower,
-        extra_firstwall_lower,
-        extra_blanket_rear_wall_lower,
-        plasma,
-        blanket_rear_wall_end_height,
-        divertor_start_radius,
-        divertor_end_radius,
-    ):
+    def make_divertor(self, shapes_or_components):
         # used as an intersect when making the divertor
-        blanket_fw_rear_wall_envelope = paramak.BlanketConstantThicknessArcV(
-            inner_mid_point=(firstwall_start_radius, 0),
-            inner_upper_point=(plasma.high_point[0], firstwall_start_height),
-            inner_lower_point=(plasma.low_point[0], -firstwall_start_height),
+        self._blanket_fw_rear_wall_envelope = paramak.BlanketConstantThicknessArcV(
+            inner_mid_point=(self._firstwall_start_radius, 0),
+            inner_upper_point=(self._plasma.high_point[0], self._firstwall_start_height),
+            inner_lower_point=(self._plasma.low_point[0], -self._firstwall_start_height),
             thickness=self.firstwall_radial_thickness
             + self.blanket_radial_thickness
             + self.blanket_rear_wall_radial_thickness,
             rotation_angle=self.rotation_angle,
             union=[
-                extra_blanket_upper,
-                extra_firstwall_upper,
-                extra_blanket_rear_wall_upper,
-                extra_blanket_lower,
-                extra_firstwall_lower,
-                extra_blanket_rear_wall_lower,
+                self._extra_blanket_upper,
+                self._extra_firstwall_upper,
+                self._extra_blanket_rear_wall_upper,
+                self._extra_blanket_lower,
+                self._extra_firstwall_lower,
+                self._extra_blanket_rear_wall_lower,
             ],
             stp_filename="test.stp",
         )
 
-        divertor = paramak.CenterColumnShieldCylinder(
-            height=blanket_rear_wall_end_height * 2,
-            inner_radius=divertor_start_radius,
-            outer_radius=divertor_end_radius,
-            intersect=blanket_fw_rear_wall_envelope,
+        self._divertor = paramak.CenterColumnShieldCylinder(
+            height=self._blanket_rear_wall_end_height * 2,
+            inner_radius=self._divertor_start_radius,
+            outer_radius=self._divertor_end_radius,
+            intersect=self._blanket_fw_rear_wall_envelope,
             stp_filename="divertor.stp",
             name="divertor",
             material_tag="divertor_mat",
             rotation_angle=self.rotation_angle
         )
-        shapes_or_components.append(divertor)
+        shapes_or_components.append(self._divertor)
 
-        return blanket_fw_rear_wall_envelope, divertor
-
-    def make_component_cuts(
-        self,
-        shapes_or_components,
-        firstwall,
-        blanket,
-        blanket_rear_casing,
-        divertor,
-        pf_coils_y_values,
-        pf_coils_x_values,
-        inboard_tf_coils_start_radius,
-        inboard_tf_coils_end_radius,
-        tf_coil_height,
-        tf_coil_start_radius,
-        cutting_slice,
-    ):
-        firstwall.solid = firstwall.solid.cut(divertor.solid)
-        blanket.solid = blanket.solid.cut(divertor.solid)
-        blanket_rear_casing.solid = blanket_rear_casing.solid.cut(
-            divertor.solid)
-        shapes_or_components.append(firstwall)
-        shapes_or_components.append(blanket)
-        shapes_or_components.append(blanket_rear_casing)
+    def make_component_cuts(self, shapes_or_components):
+        
+        self._firstwall.solid = self._firstwall.solid.cut(self._divertor.solid)
+        self._blanket.solid = self._blanket.solid.cut(self._divertor.solid)
+        self._blanket_rear_casing.solid = self._blanket_rear_casing.solid.cut(
+            self._divertor.solid)
+        shapes_or_components.append(self._firstwall)
+        shapes_or_components.append(self._blanket)
+        shapes_or_components.append(self._blanket_rear_casing)
 
         if (
             self.pf_coil_vertical_thicknesses is not None
@@ -698,12 +484,12 @@ class BallReactor(paramak.Reactor):
                 zip(
                     self.pf_coil_radial_thicknesses,
                     self.pf_coil_vertical_thicknesses,
-                    pf_coils_y_values,
-                    pf_coils_x_values,
+                    self._pf_coils_y_values,
+                    self._pf_coils_x_values,
                 )
             ):
 
-                pf_coil = paramak.PoloidalFieldCoil(
+                self._pf_coil = paramak.PoloidalFieldCoil(
                     width=rt,
                     height=vt,
                     center_point=(x_value, y_value),
@@ -713,16 +499,16 @@ class BallReactor(paramak.Reactor):
                     name="pf_coil",
                     material_tag="pf_coil_mat",
                 )
-                shapes_or_components.append(pf_coil)
+                shapes_or_components.append(self._pf_coil)
 
             if (
                 self.pf_coil_to_tf_coil_radial_gap is not None
                 and self.outboard_tf_coil_radial_thickness is not None
             ):
-                tf_coil = paramak.ToroidalFieldCoilRectangle(
-                    inner_upper_point=(inboard_tf_coils_start_radius, tf_coil_height),
-                    inner_lower_point=(inboard_tf_coils_start_radius, -tf_coil_height),
-                    inner_mid_point=(tf_coil_start_radius, 0),
+                self._tf_coil = paramak.ToroidalFieldCoilRectangle(
+                    inner_upper_point=(self._inboard_tf_coils_start_radius, self._tf_coil_height),
+                    inner_lower_point=(self._inboard_tf_coils_start_radius, -self._tf_coil_height),
+                    inner_mid_point=(self._tf_coil_start_radius, 0),
                     thickness=self.outboard_tf_coil_radial_thickness,
                     number_of_coils=self.number_of_tf_coils,
                     distance=self.tf_coil_poloidal_thickness,
@@ -730,7 +516,7 @@ class BallReactor(paramak.Reactor):
                     name="tf_coil",
                     material_tag="tf_coil_mat",
                     stl_filename="tf_coil.stl",
-                    cut=cutting_slice,
+                    cut=self._cutting_slice,
                 )
 
-                shapes_or_components.append(tf_coil)
+                shapes_or_components.append(self._tf_coil)

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -178,8 +178,8 @@ class BallReactor(paramak.Reactor):
 
         self._divertor_start_radius = self._center_column_shield_end_radius
         self._divertor_end_radius = (
-            self._center_column_shield_end_radius + self.divertor_radial_thickness
-        )
+            self._center_column_shield_end_radius +
+            self.divertor_radial_thickness)
 
         self._firstwall_start_radius = (
             self._center_column_shield_end_radius
@@ -187,7 +187,8 @@ class BallReactor(paramak.Reactor):
             + self.plasma_radial_thickness
             + self.outer_plasma_gap_radial_thickness
         )
-        self._firstwall_end_radius = self._firstwall_start_radius + self.firstwall_radial_thickness
+        self._firstwall_end_radius = self._firstwall_start_radius + \
+            self.firstwall_radial_thickness
 
         self._blanket_start_radius = self._firstwall_end_radius
         self._blanket_end_radius = self._blanket_start_radius + self.blanket_radial_thickness
@@ -197,7 +198,6 @@ class BallReactor(paramak.Reactor):
             self._blanket_rear_wall_start_radius +
             self.blanket_rear_wall_radial_thickness)
 
-
     def make_vertical_build(self, shapes_or_components):
 
         # this is the vertical build sequence, components build on each other in
@@ -206,7 +206,8 @@ class BallReactor(paramak.Reactor):
         self._firstwall_start_height = (
             self._plasma.high_point[1] + self.outer_plasma_gap_radial_thickness
         )
-        self._firstwall_end_height = self._firstwall_start_height + self.firstwall_radial_thickness
+        self._firstwall_end_height = self._firstwall_start_height + \
+            self.firstwall_radial_thickness
 
         self._blanket_start_height = self._firstwall_end_height
         self._blanket_end_height = self._blanket_start_height + self.blanket_radial_thickness
@@ -465,7 +466,7 @@ class BallReactor(paramak.Reactor):
         shapes_or_components.append(self._divertor)
 
     def make_component_cuts(self, shapes_or_components):
-        
+
         self._firstwall.solid = self._firstwall.solid.cut(self._divertor.solid)
         self._blanket.solid = self._blanket.solid.cut(self._divertor.solid)
         self._blanket_rear_casing.solid = self._blanket_rear_casing.solid.cut(

--- a/paramak/parametric_reactors/single_null_ball_reactor.py
+++ b/paramak/parametric_reactors/single_null_ball_reactor.py
@@ -72,179 +72,60 @@ class SingleNullBallReactor(paramak.BallReactor):
 
     def create_components_single_null(self):
 
-        # this calls each method for constructing the reactor components by passing the
-        # relevant parameters/objects to each method which return more objects
+        # this calls each method for constructing the reactor components
 
         shapes_or_components = []
 
-        plasma = self.make_plasma(shapes_or_components)
-
-        (
-            inner_bore_start_radius,
-            inner_bore_end_radius,
-            inboard_tf_coils_start_radius,
-            inboard_tf_coils_end_radius,
-            center_column_shield_start_radius,
-            center_column_shield_end_radius,
-            divertor_start_radius,
-            divertor_end_radius,
-            firstwall_start_radius,
-            firstwall_end_radius,
-            blanket_start_radius,
-            blanket_end_radius,
-            blanket_rear_wall_start_radius,
-            blanket_read_wall_end_radius,
-        ) = self.make_radial_build(shapes_or_components)
-
-        (
-            firstwall_start_height,
-            firstwall_end_height,
-            blanket_start_height,
-            blanket_end_height,
-            blanket_rear_wall_start_height,
-            blanket_rear_wall_end_height,
-            tf_coil_height,
-            center_column_shield_height,
-            pf_coil_start_radius,
-            pf_coil_end_radius,
-            pf_coils_y_values,
-            pf_coils_x_values,
-            tf_coil_start_radius,
-            tf_coil_end_radius,
-        ) = self.make_vertical_build(
-            shapes_or_components, plasma, blanket_read_wall_end_radius
-        )
-
-        inboard_tf_coils, cutting_slice = self.make_inboard_tf_coils(
-            shapes_or_components,
-            center_column_shield_height,
-            blanket_read_wall_end_radius,
-            tf_coil_height,
-            inboard_tf_coils_start_radius,
-            inboard_tf_coils_end_radius
-        )
-
-        center_column_shield = self.make_center_column_shield(
-            shapes_or_components,
-            center_column_shield_height,
-            center_column_shield_start_radius,
-            center_column_shield_end_radius,
-        )
-
-        (
-            firstwall,
-            blanket,
-            blanket_rear_casing,
-            extra_blanket_upper,
-            extra_firstwall_upper,
-            extra_blanket_rear_wall_upper,
-            extra_blanket_lower,
-            extra_firstwall_lower,
-            extra_blanket_rear_wall_lower,
-        ) = self.make_blanket_and_firstwall(
-            shapes_or_components,
-            center_column_shield_end_radius,
-            blanket_start_height,
-            blanket_end_height,
-            firstwall_start_height,
-            firstwall_end_height,
-            blanket_rear_wall_start_height,
-            blanket_rear_wall_end_height,
-            plasma,
-            firstwall_start_radius,
-            blanket_start_radius,
-            blanket_rear_wall_start_radius,
-        )
-
-        blanket_fw_rear_wall_envelope, divertor = self.make_divertor_single_null(
-            shapes_or_components,
-            firstwall_start_radius,
-            firstwall_start_height,
-            extra_blanket_upper,
-            extra_firstwall_upper,
-            extra_blanket_rear_wall_upper,
-            extra_blanket_lower,
-            extra_firstwall_lower,
-            extra_blanket_rear_wall_lower,
-            plasma,
-            blanket_rear_wall_end_height,
-            divertor_start_radius,
-            divertor_end_radius,
-        )
-
-        self.make_component_cuts(
-            shapes_or_components,
-            firstwall,
-            blanket,
-            blanket_rear_casing,
-            divertor,
-            pf_coils_y_values,
-            pf_coils_x_values,
-            inboard_tf_coils_start_radius,
-            inboard_tf_coils_end_radius,
-            tf_coil_height,
-            tf_coil_start_radius,
-            cutting_slice,
-        )
+        self.make_plasma(shapes_or_components)
+        self.make_radial_build(shapes_or_components)
+        self.make_vertical_build(shapes_or_components)
+        self.make_inboard_tf_coils(shapes_or_components)
+        self.make_center_column_shield(shapes_or_components)
+        self.make_blanket_and_firstwall(shapes_or_components)
+        self.make_divertor_single_null(shapes_or_components)
+        self.make_component_cuts(shapes_or_components)
 
         self.shapes_and_components = shapes_or_components
 
-    def make_divertor_single_null(
-        self,
-        shapes_or_components,
-        firstwall_start_radius,
-        firstwall_start_height,
-        extra_blanket_upper,
-        extra_firstwall_upper,
-        extra_blanket_rear_wall_upper,
-        extra_blanket_lower,
-        extra_firstwall_lower,
-        extra_blanket_rear_wall_lower,
-        plasma,
-        blanket_rear_wall_end_height,
-        divertor_start_radius,
-        divertor_end_radius
-    ):
+    def make_divertor_single_null(self, shapes_or_components):
 
         # used as an intersect when making the divertor
-        blanket_fw_rear_wall_envelope = paramak.BlanketConstantThicknessArcV(
-            inner_mid_point=(firstwall_start_radius, 0),
-            inner_upper_point=(plasma.high_point[0], firstwall_start_height),
-            inner_lower_point=(plasma.low_point[0], -firstwall_start_height),
+        self._blanket_fw_rear_wall_envelope = paramak.BlanketConstantThicknessArcV(
+            inner_mid_point=(self._firstwall_start_radius, 0),
+            inner_upper_point=(self._plasma.high_point[0], self._firstwall_start_height),
+            inner_lower_point=(self._plasma.low_point[0], -self._firstwall_start_height),
             thickness=self.firstwall_radial_thickness
             + self.blanket_radial_thickness
             + self.blanket_rear_wall_radial_thickness,
             rotation_angle=self.rotation_angle,
             union=[
-                extra_blanket_upper,
-                extra_firstwall_upper,
-                extra_blanket_rear_wall_upper,
-                extra_blanket_lower,
-                extra_firstwall_lower,
-                extra_blanket_rear_wall_lower,
+                self._extra_blanket_upper,
+                self._extra_firstwall_upper,
+                self._extra_blanket_rear_wall_upper,
+                self._extra_blanket_lower,
+                self._extra_firstwall_lower,
+                self._extra_blanket_rear_wall_lower,
             ],
             stp_filename="test.stp",
         )
 
         if self.divertor_position == "upper":
-            divertor_height = blanket_rear_wall_end_height
+            divertor_height = self._blanket_rear_wall_end_height
         elif self.divertor_position == "lower":
-            divertor_height = -blanket_rear_wall_end_height
+            divertor_height = -self._blanket_rear_wall_end_height
 
-        divertor = paramak.RotateStraightShape(
+        self._divertor = paramak.RotateStraightShape(
             points=[
-                (divertor_start_radius, 0),
-                (divertor_end_radius, 0),
-                (divertor_end_radius, divertor_height),
-                (divertor_start_radius, divertor_height)
+                (self._divertor_start_radius, 0),
+                (self._divertor_end_radius, 0),
+                (self._divertor_end_radius, divertor_height),
+                (self._divertor_start_radius, divertor_height)
             ],
-            intersect=blanket_fw_rear_wall_envelope,
+            intersect=self._blanket_fw_rear_wall_envelope,
             stp_filename="divertor.stp",
             stl_filename="divertor.stl",
             name="divertor",
             material_tag="divertor_mat",
             rotation_angle=self.rotation_angle
         )
-        shapes_or_components.append(divertor)
-
-        return blanket_fw_rear_wall_envelope, divertor
+        shapes_or_components.append(self._divertor)

--- a/tests/test_BallReactor.py
+++ b/tests/test_BallReactor.py
@@ -253,5 +253,3 @@ class test_BallReactor(unittest.TestCase):
         test_reactor.export_stp()
 
         assert len(test_reactor.shapes_and_components) == 12
-
-    


### PR DESCRIPTION
This PR changes the ball reactor to use parameters stored as attributes of the instance, i.e. self._attributes, rather than local parameters. This allows all parameters to be passed between the methods via self, rather than in large lists of attributes and return statements