### PR TITLE
Convert sub to self

### DIFF
--- a/paramak/parametric_reactors/single_null_submersion_reactor.py
+++ b/paramak/parametric_reactors/single_null_submersion_reactor.py
@@ -95,193 +95,65 @@ class SingleNullSubmersionTokamak(paramak.SubmersionTokamak):
 
     def create_components_single_null(self):
 
-        # this calls each method for constructing the reactor components by passing the
-        # relevant parameters/objects to each method which return more objects
+        # this calls each method for constructing the reactor components
 
         shapes_or_components = []
-
-        (
-            inner_bore_start_radius,
-            inner_bore_end_radius,
-            inboard_tf_coils_start_radius,
-            inboard_tf_coils_end_radius,
-            center_column_shield_start_radius,
-            center_column_shield_end_radius,
-            inboard_blanket_start_radius,
-            inboard_blanket_end_radius,
-            inboard_firstwall_start_radius,
-            inboard_firstwall_end_radius,
-            inner_plasma_gap_start_radius,
-            inner_plasma_gap_end_radius,
-            plasma_start_radius,
-            plasma_end_radius,
-            outer_plasma_gap_start_radius,
-            outer_plasma_gap_end_radius,
-            outboard_firstwall_start_radius,
-            outboard_firstwall_end_radius,
-            outboard_blanket_start_radius,
-            outboard_blanket_end_radius,
-            blanket_rear_wall_start_radius,
-            blanket_rear_wall_end_radius,
-            tf_info_provided,
-            pf_info_provided,
-            divertor_start_radius,
-            divertor_end_radius,
-            support_start_radius,
-            support_end_radius,
-            outboard_tf_coil_end_radius,
-            outboard_tf_coil_start_radius
-        ) = self.make_radial_build()
-
-        (
-            plasma_start_height,
-            plasma_end_height,
-            plasma_to_divertor_gap_start_height,
-            plasma_to_divertor_gap_end_height,
-            firstwall_start_height,
-            firstwall_end_height,
-            blanket_start_height,
-            blanket_end_height,
-            blanket_rear_wall_start_height,
-            blanket_rear_wall_end_height,
-            number_of_pf_coils,
-            pf_coils_y_values,
-            pf_coils_x_values,
-            pf_coil_start_radius,
-            pf_coil_end_radius,
-            cutting_slice
-        ) = self.make_vertical_build(tf_info_provided, pf_info_provided, plasma_start_radius, plasma_end_radius, blanket_rear_wall_end_radius, outboard_tf_coil_end_radius, outboard_tf_coil_start_radius)
-
-        inboard_tf_coils = self.make_inboard_tf_coils(
-            blanket_rear_wall_end_height,
-            inboard_tf_coils_start_radius,
-            inboard_tf_coils_end_radius
-        )
-
-        center_column_shield = self.make_center_column_shield(
-            shapes_or_components,
-            blanket_rear_wall_end_height,
-            center_column_shield_start_radius,
-            center_column_shield_end_radius
-        )
-
-        plasma = self.make_plasma(
-            shapes_or_components,
-            plasma_end_radius,
-            plasma_start_radius
-        )
-
-        inboard_firstwall, inboard_blanket, firstwall = self.make_inboard_blanket_and_firstwall(
-            shapes_or_components,
-            inboard_blanket_start_radius,
-            plasma,
-            blanket_end_height
-        )
-
-        divertor = self.make_divertor_single_null(
-            shapes_or_components,
-            blanket_rear_wall_end_height,
-            divertor_start_radius,
-            divertor_end_radius,
-            firstwall
-        )
-
-        blanket = self.make_outboard_blanket(
-            shapes_or_components,
-            plasma,
-            inboard_blanket
-        )
-
-        supports = self.make_supports_single_null(
-            shapes_or_components,
-            blanket_rear_wall_end_height,
-            support_start_radius,
-            support_end_radius,
-            blanket
-        )
-
-        self.make_component_cuts(
-            shapes_or_components,
-            firstwall,
-            center_column_shield_end_radius,
-            blanket_rear_wall_start_height,
-            blanket_rear_wall_end_height,
-            inboard_tf_coils_start_radius,
-            tf_info_provided,
-            pf_info_provided,
-            pf_coils_y_values,
-            pf_coils_x_values,
-            divertor,
-            plasma,
-            inboard_firstwall,
-            outboard_tf_coil_start_radius,
-            cutting_slice,
-            supports,
-            blanket
-        )
+        
+        self.make_radial_build()
+        self.make_vertical_build()
+        self.make_inboard_tf_coils(shapes_or_components)
+        self.make_center_column_shield(shapes_or_components)
+        self.make_plasma(shapes_or_components)
+        self.make_inboard_blanket_and_firstwall(shapes_or_components)
+        self.make_divertor_single_null(shapes_or_components)
+        self.make_outboard_blanket(shapes_or_components)
+        self.make_supports_single_null(shapes_or_components)
+        self.make_component_cuts(shapes_or_components)
 
         self.shapes_and_components = shapes_or_components
 
-    def make_divertor_single_null(
-        self, 
-        shapes_or_components, 
-        blanket_rear_wall_end_height, 
-        divertor_start_radius, 
-        divertor_end_radius, 
-        firstwall
-    ):
+    def make_divertor_single_null(self, shapes_or_components):
 
         if self.divertor_position == "upper":
-            divertor_height = blanket_rear_wall_end_height
+            divertor_height = self._blanket_rear_wall_end_height
         elif self.divertor_position == "lower":
-            divertor_height = -blanket_rear_wall_end_height
+            divertor_height = -self._blanket_rear_wall_end_height
 
-        divertor = paramak.RotateStraightShape(
+        self._divertor = paramak.RotateStraightShape(
             points=[
-                (divertor_start_radius, 0),
-                (divertor_end_radius, 0),
-                (divertor_end_radius, divertor_height),
-                (divertor_start_radius, divertor_height)
+                (self._divertor_start_radius, 0),
+                (self._divertor_end_radius, 0),
+                (self._divertor_end_radius, divertor_height),
+                (self._divertor_start_radius, divertor_height)
             ],
-            intersect=firstwall,
+            intersect=self._firstwall,
             rotation_angle=self.rotation_angle,
             stp_filename="divertor.stp",
             stl_filename="divertor.stl",
             name="divertor",
             material_tag="divertor_mat"
         )
-        shapes_or_components.append(divertor)
+        shapes_or_components.append(self._divertor)
 
-        return(divertor)
-
-    def make_supports_single_null(
-        self,
-        shapes_or_components,
-        blanket_rear_wall_end_height,
-        support_start_radius,
-        support_end_radius,
-        blanket 
-    ):
+    def make_supports_single_null(self, shapes_or_components):
 
         if self.support_position == "upper":
-            support_height = blanket_rear_wall_end_height
+            support_height = self._blanket_rear_wall_end_height
         elif self.support_position == "lower":
-            support_height = -blanket_rear_wall_end_height
+            support_height = -self._blanket_rear_wall_end_height
 
-        supports = paramak.RotateStraightShape(
+        self._supports = paramak.RotateStraightShape(
             points = [
-                (support_start_radius, 0),
-                (support_end_radius, 0),
-                (support_end_radius, support_height),
-                (support_start_radius, support_height)
+                (self._support_start_radius, 0),
+                (self._support_end_radius, 0),
+                (self._support_end_radius, support_height),
+                (self._support_start_radius, support_height)
             ],
-            intersect=blanket,
+            intersect=self._blanket,
             rotation_angle=self.rotation_angle,
             stp_filename="supports.stp",
             stl_filename="supports.stl",
             name="supports",
             material_tag="supports_mat",
         )
-        shapes_or_components.append(supports)
-
-        return supports
+        shapes_or_components.append(self._supports)

--- a/paramak/parametric_reactors/single_null_submersion_reactor.py
+++ b/paramak/parametric_reactors/single_null_submersion_reactor.py
@@ -1,7 +1,7 @@
 import math
 import operator
 
-import cadquery as cq 
+import cadquery as cq
 
 import paramak
 
@@ -36,28 +36,27 @@ class SingleNullSubmersionTokamak(paramak.SubmersionTokamak):
     ):
 
         super().__init__(
-            inner_bore_radial_thickness = inner_bore_radial_thickness,
-            inboard_tf_leg_radial_thickness = inboard_tf_leg_radial_thickness,
-            center_column_shield_radial_thickness = center_column_shield_radial_thickness,
-            inboard_blanket_radial_thickness = inboard_blanket_radial_thickness,
-            firstwall_radial_thickness = firstwall_radial_thickness,
-            inner_plasma_gap_radial_thickness = inner_plasma_gap_radial_thickness,
-            plasma_radial_thickness = plasma_radial_thickness,
-            outer_plasma_gap_radial_thickness = outer_plasma_gap_radial_thickness,
-            outboard_blanket_radial_thickness = outboard_blanket_radial_thickness,
-            blanket_rear_wall_radial_thickness = blanket_rear_wall_radial_thickness,
-            pf_coil_radial_thicknesses = pf_coil_radial_thicknesses,
-            pf_coil_to_tf_coil_radial_gap = pf_coil_to_tf_coil_radial_gap,
-            outboard_tf_coil_radial_thickness = outboard_tf_coil_radial_thickness,
-            tf_coil_poloidal_thickness = tf_coil_poloidal_thickness,
-            divertor_radial_thickness = divertor_radial_thickness,
-            support_radial_thickness = support_radial_thickness,
-            plasma_high_point = plasma_high_point,
-            tf_coil_to_rear_blanket_radial_gap = tf_coil_to_rear_blanket_radial_gap,
-            pf_coil_vertical_thicknesses = pf_coil_vertical_thicknesses,
-            number_of_tf_coils = number_of_tf_coils,
-            rotation_angle = rotation_angle
-        )
+            inner_bore_radial_thickness=inner_bore_radial_thickness,
+            inboard_tf_leg_radial_thickness=inboard_tf_leg_radial_thickness,
+            center_column_shield_radial_thickness=center_column_shield_radial_thickness,
+            inboard_blanket_radial_thickness=inboard_blanket_radial_thickness,
+            firstwall_radial_thickness=firstwall_radial_thickness,
+            inner_plasma_gap_radial_thickness=inner_plasma_gap_radial_thickness,
+            plasma_radial_thickness=plasma_radial_thickness,
+            outer_plasma_gap_radial_thickness=outer_plasma_gap_radial_thickness,
+            outboard_blanket_radial_thickness=outboard_blanket_radial_thickness,
+            blanket_rear_wall_radial_thickness=blanket_rear_wall_radial_thickness,
+            pf_coil_radial_thicknesses=pf_coil_radial_thicknesses,
+            pf_coil_to_tf_coil_radial_gap=pf_coil_to_tf_coil_radial_gap,
+            outboard_tf_coil_radial_thickness=outboard_tf_coil_radial_thickness,
+            tf_coil_poloidal_thickness=tf_coil_poloidal_thickness,
+            divertor_radial_thickness=divertor_radial_thickness,
+            support_radial_thickness=support_radial_thickness,
+            plasma_high_point=plasma_high_point,
+            tf_coil_to_rear_blanket_radial_gap=tf_coil_to_rear_blanket_radial_gap,
+            pf_coil_vertical_thicknesses=pf_coil_vertical_thicknesses,
+            number_of_tf_coils=number_of_tf_coils,
+            rotation_angle=rotation_angle)
 
         self.major_radius = None
         self.minor_radius = None
@@ -67,7 +66,6 @@ class SingleNullSubmersionTokamak(paramak.SubmersionTokamak):
         self.divertor_position = divertor_position
         self.support_position = support_position
         self.create_components_single_null()
-        
 
     @property
     def divertor_position(self):
@@ -98,7 +96,7 @@ class SingleNullSubmersionTokamak(paramak.SubmersionTokamak):
         # this calls each method for constructing the reactor components
 
         shapes_or_components = []
-        
+
         self.make_radial_build()
         self.make_vertical_build()
         self.make_inboard_tf_coils(shapes_or_components)
@@ -143,7 +141,7 @@ class SingleNullSubmersionTokamak(paramak.SubmersionTokamak):
             support_height = -self._blanket_rear_wall_end_height
 
         self._supports = paramak.RotateStraightShape(
-            points = [
+            points=[
                 (self._support_start_radius, 0),
                 (self._support_end_radius, 0),
                 (self._support_end_radius, support_height),

--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -121,130 +121,20 @@ class SubmersionTokamak(paramak.Reactor):
 
     def create_components(self):
 
-        # this calls each method for constructing the reactor components by passing the
-        # relevant parameters/objects to each method which return more objects
+        # this calls each method for constructing the reactor components
 
         shapes_or_components = []
 
-        (
-            inner_bore_start_radius,
-            inner_bore_end_radius,
-            inboard_tf_coils_start_radius,
-            inboard_tf_coils_end_radius,
-            center_column_shield_start_radius,
-            center_column_shield_end_radius,
-            inboard_blanket_start_radius,
-            inboard_blanket_end_radius,
-            inboard_firstwall_start_radius,
-            inboard_firstwall_end_radius,
-            inner_plasma_gap_start_radius,
-            inner_plasma_gap_end_radius,
-            plasma_start_radius,
-            plasma_end_radius,
-            outer_plasma_gap_start_radius,
-            outer_plasma_gap_end_radius,
-            outboard_firstwall_start_radius,
-            outboard_firstwall_end_radius,
-            outboard_blanket_start_radius,
-            outboard_blanket_end_radius,
-            blanket_rear_wall_start_radius,
-            blanket_rear_wall_end_radius,
-            tf_info_provided,
-            pf_info_provided,
-            divertor_start_radius,
-            divertor_end_radius,
-            support_start_radius,
-            support_end_radius,
-            outboard_tf_coil_end_radius,
-            outboard_tf_coil_start_radius
-        ) = self.make_radial_build()
-
-        (
-            plasma_start_height,
-            plasma_end_height,
-            plasma_to_divertor_gap_start_height,
-            plasma_to_divertor_gap_end_height,
-            firstwall_start_height,
-            firstwall_end_height,
-            blanket_start_height,
-            blanket_end_height,
-            blanket_rear_wall_start_height,
-            blanket_rear_wall_end_height,
-            number_of_pf_coils,
-            pf_coils_y_values,
-            pf_coils_x_values,
-            pf_coil_start_radius,
-            pf_coil_end_radius,
-            cutting_slice
-        ) = self.make_vertical_build(tf_info_provided, pf_info_provided, plasma_start_radius, plasma_end_radius, blanket_rear_wall_end_radius, outboard_tf_coil_end_radius, outboard_tf_coil_start_radius)
-
-        inboard_tf_coils = self.make_inboard_tf_coils(
-            blanket_rear_wall_end_height,
-            inboard_tf_coils_start_radius,
-            inboard_tf_coils_end_radius,
-        )
-
-        center_column_shield = self.make_center_column_shield(
-            shapes_or_components,
-            blanket_rear_wall_end_height,
-            center_column_shield_start_radius,
-            center_column_shield_end_radius,
-        )
-
-        plasma = self.make_plasma(
-            shapes_or_components,
-            plasma_end_radius,
-            plasma_start_radius,
-        )
-
-        inboard_firstwall, inboard_blanket, firstwall = self.make_inboard_blanket_and_firstwall(
-            shapes_or_components,
-            inboard_blanket_start_radius,
-            plasma,
-            blanket_end_height,
-        )
-
-        divertor = self.make_divertor(
-            shapes_or_components,
-            blanket_rear_wall_end_height,
-            divertor_start_radius,
-            divertor_end_radius,
-            firstwall
-        )
-
-        blanket = self.make_outboard_blanket(
-            shapes_or_components,
-            plasma,
-            inboard_blanket
-        )
-
-        supports = self.make_supports(
-            shapes_or_components,
-            blanket_rear_wall_end_height,
-            support_start_radius,
-            support_end_radius,
-            blanket
-        )
-
-        self.make_component_cuts(
-            shapes_or_components,
-            firstwall,
-            center_column_shield_end_radius,
-            blanket_rear_wall_start_height,
-            blanket_rear_wall_end_height,
-            inboard_tf_coils_start_radius,
-            tf_info_provided,
-            pf_info_provided,
-            pf_coils_y_values,
-            pf_coils_x_values,
-            divertor,
-            plasma,
-            inboard_firstwall,
-            outboard_tf_coil_start_radius,
-            cutting_slice,
-            supports,
-            blanket
-        )
+        self.make_radial_build()
+        self.make_vertical_build()
+        self.make_inboard_tf_coils(shapes_or_components)
+        self.make_center_column_shield(shapes_or_components)
+        self.make_plasma(shapes_or_components)
+        self.make_inboard_blanket_and_firstwall(shapes_or_components)
+        self.make_divertor(shapes_or_components)
+        self.make_outboard_blanket(shapes_or_components)
+        self.make_supports(shapes_or_components)
+        self.make_component_cuts(shapes_or_components)
 
         self.shapes_and_components = shapes_or_components
 
@@ -253,225 +143,184 @@ class SubmersionTokamak(paramak.Reactor):
         # this is the radial build sequence, where one component stops and
         # another starts
 
-        inner_bore_start_radius = 0
-        inner_bore_end_radius = (
-            inner_bore_start_radius + self.inner_bore_radial_thickness
+        self._inner_bore_start_radius = 0
+        self._inner_bore_end_radius = (
+            self._inner_bore_start_radius + self.inner_bore_radial_thickness
         )
 
-        inboard_tf_coils_start_radius = inner_bore_end_radius
-        inboard_tf_coils_end_radius = (
-            inboard_tf_coils_start_radius +
+        self._inboard_tf_coils_start_radius = self._inner_bore_end_radius
+        self._inboard_tf_coils_end_radius = (
+            self._inboard_tf_coils_start_radius +
             self.inboard_tf_leg_radial_thickness)
 
-        center_column_shield_start_radius = inboard_tf_coils_end_radius
-        center_column_shield_end_radius = (
-            center_column_shield_start_radius
+        self._center_column_shield_start_radius = self._inboard_tf_coils_end_radius
+        self._center_column_shield_end_radius = (
+            self._center_column_shield_start_radius
             + self.center_column_shield_radial_thickness
         )
 
-        inboard_blanket_start_radius = center_column_shield_end_radius
-        inboard_blanket_end_radius = (
-            inboard_blanket_start_radius +
+        self._inboard_blanket_start_radius = self._center_column_shield_end_radius
+        self._inboard_blanket_end_radius = (
+            self._inboard_blanket_start_radius +
             self.inboard_blanket_radial_thickness)
 
-        inboard_firstwall_start_radius = inboard_blanket_end_radius
-        inboard_firstwall_end_radius = (
-            inboard_firstwall_start_radius + self.firstwall_radial_thickness
+        self._inboard_firstwall_start_radius = self._inboard_blanket_end_radius
+        self._inboard_firstwall_end_radius = (
+            self._inboard_firstwall_start_radius + self.firstwall_radial_thickness
         )
 
-        inner_plasma_gap_start_radius = inboard_firstwall_end_radius
-        inner_plasma_gap_end_radius = (
-            inner_plasma_gap_start_radius +
+        self._inner_plasma_gap_start_radius = self._inboard_firstwall_end_radius
+        self._inner_plasma_gap_end_radius = (
+            self._inner_plasma_gap_start_radius +
             self.inner_plasma_gap_radial_thickness)
 
-        plasma_start_radius = inner_plasma_gap_end_radius
-        plasma_end_radius = plasma_start_radius + self.plasma_radial_thickness
+        self._plasma_start_radius = self._inner_plasma_gap_end_radius
+        self._plasma_end_radius = self._plasma_start_radius + self.plasma_radial_thickness
 
-        outer_plasma_gap_start_radius = plasma_end_radius
-        outer_plasma_gap_end_radius = (
-            outer_plasma_gap_start_radius +
+        self._outer_plasma_gap_start_radius = self._plasma_end_radius
+        self._outer_plasma_gap_end_radius = (
+            self._outer_plasma_gap_start_radius +
             self.outer_plasma_gap_radial_thickness)
 
-        outboard_firstwall_start_radius = outer_plasma_gap_end_radius
-        outboard_firstwall_end_radius = (
-            outboard_firstwall_start_radius + self.firstwall_radial_thickness
+        self._outboard_firstwall_start_radius = self._outer_plasma_gap_end_radius
+        self._outboard_firstwall_end_radius = (
+            self._outboard_firstwall_start_radius + self.firstwall_radial_thickness
         )
 
-        outboard_blanket_start_radius = outboard_firstwall_end_radius
-        outboard_blanket_end_radius = (
-            outboard_blanket_start_radius +
+        self._outboard_blanket_start_radius = self._outboard_firstwall_end_radius
+        self._outboard_blanket_end_radius = (
+            self._outboard_blanket_start_radius +
             self.outboard_blanket_radial_thickness)
 
-        blanket_rear_wall_start_radius = outboard_blanket_end_radius
-        blanket_rear_wall_end_radius = (
-            blanket_rear_wall_start_radius +
+        self._blanket_rear_wall_start_radius = self._outboard_blanket_end_radius
+        self._blanket_rear_wall_end_radius = (
+            self._blanket_rear_wall_start_radius +
             self.blanket_rear_wall_radial_thickness)
 
-        tf_info_provided = False
+        self._tf_info_provided = False
         if (
             self.outboard_tf_coil_radial_thickness is not None
             and self.tf_coil_to_rear_blanket_radial_gap is not None
             and self.tf_coil_poloidal_thickness is not None
         ):
-            tf_info_provided = True
-            outboard_tf_coil_start_radius = (
-                blanket_rear_wall_end_radius +
+            self._tf_info_provided = True
+            self._outboard_tf_coil_start_radius = (
+                self._blanket_rear_wall_end_radius +
                 self.tf_coil_to_rear_blanket_radial_gap)
-            outboard_tf_coil_end_radius = (
-                outboard_tf_coil_start_radius +
+            self._outboard_tf_coil_end_radius = (
+                self._outboard_tf_coil_start_radius +
                 self.outboard_tf_coil_radial_thickness)
         
         else:
-            outboard_tf_coil_end_radius = None
-            outboard_tf_coil_start_radius = None
+            self._outboard_tf_coil_end_radius = None
+            self._outboard_tf_coil_start_radius = None
 
-        pf_info_provided = False
+        self._pf_info_provided = False
         if (
             self.pf_coil_vertical_thicknesses is not None
             and self.pf_coil_radial_thicknesses is not None
             and self.pf_coil_to_tf_coil_radial_gap is not None
         ):
-            pf_info_provided = True
+            self._pf_info_provided = True
 
-        divertor_start_radius = (
+        self._divertor_start_radius = (
             self.plasma_high_point[0] - 0.5 * self.divertor_radial_thickness
         )
-        divertor_end_radius = (
+        self._divertor_end_radius = (
             self.plasma_high_point[0] + 0.5 * self.divertor_radial_thickness
         )
 
-        support_start_radius = (
+        self._support_start_radius = (
             self.plasma_high_point[0] - 0.5 * self.support_radial_thickness
         )
-        support_end_radius = (
+        self._support_end_radius = (
             self.plasma_high_point[0] + 0.5 * self.support_radial_thickness
         )
 
-        return (
-            inner_bore_start_radius,
-            inner_bore_end_radius,
-            inboard_tf_coils_start_radius,
-            inboard_tf_coils_end_radius,
-            center_column_shield_start_radius,
-            center_column_shield_end_radius,
-            inboard_blanket_start_radius,
-            inboard_blanket_end_radius,
-            inboard_firstwall_start_radius,
-            inboard_firstwall_end_radius,
-            inner_plasma_gap_start_radius,
-            inner_plasma_gap_end_radius,
-            plasma_start_radius,
-            plasma_end_radius,
-            outer_plasma_gap_start_radius,
-            outer_plasma_gap_end_radius,
-            outboard_firstwall_start_radius,
-            outboard_firstwall_end_radius,
-            outboard_blanket_start_radius,
-            outboard_blanket_end_radius,
-            blanket_rear_wall_start_radius,
-            blanket_rear_wall_end_radius,
-            tf_info_provided,
-            pf_info_provided,
-            divertor_start_radius,
-            divertor_end_radius,
-            support_start_radius,
-            support_end_radius,
-            outboard_tf_coil_end_radius,
-            outboard_tf_coil_start_radius
-        )
 
-    def make_vertical_build(
-        self, 
-        tf_info_provided, 
-        pf_info_provided, 
-        plasma_start_radius, 
-        plasma_end_radius, 
-        blanket_rear_wall_end_radius,
-        outboard_tf_coil_end_radius,
-        outboard_tf_coil_start_radius
-    ):
+    def make_vertical_build(self):
         
         # this is the vertical build sequence, componets build on each other in
         # a similar manner to the radial build
         
-        plasma_start_height = 0
-        plasma_end_height = plasma_start_height + self.plasma_high_point[1]
+        self._plasma_start_height = 0
+        self._plasma_end_height = self._plasma_start_height + self.plasma_high_point[1]
 
-        plasma_to_divertor_gap_start_height = plasma_end_height
-        plasma_to_divertor_gap_end_height = (
-            plasma_to_divertor_gap_start_height +
+        self._plasma_to_divertor_gap_start_height = self._plasma_end_height
+        self._plasma_to_divertor_gap_end_height = (
+            self._plasma_to_divertor_gap_start_height +
             self.outer_plasma_gap_radial_thickness)
 
         # the firstwall is cut by the divertor but uses the same control points
-        firstwall_start_height = plasma_to_divertor_gap_end_height
-        firstwall_end_height = firstwall_start_height + self.firstwall_radial_thickness
+        self._firstwall_start_height = self._plasma_to_divertor_gap_end_height
+        self._firstwall_end_height = self._firstwall_start_height + self.firstwall_radial_thickness
 
-        blanket_start_height = firstwall_end_height
-        blanket_end_height = (
-            blanket_start_height + self.outboard_blanket_radial_thickness
+        self._blanket_start_height = self._firstwall_end_height
+        self._blanket_end_height = (
+            self._blanket_start_height + self.outboard_blanket_radial_thickness
         )
 
-        blanket_rear_wall_start_height = blanket_end_height
-        blanket_rear_wall_end_height = (
-            blanket_rear_wall_start_height +
+        self._blanket_rear_wall_start_height = self._blanket_end_height
+        self._blanket_rear_wall_end_height = (
+            self._blanket_rear_wall_start_height +
             self.blanket_rear_wall_radial_thickness)
 
-        if tf_info_provided and pf_info_provided:
-            number_of_pf_coils = len(self.pf_coil_vertical_thicknesses)
+        if self._tf_info_provided and self._pf_info_provided:
+            self._number_of_pf_coils = len(self.pf_coil_vertical_thicknesses)
 
-            y_position_step = (2 * blanket_rear_wall_end_height) / (
-                number_of_pf_coils + 1
+            y_position_step = (2 * self._blanket_rear_wall_end_height) / (
+                self._number_of_pf_coils + 1
             )
 
-            pf_coils_y_values = []
-            pf_coils_x_values = []
+            self._pf_coils_y_values = []
+            self._pf_coils_x_values = []
             # adds in coils with equal spacing strategy, should be updated to
             # allow user positions
-            for i in range(number_of_pf_coils):
+            for i in range(self._number_of_pf_coils):
                 y_value = (
-                    blanket_rear_wall_end_height
+                    self._blanket_rear_wall_end_height
                     + self.pf_coil_to_tf_coil_radial_gap
                     - y_position_step * (i + 1)
                 )
                 x_value = (
-                    outboard_tf_coil_end_radius
+                    self._outboard_tf_coil_end_radius
                     + self.pf_coil_to_tf_coil_radial_gap
                     + 0.5 * self.pf_coil_radial_thicknesses[i]
                 )
-                pf_coils_y_values.append(y_value)
-                pf_coils_x_values.append(x_value)
+                self._pf_coils_y_values.append(y_value)
+                self._pf_coils_x_values.append(x_value)
 
-            pf_coil_start_radius = (
-                outboard_tf_coil_end_radius +
+            self._pf_coil_start_radius = (
+                self._outboard_tf_coil_end_radius +
                 self.pf_coil_to_tf_coil_radial_gap)
-            pf_coil_end_radius = pf_coil_start_radius + max(
+            self._pf_coil_end_radius = self._pf_coil_start_radius + max(
                 self.pf_coil_radial_thicknesses
             )
         
         else:
-            number_of_pf_coils = None
-            pf_coils_y_values = None
-            pf_coils_x_values = None
-            pf_coil_start_radius = None
-            pf_coil_end_radius = None
+            self._number_of_pf_coils = None
+            self._pf_coils_y_values = None
+            self._pf_coils_x_values = None
+            self._pf_coil_start_radius = None
+            self._pf_coil_end_radius = None
 
         # raises an error if the plasma high point is not above part of the
         # plasma
-        if self.plasma_high_point[0] < plasma_start_radius:
+        if self.plasma_high_point[0] < self._plasma_start_radius:
             raise ValueError(
                 "The first value in plasma high_point is too small, it should be larger than",
-                plasma_start_radius,
+                self._plasma_start_radius,
             )
-        if self.plasma_high_point[0] > plasma_end_radius:
+        if self.plasma_high_point[0] > self._plasma_end_radius:
             raise ValueError(
                 "The first value in plasma high_point is too large, it should be smaller than",
-                plasma_end_radius,
+                self._plasma_end_radius,
             )
 
         if self.rotation_angle < 360:
-            max_high = 3 * blanket_rear_wall_end_height
-            max_width = 3 * blanket_rear_wall_end_radius
-            cutting_slice = paramak.RotateStraightShape(
+            max_high = 3 * self._blanket_rear_wall_end_height
+            max_width = 3 * self._blanket_rear_wall_end_radius
+            self._cutting_slice = paramak.RotateStraightShape(
                 points=[
                     (0, max_high),
                     (max_width, max_high),
@@ -482,108 +331,59 @@ class SubmersionTokamak(paramak.Reactor):
                 azimuth_placement_angle=360 - self.rotation_angle,
             )
         else:
-            cutting_slice = None
+            self._cutting_slice = None
 
-        return (
-            plasma_start_height,
-            plasma_end_height,
-            plasma_to_divertor_gap_start_height,
-            plasma_to_divertor_gap_end_height,
-            firstwall_start_height,
-            firstwall_end_height,
-            blanket_start_height,
-            blanket_end_height,
-            blanket_rear_wall_start_height,
-            blanket_rear_wall_end_height,
-            number_of_pf_coils,
-            pf_coils_y_values,
-            pf_coils_x_values,
-            pf_coil_start_radius,
-            pf_coil_end_radius,
-            cutting_slice
-        )
-
-    def make_inboard_tf_coils(
-        self, 
-        blanket_rear_wall_end_height, 
-        inboard_tf_coils_start_radius, 
-        inboard_tf_coils_end_radius
-    ):    
-
-        shapes_or_components = []
+    def make_inboard_tf_coils(self, shapes_or_components):
 
         # shapes_or_components.append(inboard_tf_coils)
-        inboard_tf_coils = paramak.CenterColumnShieldCylinder(
-            height=blanket_rear_wall_end_height * 2,
-            inner_radius=inboard_tf_coils_start_radius,
-            outer_radius=inboard_tf_coils_end_radius,
+        self._inboard_tf_coils = paramak.CenterColumnShieldCylinder(
+            height=self._blanket_rear_wall_end_height * 2,
+            inner_radius=self._inboard_tf_coils_start_radius,
+            outer_radius=self._inboard_tf_coils_end_radius,
             rotation_angle=self.rotation_angle,
             stp_filename="inboard_tf_coils.stp",
             stl_filename="inboard_tf_coils.stl",
             name="inboard_tf_coils",
             material_tag="inboard_tf_coils_mat",
         )
-        shapes_or_components.append(inboard_tf_coils)
+        shapes_or_components.append(self._inboard_tf_coils)
 
-        return inboard_tf_coils
+    def make_center_column_shield(self, shapes_or_components):
 
-    def make_center_column_shield(
-        self, 
-        shapes_or_components, 
-        blanket_rear_wall_end_height, 
-        center_column_shield_start_radius, 
-        center_column_shield_end_radius
-    ):
-
-        center_column_shield = paramak.CenterColumnShieldCylinder(
-            height=blanket_rear_wall_end_height * 2,
-            inner_radius=center_column_shield_start_radius,
-            outer_radius=center_column_shield_end_radius,
+        self._center_column_shield = paramak.CenterColumnShieldCylinder(
+            height=self._blanket_rear_wall_end_height * 2,
+            inner_radius=self._center_column_shield_start_radius,
+            outer_radius=self._center_column_shield_end_radius,
             rotation_angle=self.rotation_angle,
             stp_filename="center_column_shield.stp",
             stl_filename="center_column_shield.stl",
             name="center_column_shield",
             material_tag="center_column_shield_mat",
         )
-        shapes_or_components.append(center_column_shield)
+        shapes_or_components.append(self._center_column_shield)
 
-        return center_column_shield
+    def make_plasma(self, shapes_or_components):
 
-    def make_plasma(
-        self, 
-        shapes_or_components, 
-        plasma_end_radius, 
-        plasma_start_radius
-    ):
-
-        plasma = paramak.PlasmaFromPoints(
-            outer_equatorial_x_point=plasma_end_radius,
-            inner_equatorial_x_point=plasma_start_radius,
+        self._plasma = paramak.PlasmaFromPoints(
+            outer_equatorial_x_point=self._plasma_end_radius,
+            inner_equatorial_x_point=self._plasma_start_radius,
             high_point=self.plasma_high_point,
             rotation_angle=self.rotation_angle,
         )
 
-        self.major_radius = plasma.major_radius
-        self.minor_radius = plasma.minor_radius
-        self.elongation = plasma.elongation
-        self.triangularity = plasma.triangularity
+        self.major_radius = self._plasma.major_radius
+        self.minor_radius = self._plasma.minor_radius
+        self.elongation = self._plasma.elongation
+        self.triangularity = self._plasma.triangularity
 
-        shapes_or_components.append(plasma)
+        shapes_or_components.append(self._plasma)
 
-        return plasma
-
-    def make_inboard_blanket_and_firstwall(
-        self, 
-        shapes_or_components, 
-        inboard_blanket_start_radius, 
-        plasma, 
-        blanket_end_height
-    ):
+    def make_inboard_blanket_and_firstwall(self, shapes_or_components):
 
         # this is used to cut the inboard blanket and then fused / unioned with
         # the firstwall
-        inboard_firstwall = paramak.BlanketFP(
-            plasma=plasma,
+        self._inboard_firstwall = paramak.BlanketFP(
+            plasma=self._plasma,
             offset_from_plasma=self.inner_plasma_gap_radial_thickness,
             start_angle=90,
             stop_angle=270,
@@ -591,22 +391,22 @@ class SubmersionTokamak(paramak.Reactor):
             rotation_angle=self.rotation_angle,
         )
 
-        inboard_blanket = paramak.CenterColumnShieldCylinder(
-            height=blanket_end_height * 2,
-            inner_radius=inboard_blanket_start_radius,
-            outer_radius=max([item[0] for item in inboard_firstwall.points]),
+        self._inboard_blanket = paramak.CenterColumnShieldCylinder(
+            height=self._blanket_end_height * 2,
+            inner_radius=self._inboard_blanket_start_radius,
+            outer_radius=max([item[0] for item in self._inboard_firstwall.points]),
             rotation_angle=self.rotation_angle,
-            cut=inboard_firstwall,
+            cut=self._inboard_firstwall,
         )
 
         # this takes a single solid from a compound of solids by finding the
         # solid nearest to a point
-        inboard_blanket.solid = inboard_blanket.solid.solids(
+        self._inboard_blanket.solid = self._inboard_blanket.solid.solids(
             cq.selectors.NearestToPointSelector((0, 0, 0))
         )
 
-        firstwall = paramak.BlanketFP(
-            plasma=plasma,
+        self._firstwall = paramak.BlanketFP(
+            plasma=self._plasma,
             offset_from_plasma=self.outer_plasma_gap_radial_thickness,
             start_angle=90,
             stop_angle=-90,
@@ -616,50 +416,30 @@ class SubmersionTokamak(paramak.Reactor):
             stl_filename="outboard_firstwall.stl",
             name="outboard_firstwall",
             material_tag="firstwall_mat",
-            union=inboard_firstwall,
+            union=self._inboard_firstwall,
         )
 
-        return (
-            inboard_firstwall,
-            inboard_blanket,
-            firstwall
-        )
+    def make_divertor(self, shapes_or_components):
 
-    def make_divertor(
-        self, 
-        shapes_or_components, 
-        blanket_rear_wall_end_height, 
-        divertor_start_radius, 
-        divertor_end_radius, 
-        firstwall
-    ):
-
-        divertor = paramak.CenterColumnShieldCylinder(
-            height=blanket_rear_wall_end_height * 2,
-            inner_radius=divertor_start_radius,
-            outer_radius=divertor_end_radius,
+        self._divertor = paramak.CenterColumnShieldCylinder(
+            height=self._blanket_rear_wall_end_height * 2,
+            inner_radius=self._divertor_start_radius,
+            outer_radius=self._divertor_end_radius,
             rotation_angle=self.rotation_angle,
             stp_filename="divertor.stp",
             stl_filename="divertor.stl",
             name="divertor",
             material_tag="divertor_mat",
-            intersect=firstwall,
+            intersect=self._firstwall,
         )
-        shapes_or_components.append(divertor)
+        shapes_or_components.append(self._divertor)
 
-        return(divertor)
-
-    def make_outboard_blanket(
-        self,
-        shapes_or_components,
-        plasma,
-        inboard_blanket
-    ):
+    def make_outboard_blanket(self, shapes_or_components):
 
         # this is the outboard fused /unioned with the inboard blanket
 
-        blanket = paramak.BlanketFP(
-            plasma=plasma,
+        self._blanket = paramak.BlanketFP(
+            plasma=self._plasma,
             start_angle=90,
             stop_angle=-90,
             offset_from_plasma=self.outer_plasma_gap_radial_thickness
@@ -670,104 +450,73 @@ class SubmersionTokamak(paramak.Reactor):
             stl_filename="blanket.stl",
             name="blanket",
             material_tag="blanket_mat",
-            union=inboard_blanket,
+            union=self._inboard_blanket,
         )
 
-        return blanket
+    def make_supports(self, shapes_or_components):
 
-    def make_supports(
-        self,
-        shapes_or_components,
-        blanket_rear_wall_end_height,
-        support_start_radius,
-        support_end_radius,
-        blanket
-    ):
-
-        supports = paramak.CenterColumnShieldCylinder(
-            height=blanket_rear_wall_end_height * 2,
-            inner_radius=support_start_radius,
-            outer_radius=support_end_radius,
+        self._supports = paramak.CenterColumnShieldCylinder(
+            height=self._blanket_rear_wall_end_height * 2,
+            inner_radius=self._support_start_radius,
+            outer_radius=self._support_end_radius,
             rotation_angle=self.rotation_angle,
             stp_filename="supports.stp",
             stl_filename="supports.stl",
             name="supports",
             material_tag="supports_mat",
-            intersect=blanket,
+            intersect=self._blanket,
         )
-        shapes_or_components.append(supports)
+        shapes_or_components.append(self._supports)
 
-        return supports
-
-    def make_component_cuts(
-        self, 
-        shapes_or_components,
-        firstwall,
-        center_column_shield_end_radius,
-        blanket_rear_wall_start_height,
-        blanket_rear_wall_end_height,
-        inboard_tf_coils_start_radius,
-        tf_info_provided,
-        pf_info_provided,
-        pf_coils_y_values,
-        pf_coils_x_values,
-        divertor,
-        plasma,
-        inboard_firstwall,
-        outboard_tf_coil_start_radius,
-        cutting_slice,
-        supports,
-        blanket,
-    ):
+    def make_component_cuts(self, shapes_or_components):
 
         # the divertor is cut away then the firstwall can be added to the
         # reactor using CQ operations
-        firstwall.solid = firstwall.solid.cut(divertor.solid)
-        shapes_or_components.append(firstwall)
+        self._firstwall.solid = self._firstwall.solid.cut(self._divertor.solid)
+        shapes_or_components.append(self._firstwall)
 
         # cutting the supports away from the blanket
-        blanket.solid = blanket.solid.cut(supports.solid)
-        shapes_or_components.append(blanket)
+        self._blanket.solid = self._blanket.solid.cut(self._supports.solid)
+        shapes_or_components.append(self._blanket)
 
         # shapes_or_components.append(outboard_rear_blanket_wall)
 
-        outboard_rear_blanket_wall_upper = paramak.RotateStraightShape(
+        self._outboard_rear_blanket_wall_upper = paramak.RotateStraightShape(
             points=[
-                (center_column_shield_end_radius, blanket_rear_wall_start_height),
-                (center_column_shield_end_radius, blanket_rear_wall_end_height),
+                (self._center_column_shield_end_radius, self._blanket_rear_wall_start_height),
+                (self._center_column_shield_end_radius, self._blanket_rear_wall_end_height),
                 (
-                    max([item[0] for item in inboard_firstwall.points]),
-                    blanket_rear_wall_end_height,
+                    max([item[0] for item in self._inboard_firstwall.points]),
+                    self._blanket_rear_wall_end_height,
                 ),
                 (
-                    max([item[0] for item in inboard_firstwall.points]),
-                    blanket_rear_wall_start_height,
+                    max([item[0] for item in self._inboard_firstwall.points]),
+                    self._blanket_rear_wall_start_height,
                 ),
             ],
             rotation_angle=self.rotation_angle,
         )
 
-        outboard_rear_blanket_wall_lower = paramak.RotateStraightShape(
+        self._outboard_rear_blanket_wall_lower = paramak.RotateStraightShape(
             points=[
-                (center_column_shield_end_radius, -blanket_rear_wall_start_height),
-                (center_column_shield_end_radius, -blanket_rear_wall_end_height),
+                (self._center_column_shield_end_radius, -self._blanket_rear_wall_start_height),
+                (self._center_column_shield_end_radius, -self._blanket_rear_wall_end_height),
                 (
-                    max([item[0] for item in inboard_firstwall.points]),
-                    -blanket_rear_wall_end_height,
+                    max([item[0] for item in self._inboard_firstwall.points]),
+                    -self._blanket_rear_wall_end_height,
                 ),
                 (
-                    max([item[0] for item in inboard_firstwall.points]),
-                    -blanket_rear_wall_start_height,
+                    max([item[0] for item in self._inboard_firstwall.points]),
+                    -self._blanket_rear_wall_start_height,
                 ),
             ],
             rotation_angle=self.rotation_angle,
         )
 
-        outboard_rear_blanket_wall = paramak.BlanketFP(
-            plasma=plasma,
+        self._outboard_rear_blanket_wall = paramak.BlanketFP(
+            plasma=self._plasma,
             start_angle=90,
-            stop_angle=-
-            90,
+            stop_angle=-90,
             offset_from_plasma=self.outer_plasma_gap_radial_thickness +
             self.firstwall_radial_thickness +
             self.outboard_blanket_radial_thickness,
@@ -778,44 +527,44 @@ class SubmersionTokamak(paramak.Reactor):
             name="outboard_rear_blanket_wall",
             material_tag="rear_blanket_wall_mat",
             union=[
-                outboard_rear_blanket_wall_upper,
-                outboard_rear_blanket_wall_lower],
+                self._outboard_rear_blanket_wall_upper,
+                self._outboard_rear_blanket_wall_lower],
         )
 
-        shapes_or_components.append(outboard_rear_blanket_wall)
+        shapes_or_components.append(self._outboard_rear_blanket_wall)
 
-        if tf_info_provided:
-            tf_coil = paramak.ToroidalFieldCoilRectangle(
+        if self._tf_info_provided:
+            self._tf_coil = paramak.ToroidalFieldCoilRectangle(
                 inner_upper_point=(
-                    inboard_tf_coils_start_radius,
-                    blanket_rear_wall_end_height,
+                    self._inboard_tf_coils_start_radius,
+                    self._blanket_rear_wall_end_height,
                 ),
                 inner_lower_point=(
-                    inboard_tf_coils_start_radius,
-                    -blanket_rear_wall_end_height,
+                    self._inboard_tf_coils_start_radius,
+                    -self._blanket_rear_wall_end_height,
                 ),
-                inner_mid_point=(outboard_tf_coil_start_radius, 0),
+                inner_mid_point=(self._outboard_tf_coil_start_radius, 0),
                 thickness=self.outboard_tf_coil_radial_thickness,
                 number_of_coils=self.number_of_tf_coils,
                 distance=self.tf_coil_poloidal_thickness,
                 stp_filename="outboard_tf_coil.stp",
                 stl_filename="outboard_tf_coil.stl",
-                cut=cutting_slice,
+                cut=self._cutting_slice,
             )
-            shapes_or_components.append(tf_coil)
+            shapes_or_components.append(self._tf_coil)
 
-            if pf_info_provided:
+            if self._pf_info_provided:
 
                 for i, (rt, vt, y_value, x_value) in enumerate(
                     zip(
                         self.pf_coil_radial_thicknesses,
                         self.pf_coil_vertical_thicknesses,
-                        pf_coils_y_values,
-                        pf_coils_x_values,
+                        self._pf_coils_y_values,
+                        self._pf_coils_x_values,
                     )
                 ):
 
-                    pf_coil = paramak.PoloidalFieldCoil(
+                    self._pf_coil = paramak.PoloidalFieldCoil(
                         width=rt,
                         height=vt,
                         center_point=(x_value, y_value),
@@ -825,5 +574,5 @@ class SubmersionTokamak(paramak.Reactor):
                         name="pf_coil",
                         material_tag="pf_coil_mat",
                     )
-                    shapes_or_components.append(pf_coil)
+                    shapes_or_components.append(self._pf_coil)
 

--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -55,7 +55,7 @@ class SubmersionTokamak(paramak.Reactor):
         pf_coil_to_tf_coil_radial_gap (float): the radial distance between
             the rear of the poloidal field coil and the toroidal field coil
             (optional)
-        
+
     Returns:
         a paramak shape object: a Reactor object that has generic functionality
     """
@@ -166,8 +166,8 @@ class SubmersionTokamak(paramak.Reactor):
 
         self._inboard_firstwall_start_radius = self._inboard_blanket_end_radius
         self._inboard_firstwall_end_radius = (
-            self._inboard_firstwall_start_radius + self.firstwall_radial_thickness
-        )
+            self._inboard_firstwall_start_radius +
+            self.firstwall_radial_thickness)
 
         self._inner_plasma_gap_start_radius = self._inboard_firstwall_end_radius
         self._inner_plasma_gap_end_radius = (
@@ -184,8 +184,8 @@ class SubmersionTokamak(paramak.Reactor):
 
         self._outboard_firstwall_start_radius = self._outer_plasma_gap_end_radius
         self._outboard_firstwall_end_radius = (
-            self._outboard_firstwall_start_radius + self.firstwall_radial_thickness
-        )
+            self._outboard_firstwall_start_radius +
+            self.firstwall_radial_thickness)
 
         self._outboard_blanket_start_radius = self._outboard_firstwall_end_radius
         self._outboard_blanket_end_radius = (
@@ -210,7 +210,7 @@ class SubmersionTokamak(paramak.Reactor):
             self._outboard_tf_coil_end_radius = (
                 self._outboard_tf_coil_start_radius +
                 self.outboard_tf_coil_radial_thickness)
-        
+
         else:
             self._outboard_tf_coil_end_radius = None
             self._outboard_tf_coil_start_radius = None
@@ -237,14 +237,14 @@ class SubmersionTokamak(paramak.Reactor):
             self.plasma_high_point[0] + 0.5 * self.support_radial_thickness
         )
 
-
     def make_vertical_build(self):
-        
+
         # this is the vertical build sequence, componets build on each other in
         # a similar manner to the radial build
-        
+
         self._plasma_start_height = 0
-        self._plasma_end_height = self._plasma_start_height + self.plasma_high_point[1]
+        self._plasma_end_height = self._plasma_start_height + \
+            self.plasma_high_point[1]
 
         self._plasma_to_divertor_gap_start_height = self._plasma_end_height
         self._plasma_to_divertor_gap_end_height = (
@@ -253,7 +253,8 @@ class SubmersionTokamak(paramak.Reactor):
 
         # the firstwall is cut by the divertor but uses the same control points
         self._firstwall_start_height = self._plasma_to_divertor_gap_end_height
-        self._firstwall_end_height = self._firstwall_start_height + self.firstwall_radial_thickness
+        self._firstwall_end_height = self._firstwall_start_height + \
+            self.firstwall_radial_thickness
 
         self._blanket_start_height = self._firstwall_end_height
         self._blanket_end_height = (
@@ -296,7 +297,7 @@ class SubmersionTokamak(paramak.Reactor):
             self._pf_coil_end_radius = self._pf_coil_start_radius + max(
                 self.pf_coil_radial_thicknesses
             )
-        
+
         else:
             self._number_of_pf_coils = None
             self._pf_coils_y_values = None
@@ -575,4 +576,3 @@ class SubmersionTokamak(paramak.Reactor):
                         material_tag="pf_coil_mat",
                     )
                     shapes_or_components.append(self._pf_coil)
-


### PR DESCRIPTION
This PR changes the submersion ball reactor to use parameters stored as attributes of the instance, i.e. self._attributes, rather than local parameters. This allows all parameters to be passed between the methods via self, rather than in large lists of attributes and return statements