### PR TITLE
Add rotation angle warning

### DIFF
--- a/paramak/__init__.py
+++ b/paramak/__init__.py
@@ -67,4 +67,3 @@ from .parametric_components.toroidal_field_coil_rectangle import (
 from .parametric_components.toroidal_field_coil_triple_arc import ToroidalFieldCoilTripleArc
 
 from .parametric_components.toroidal_field_coil_princeton_d import ToroidalFieldCoilPrincetonD
-

--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -115,7 +115,8 @@ class BlanketFP(RotateMixedShape):
             **default_dict
         )
         # raise error if full coverage and full rotation angle are set
-        if diff_between_angles(start_angle, stop_angle) == 0 and rotation_angle == 360:
+        if diff_between_angles(start_angle,
+                               stop_angle) == 0 and rotation_angle == 360:
             raise ValueError("Full coverage and 360 rotation will result in a \
                 standard construction error.")
         self.thickness = thickness

--- a/paramak/parametric_components/toroidal_field_coil_princeton_d.py
+++ b/paramak/parametric_components/toroidal_field_coil_princeton_d.py
@@ -33,6 +33,7 @@ class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
         material_tag (str, optional): The material name to use when exporting
             the neutronics description.. Defaults to "outer_tf_coil_mat".
     """
+
     def __init__(
         self,
         R1,
@@ -121,10 +122,10 @@ class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
             return a_R, asol[:, 0], asol[:, 1]
 
         def solvr(Y, R):
-            return [Y[1], -1/(k*R)*(1 + Y[1]**2)**(3/2)]
+            return [Y[1], -1 / (k * R) * (1 + Y[1]**2)**(3 / 2)]
 
-        R0 = (R1*R2)**0.5
-        k = 0.5*np.log(R2/R1)
+        R0 = (R1 * R2)**0.5
+        k = 0.5 * np.log(R2 / R1)
 
         # computing of Z0
         # Z0 is computed by ensuring outer segment end is zero
@@ -136,8 +137,10 @@ class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
         segment1 = get_segment(R0, R1, Z0)
         segment2 = get_segment(R0, R2, Z0)
 
-        R = np.concatenate([np.flip(segment1[0]), segment2[0][1:], np.flip(segment2[0])[1:], segment1[0][1:]])
-        Z = np.concatenate([np.flip(segment1[1]), segment2[1][1:], -np.flip(segment2[1])[1:], -segment1[1][1:]])
+        R = np.concatenate([np.flip(segment1[0]), segment2[0]
+                            [1:], np.flip(segment2[0])[1:], segment1[0][1:]])
+        Z = np.concatenate([np.flip(segment1[1]), segment2[1]
+                            [1:], -np.flip(segment2[1])[1:], -segment1[1][1:]])
         dz_dr = np.concatenate([np.flip(segment1[2]), segment2[2]])
         return R, Z, dz_dr
 

--- a/paramak/parametric_components/toroidal_field_coil_triple_arc.py
+++ b/paramak/parametric_components/toroidal_field_coil_triple_arc.py
@@ -38,6 +38,7 @@ class ToroidalFieldCoilTripleArc(ExtrudeMixedShape):
         material_tag (str, optional): The material name to use when exporting
             the neutronics description.. Defaults to "outer_tf_coil_mat".
     """
+
     def __init__(
         self,
         R1,
@@ -168,7 +169,7 @@ class ToroidalFieldCoilTripleArc(ExtrudeMixedShape):
 
         # create outer coordinates
         R_outer, Z_outer = self.compute_curve(
-            self.R1-thickness, self.h,
+            self.R1 - thickness, self.h,
             radii=(small_radius + thickness, mid_radius + thickness),
             coverages=(small_coverage, mid_coverage))
         R_outer, Z_outer = np.flip(R_outer), np.flip(Z_outer)

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -123,7 +123,8 @@ class BallReactor(paramak.Reactor):
         shapes_or_components = []
 
         if self.rotation_angle == 360:
-            print('Warning - 360 degree rotation may result in a Standard_ConstructionError or AttributeError')
+            print(
+                'Warning - 360 degree rotation may result in a Standard_ConstructionError or AttributeError')
 
         self.make_plasma(shapes_or_components)
         self.make_radial_build(shapes_or_components)

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -122,6 +122,9 @@ class BallReactor(paramak.Reactor):
 
         shapes_or_components = []
 
+        if self.rotation_angle == 360:
+            print('Warning - 360 degree rotation may result in a Standard_ConstructionError or AttributeError')
+
         self.make_plasma(shapes_or_components)
         self.make_radial_build(shapes_or_components)
         self.make_vertical_build(shapes_or_components)

--- a/paramak/parametric_reactors/single_null_ball_reactor.py
+++ b/paramak/parametric_reactors/single_null_ball_reactor.py
@@ -105,7 +105,8 @@ class SingleNullBallReactor(paramak.BallReactor):
         shapes_or_components = []
 
         if self.rotation_angle == 360:
-            print('Warning - 360 degree rotation may result in a Standard_ConstructionError or AttributeError')
+            print(
+                'Warning - 360 degree rotation may result in a Standard_ConstructionError or AttributeError')
 
         self.make_plasma(shapes_or_components)
         self.make_radial_build(shapes_or_components)

--- a/paramak/parametric_reactors/single_null_ball_reactor.py
+++ b/paramak/parametric_reactors/single_null_ball_reactor.py
@@ -104,6 +104,9 @@ class SingleNullBallReactor(paramak.BallReactor):
 
         shapes_or_components = []
 
+        if self.rotation_angle == 360:
+            print('Warning - 360 degree rotation may result in a Standard_ConstructionError or AttributeError')
+
         self.make_plasma(shapes_or_components)
         self.make_radial_build(shapes_or_components)
         self.make_vertical_build(shapes_or_components)

--- a/paramak/parametric_reactors/single_null_submersion_reactor.py
+++ b/paramak/parametric_reactors/single_null_submersion_reactor.py
@@ -121,7 +121,8 @@ class SingleNullSubmersionTokamak(paramak.SubmersionTokamak):
         shapes_or_components = []
 
         if self.rotation_angle == 360:
-            print('Warning - 360 degree rotation may result in a Standard_ConstructionError or AttributeError')
+            print(
+                'Warning - 360 degree rotation may result in a Standard_ConstructionError or AttributeError')
 
         self.make_radial_build()
         self.make_vertical_build()

--- a/paramak/parametric_reactors/single_null_submersion_reactor.py
+++ b/paramak/parametric_reactors/single_null_submersion_reactor.py
@@ -120,6 +120,9 @@ class SingleNullSubmersionTokamak(paramak.SubmersionTokamak):
 
         shapes_or_components = []
 
+        if self.rotation_angle == 360:
+            print('Warning - 360 degree rotation may result in a Standard_ConstructionError or AttributeError')
+
         self.make_radial_build()
         self.make_vertical_build()
         self.make_inboard_tf_coils(shapes_or_components)

--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -117,6 +117,9 @@ class SubmersionTokamak(paramak.Reactor):
 
         shapes_or_components = []
 
+        if self.rotation_angle == 360:
+            print('Warning - 360 degree rotation may result in a Standard_ConstructionError or AttributeError')
+
         self.make_radial_build()
         self.make_vertical_build()
         self.make_inboard_tf_coils(shapes_or_components)

--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -118,7 +118,8 @@ class SubmersionTokamak(paramak.Reactor):
         shapes_or_components = []
 
         if self.rotation_angle == 360:
-            print('Warning - 360 degree rotation may result in a Standard_ConstructionError or AttributeError')
+            print(
+                'Warning - 360 degree rotation may result in a Standard_ConstructionError or AttributeError')
 
         self.make_radial_build()
         self.make_vertical_build()

--- a/tests/test_SubmersionTokamak.py
+++ b/tests/test_SubmersionTokamak.py
@@ -28,7 +28,7 @@ class test_SubmersionTokamak(unittest.TestCase):
             blanket_rear_wall_radial_thickness=50,
             support_radial_thickness=150,
             plasma_high_point=(50 + 50 + 50 + 100 + 50 + 50 + 100, 350),
-            rotation_angle=180,
+            rotation_angle=359,
         )
         test_reactor.export_svg("test_SubmersionTokamak_image.svg")
 
@@ -53,7 +53,7 @@ class test_SubmersionTokamak(unittest.TestCase):
             blanket_rear_wall_radial_thickness=50,
             support_radial_thickness=150,
             plasma_high_point=(50 + 50 + 50 + 100 + 50 + 50 + 100, 350),
-            rotation_angle=180,
+            rotation_angle=359,
         )
 
         assert len(test_reactor.shapes_and_components) == 8
@@ -75,12 +75,12 @@ class test_SubmersionTokamak(unittest.TestCase):
             blanket_rear_wall_radial_thickness=50,
             divertor_radial_thickness=50,
             plasma_high_point=(50 + 50 + 50 + 100 + 100, 350),
-            rotation_angle=180,
             support_radial_thickness=150,
             outboard_tf_coil_radial_thickness=50,
             tf_coil_to_rear_blanket_radial_gap=50,
             tf_coil_poloidal_thickness=70,
             number_of_tf_coils=4,
+            rotation_angle=359,
         )
         assert len(test_reactor.shapes_and_components) == 9
 
@@ -101,7 +101,6 @@ class test_SubmersionTokamak(unittest.TestCase):
             blanket_rear_wall_radial_thickness=50,
             divertor_radial_thickness=50,
             plasma_high_point=(50 + 50 + 50 + 100 + 100, 350),
-            rotation_angle=180,
             support_radial_thickness=150,
             outboard_tf_coil_radial_thickness=50,
             tf_coil_to_rear_blanket_radial_gap=50,
@@ -110,6 +109,7 @@ class test_SubmersionTokamak(unittest.TestCase):
             pf_coil_radial_thicknesses=[40, 40, 40, 40, 40],
             pf_coil_to_tf_coil_radial_gap=50,
             number_of_tf_coils=4,
+            rotation_angle=359,
         )
         assert len(test_reactor.shapes_and_components) == 14
 
@@ -133,7 +133,7 @@ class test_SubmersionTokamak(unittest.TestCase):
             blanket_rear_wall_radial_thickness=50,
             support_radial_thickness=150,
             plasma_high_point=(50 + 50 + 50 + 100 + 50 + 50 + 100, 350),
-            rotation_angle=180,
+            rotation_angle=359,
         )
         test_reactor.export_stp("minimal_SubmersionTokamak")
 
@@ -173,12 +173,12 @@ class test_SubmersionTokamak(unittest.TestCase):
             blanket_rear_wall_radial_thickness=50,
             divertor_radial_thickness=50,
             plasma_high_point=(50 + 50 + 50 + 100 + 100, 350),
-            rotation_angle=180,
             support_radial_thickness=150,
             outboard_tf_coil_radial_thickness=50,
             tf_coil_to_rear_blanket_radial_gap=50,
             tf_coil_poloidal_thickness=70,
             number_of_tf_coils=4,
+            rotation_angle=360
         )
         test_reactor.export_stp("pf_SubmersionTokamak")
 
@@ -218,7 +218,6 @@ class test_SubmersionTokamak(unittest.TestCase):
             blanket_rear_wall_radial_thickness=50,
             divertor_radial_thickness=50,
             plasma_high_point=(50 + 50 + 50 + 100 + 100, 350),
-            rotation_angle=180,
             support_radial_thickness=150,
             outboard_tf_coil_radial_thickness=50,
             tf_coil_to_rear_blanket_radial_gap=50,
@@ -227,6 +226,7 @@ class test_SubmersionTokamak(unittest.TestCase):
             pf_coil_radial_thicknesses=[40, 40, 40, 40, 40],
             pf_coil_to_tf_coil_radial_gap=50,
             number_of_tf_coils=4,
+            rotation_angle=359,
         )
         test_reactor.export_stp("tf_pf_SubmersionTokamak")
 
@@ -262,7 +262,6 @@ class test_SubmersionTokamak(unittest.TestCase):
             firstwall_radial_thickness=30,
             blanket_rear_wall_radial_thickness=30,
             number_of_tf_coils=16,
-            rotation_angle=180,
             support_radial_thickness=20,
             inboard_blanket_radial_thickness=20,
             outboard_blanket_radial_thickness=20,
@@ -274,7 +273,8 @@ class test_SubmersionTokamak(unittest.TestCase):
             tf_coil_poloidal_thickness=50,
             tf_coil_to_rear_blanket_radial_gap=20,
             divertor_position="upper",
-            support_position="upper"
+            support_position="upper",
+            rotation_angle=359,
         )
         assert len(test_reactor.shapes_and_components) == 13
 
@@ -294,13 +294,13 @@ class test_SubmersionTokamak(unittest.TestCase):
             firstwall_radial_thickness=30,
             blanket_rear_wall_radial_thickness=30,
             number_of_tf_coils=16,
-            rotation_angle=180,
             support_radial_thickness=20,
             inboard_blanket_radial_thickness=20,
             outboard_blanket_radial_thickness=20,
             plasma_high_point=(200, 200),
             divertor_position="lower",
-            support_position="lower"
+            support_position="lower",
+            rotation_angle=359,
         )
         assert len(test_reactor.shapes_and_components) == 8
 
@@ -320,12 +320,12 @@ class test_SubmersionTokamak(unittest.TestCase):
             firstwall_radial_thickness=30,
             blanket_rear_wall_radial_thickness=30,
             number_of_tf_coils=16,
-            rotation_angle=180,
             support_radial_thickness=20,
             inboard_blanket_radial_thickness=20,
             outboard_blanket_radial_thickness=20,
             plasma_high_point=(200, 200),
             divertor_position="upper",
-            support_position="upper"
+            support_position="upper",
+            rotation_angle=359,
         )
         assert len(test_reactor.shapes_and_components) == 8


### PR DESCRIPTION
PR which prints warning message if BallReactor or SubmersionTokamak (or single null versions) rotation_angle = 360. Also updates submersion reactor tests to use rotation_angle=359.