### PR TITLE
moved hash_value to default_dict

### DIFF
--- a/paramak/parametric_shapes/extruded_circle_shape.py
+++ b/paramak/parametric_shapes/extruded_circle_shape.py
@@ -47,13 +47,13 @@ class ExtrudeCircleShape(Shape):
         intersect=None,
         union=None,
         material_tag=None,
-        hash_value=None,
         name=None,
         **kwargs
     ):
 
         default_dict = {"tet_mesh": None,
-                        "physical_groups": None}
+                        "physical_groups": None,
+                        "hash_value": None}
 
         for arg in kwargs:
             if arg in default_dict:
@@ -68,7 +68,6 @@ class ExtrudeCircleShape(Shape):
             stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
-            hash_value=None,
             **default_dict
         )
 

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -46,13 +46,13 @@ class ExtrudeMixedShape(Shape):
         intersect=None,
         union=None,
         material_tag=None,
-        hash_value=None,
         name=None,
         **kwargs
     ):
 
         default_dict = {"tet_mesh": None,
-                        "physical_groups": None}
+                        "physical_groups": None,
+                        "hash_value": None}
 
         for arg in kwargs:
             if arg in default_dict:
@@ -67,7 +67,6 @@ class ExtrudeMixedShape(Shape):
             stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
-            hash_value=hash_value,
             **default_dict
         )
 

--- a/paramak/parametric_shapes/extruded_spline_shape.py
+++ b/paramak/parametric_shapes/extruded_spline_shape.py
@@ -44,13 +44,13 @@ class ExtrudeSplineShape(Shape):
         intersect=None,
         union=None,
         material_tag=None,
-        hash_value=None,
         name=None,
         **kwargs
     ):
 
         default_dict = {"tet_mesh": None,
-                        "physical_groups": None}
+                        "physical_groups": None,
+                        "hash_value": None}
 
         for arg in kwargs:
             if arg in default_dict:
@@ -65,7 +65,6 @@ class ExtrudeSplineShape(Shape):
             stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
-            hash_value=hash_value,
             **default_dict
         )
 

--- a/paramak/parametric_shapes/extruded_straight_shape.py
+++ b/paramak/parametric_shapes/extruded_straight_shape.py
@@ -45,13 +45,13 @@ class ExtrudeStraightShape(Shape):
         intersect=None,
         union=None,
         material_tag=None,
-        hash_value=None,
         name=None,
         **kwargs
     ):
 
         default_dict = {"tet_mesh": None,
-                        "physical_groups": None}
+                        "physical_groups": None,
+                        "hash_value": None}
 
         for arg in kwargs:
             if arg in default_dict:
@@ -66,7 +66,6 @@ class ExtrudeStraightShape(Shape):
             stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
-            hash_value=hash_value,
             **default_dict
         )
 

--- a/paramak/parametric_shapes/rotate_circle_shape.py
+++ b/paramak/parametric_shapes/rotate_circle_shape.py
@@ -44,13 +44,13 @@ class RotateCircleShape(Shape):
         intersect=None,
         union=None,
         material_tag=None,
-        hash_value=None,
         name=None,
         **kwargs
     ):
 
         default_dict = {"tet_mesh": None,
-                        "physical_groups": None}
+                        "physical_groups": None,
+                        "hash_value": None}
 
         for arg in kwargs:
             if arg in default_dict:
@@ -65,7 +65,6 @@ class RotateCircleShape(Shape):
             stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
-            hash_value=hash_value,
             **default_dict
         )
 

--- a/paramak/parametric_shapes/rotate_mixed_shape.py
+++ b/paramak/parametric_shapes/rotate_mixed_shape.py
@@ -37,7 +37,6 @@ class RotateMixedShape(Shape):
         name=None,
         color=None,
         material_tag=None,
-        hash_value=None,
         stp_filename="RotateMixedShape.stp",
         stl_filename="RotateMixedShape.stl",
         azimuth_placement_angle=0,
@@ -50,7 +49,8 @@ class RotateMixedShape(Shape):
     ):
 
         default_dict = {"tet_mesh": None,
-                        "physical_groups": None}
+                        "physical_groups": None,
+                        "hash_value": None}
 
         for arg in kwargs:
             if arg in default_dict:
@@ -65,7 +65,6 @@ class RotateMixedShape(Shape):
             stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
-            hash_value=hash_value,
             **default_dict
         )
 

--- a/paramak/parametric_shapes/rotate_spline_shape.py
+++ b/paramak/parametric_shapes/rotate_spline_shape.py
@@ -35,7 +35,6 @@ class RotateSplineShape(Shape):
         name=None,
         color=None,
         material_tag=None,
-        hash_value=None,
         stp_filename="RotateSplineShape.stp",
         stl_filename="RotateSplineShape.stl",
         azimuth_placement_angle=0,
@@ -48,7 +47,8 @@ class RotateSplineShape(Shape):
     ):
 
         default_dict = {"tet_mesh": None,
-                        "physical_groups": None}
+                        "physical_groups": None,
+                        "hash_value": None}
 
         for arg in kwargs:
             if arg in default_dict:
@@ -63,7 +63,6 @@ class RotateSplineShape(Shape):
             stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
-            hash_value=hash_value,
             **default_dict
         )
 

--- a/paramak/parametric_shapes/rotate_straight_shape.py
+++ b/paramak/parametric_shapes/rotate_straight_shape.py
@@ -36,7 +36,6 @@ class RotateStraightShape(Shape):
         name=None,
         color=None,
         material_tag=None,
-        hash_value=None,
         stp_filename="RotateStraightShape.stp",
         stl_filename="RotateStraightShape.stl",
         azimuth_placement_angle=0,
@@ -49,7 +48,8 @@ class RotateStraightShape(Shape):
     ):
 
         default_dict = {"tet_mesh": None,
-                        "physical_groups": None}
+                        "physical_groups": None,
+                        "hash_value": None}
 
         for arg in kwargs:
             if arg in default_dict:
@@ -64,7 +64,6 @@ class RotateStraightShape(Shape):
             stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
-            hash_value=hash_value,
             **default_dict
         )
 


### PR DESCRIPTION
PR to move the hash_value parameter to default dict. This removes hash_value from the init constructor, but allows it to be passed as a kwarg.
See #236 for further details.
What do you think @Shimwell ?
