### PR TITLE
added two reactor images and removed height setting

### DIFF
--- a/docs/source/paramak.parametric_reactors.rst
+++ b/docs/source/paramak.parametric_reactors.rst
@@ -1,28 +1,25 @@
 Parametric Reactors
 ===================
 
-These are reactors designs that can be created from parameters.
+These are reactors current designs that can be created from parameters.
 
 BallReactor()
 ^^^^^^^^^^^^^
 
 .. image:: https://user-images.githubusercontent.com/8583900/89423931-070dc880-d72f-11ea-8cb3-1ce3ce840b7e.png
-   :width: 450
-   :height: 450
+   :width: 400
    :align: center
 
-The above image is colored by components, instead of by Shape volume type. The TF coils are blue, the PF coils are red, the center column shielding is light blue, the blanket is green, the divertor is orange, the firstwall is grey and the rear wall of the blanket is teal.
+The above image is colored by components. The TF coils are blue, the PF coils are red, the center column shielding is light blue, the blanket is green, the divertor is orange, the firstwall is grey and the rear wall of the blanket is teal.
 
 .. image:: https://user-images.githubusercontent.com/56687624/88921452-79ca0000-d266-11ea-9f8f-5247e88b03cf.png
-   :width: 450
-   :height: 450
+   :width: 400
    :align: center
 
-The above image is colored by Shape type with RotateStraightShape in red, ExtrudeStraightShape in orange, RotateSplineShape in purple, ExtrudeSplineShape in pink, RotateMixedShape in blue, ExtrudeMixedShape in green, RotateCircleShape in yellow and ExtrudeCircleShape in brown.
+The above image is colored by Shape type, with RotateStraightShape in red, ExtrudeStraightShape in orange, RotateSplineShape in purple, ExtrudeSplineShape in pink, RotateMixedShape in blue, ExtrudeMixedShape in green, RotateCircleShape in yellow and ExtrudeCircleShape in brown.
 
 .. image:: https://user-images.githubusercontent.com/8583900/89176602-bc028280-d581-11ea-8a16-dfc20833b8d9.png
    :width: 450
-   :height: 490
    :align: center
 
 .. automodule:: paramak.parametric_reactors.ball_reactor
@@ -33,18 +30,16 @@ SingleNullBallReactor()
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 .. image:: https://user-images.githubusercontent.com/56687624/91280446-ab0ef080-e77e-11ea-8792-71b44a38b070.png
-   :width: 450
-   :height: 450
+   :width: 400
    :align: center
 
-The above image is colored by components, instead of by Shape volume type. The TF coils are blue, the PF coils are red, the center column shielding is light blue, the blanket is green, the divertor is organe, the firstwall is grey and the rear wall of the blanket is teal.
+The above image is colored by components. The TF coils are blue, the PF coils are red, the center column shielding is light blue, the blanket is green, the divertor is organe, the firstwall is grey and the rear wall of the blanket is teal.
 
 .. image:: https://user-images.githubusercontent.com/56687624/91280475-b104d180-e77e-11ea-96ff-0bfcf8b8d5a9.png
-   :width: 450
-   :height: 450
+   :width: 400
    :align: center
 
-The above image is colored by Shape type with RotateStraightShape in red, ExtrudeStraightShape in orange, RotateSplineShape in purple, ExtrudeSplineShape in pink, RotateMixedShape in blue, ExtrudeMixedShape in green, RotateCircleShape in yellow and ExtrudeCircleShape in brown.
+The above image is colored by Shape type, with RotateStraightShape in red, ExtrudeStraightShape in orange, RotateSplineShape in purple, ExtrudeSplineShape in pink, RotateMixedShape in blue, ExtrudeMixedShape in green, RotateCircleShape in yellow and ExtrudeCircleShape in brown.
 
 .. automodule:: paramak.parametric_reactors.single_null_ball_reactor
    :members:
@@ -54,15 +49,19 @@ SubmersionTokamak()
 ^^^^^^^^^^^^^^^^^^^
 
 .. image:: https://user-images.githubusercontent.com/8583900/89411100-c0af6e00-d71c-11ea-8d6a-cef2558b82dd.png
-   :width: 450
-   :height: 450
+   :width: 400
    :align: center
 
-The above image is colored by components with RotateStraightShape in red, ExtrudeStraightShape in orange, RotateSplineShape in purple, ExtrudeSplineShape in pink, RotateMixedShape in blue, ExtrudeMixedShape in green, RotateCircleShape in yellow and ExtrudeCircleShape in brown.
+The above image is colored by components, the TF coils are blue, the PF coils are red, the center column shielding is light blue, the blanket is green, the divertor is organe, the firstwall is grey and the rear wall of the blanket is teal and the support legs are brown.
+
+.. image:: https://user-images.githubusercontent.com/8583900/92939579-de6fa180-f445-11ea-83b9-6f9f3260ac82.png
+   :width: 400
+   :align: center
+
+The above image is colored by Shape type with RotateStraightShape in red, ExtrudeStraightShape in orange, RotateSplineShape in purple, ExtrudeSplineShape in pink, RotateMixedShape in blue, ExtrudeMixedShape in green, RotateCircleShape in yellow and ExtrudeCircleShape in brown.
 
 .. image:: https://user-images.githubusercontent.com/8583900/89407027-fb61d800-d715-11ea-892a-59283742687f.png
    :width: 450
-   :height: 490
    :align: center
 
 .. automodule:: paramak.parametric_reactors.submersion_reactor
@@ -73,11 +72,17 @@ SingleNullSubmersionTokamak()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. image:: https://user-images.githubusercontent.com/56687624/91299260-3e551f80-e799-11ea-82dc-1b300d3fbe45.png
-   :width: 470
-   :height: 450
+   :width: 400
    :align: center
 
 The above image is colored by component instead of by Shape type. The TF coils are blue, the PF coils are red, the center column shielding is light blue, the blanket is green, the divertor is oragne, the firstwall is grey, the rear wall of the blanket is teal and the supports are black.
+
+.. image:: https://user-images.githubusercontent.com/8583900/92940739-61452c00-f447-11ea-90f2-a8ffa495da6c.png
+   :width: 400
+   :align: center
+
+The above image is colored by Shape type with RotateStraightShape in red, ExtrudeStraightShape in orange, RotateSplineShape in purple, ExtrudeSplineShape in pink, RotateMixedShape in blue, ExtrudeMixedShape in green, RotateCircleShape in yellow and ExtrudeCircleShape in brown.
+
 
 .. automodule:: paramak.parametric_reactors.single_null_submersion_reactor
    :members:


### PR DESCRIPTION
## Proposed changes

This adds a few reactor images to the docs and also removes the height setting for reactor images (it was causing images to be squashed). Ideally there would be a couple more svg images but that can come in a later PR

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively small PR that does not interfere with the source code
