### PR TITLE
Parametric component points

### DIFF
--- a/examples/example_parametric_components/make_all_parametric_components.py
+++ b/examples/example_parametric_components/make_all_parametric_components.py
@@ -112,8 +112,6 @@ def main():
     )
     all_components.append(component)
 
-    #
-
     # component = paramak.DivertorBlock(
     #     major_radius = 800,
     #     minor_radius = 400,

--- a/paramak/parametric_components/blanket_constant_thickness_arc_h.py
+++ b/paramak/parametric_components/blanket_constant_thickness_arc_h.py
@@ -89,14 +89,7 @@ class BlanketConstantThicknessArcH(RotateMixedShape):
         self.inner_mid_point = inner_mid_point
         self.thickness = thickness
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
 
     def find_points(self):
 
@@ -118,6 +111,5 @@ class BlanketConstantThicknessArcH(RotateMixedShape):
                 self.inner_upper_point[0] + abs(self.thickness),
                 self.inner_upper_point[1],
                 "straight",
-            ),
-            (self.inner_upper_point[0], self.inner_upper_point[1]),
+            )
         ]

--- a/paramak/parametric_components/blanket_constant_thickness_arc_v.py
+++ b/paramak/parametric_components/blanket_constant_thickness_arc_v.py
@@ -89,14 +89,7 @@ class BlanketConstantThicknessArcV(RotateMixedShape):
         self.inner_mid_point = inner_mid_point
         self.thickness = thickness
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
 
     def find_points(self):
 
@@ -118,6 +111,5 @@ class BlanketConstantThicknessArcV(RotateMixedShape):
                 self.inner_upper_point[0],
                 self.inner_upper_point[1] + abs(self.thickness),
                 "straight",
-            ),
-            (self.inner_upper_point[0], self.inner_upper_point[1]),
+            )
         ]

--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -140,6 +140,8 @@ class BlanketFP(RotateMixedShape):
         # self.points = points
         self.physical_groups = None
 
+        self.find_points()
+
     @property
     def physical_groups(self):
         self.create_physical_groups()
@@ -148,15 +150,6 @@ class BlanketFP(RotateMixedShape):
     @physical_groups.setter
     def physical_groups(self, physical_groups):
         self._physical_groups = physical_groups
-
-    @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
 
     @property
     def minor_radius(self):
@@ -239,7 +232,6 @@ class BlanketFP(RotateMixedShape):
             np.flip(thetas), R, Z, new_offset)
         points = inner_points + outer_points
         points[-1][2] = "straight"
-        points.append(inner_points[0])
         self.points = points
 
     def create_offset_points(self, thetas, R_fun, Z_fun, offset):

--- a/paramak/parametric_components/center_column_circular.py
+++ b/paramak/parametric_components/center_column_circular.py
@@ -81,14 +81,7 @@ class CenterColumnShieldCircular(RotateMixedShape):
         self.mid_radius = mid_radius
         self.outer_radius = outer_radius
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
 
     @property
     def height(self):
@@ -132,8 +125,7 @@ class CenterColumnShieldCircular(RotateMixedShape):
             (self.outer_radius, self.height / 2, "circle"),
             (self.mid_radius, 0, "circle"),
             (self.outer_radius, -self.height / 2, "straight"),
-            (self.inner_radius, -self.height / 2, "straight"),
-            (self.inner_radius, 0, "straight"),
+            (self.inner_radius, -self.height / 2, "straight")
         ]
 
         self.points = points

--- a/paramak/parametric_components/center_column_cylinder.py
+++ b/paramak/parametric_components/center_column_cylinder.py
@@ -68,14 +68,7 @@ class CenterColumnShieldCylinder(RotateStraightShape):
         self.inner_radius = inner_radius
         self.outer_radius = outer_radius
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
 
     @property
     def height(self):
@@ -120,8 +113,7 @@ class CenterColumnShieldCylinder(RotateStraightShape):
             (self.inner_radius, self.height / 2),
             (self.outer_radius, self.height / 2),
             (self.outer_radius, -self.height / 2),
-            (self.inner_radius, -self.height / 2),
-            (self.inner_radius, self.height / 2),
+            (self.inner_radius, -self.height / 2)
         ]
 
         self.points = points

--- a/paramak/parametric_components/center_column_flat_top_circular.py
+++ b/paramak/parametric_components/center_column_flat_top_circular.py
@@ -84,14 +84,7 @@ class CenterColumnShieldFlatTopCircular(RotateMixedShape):
         self.outer_radius = outer_radius
         self.inner_radius = inner_radius
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
 
     @property
     def height(self):
@@ -145,8 +138,7 @@ class CenterColumnShieldFlatTopCircular(RotateMixedShape):
             (self.mid_radius, 0, "circle"),
             (self.outer_radius, -self.arc_height / 2, "straight"),
             (self.outer_radius, -self.height / 2, "straight"),
-            (self.inner_radius, -self.height / 2, "straight"),
-            (self.inner_radius, 0, "straight"),
+            (self.inner_radius, -self.height / 2, "straight")
         ]
 
         self.points = points

--- a/paramak/parametric_components/center_column_flat_top_hyperbola.py
+++ b/paramak/parametric_components/center_column_flat_top_hyperbola.py
@@ -159,7 +159,7 @@ class CenterColumnShieldFlatTopHyperbola(RotateMixedShape):
             (self.mid_radius, 0, "spline"),
             (self.outer_radius, -self.arc_height / 2, "straight"),
             (self.outer_radius, -self.height / 2, "straight"),
-            (self.inner_radius , -self.height /2, "straight")
+            (self.inner_radius, -self.height / 2, "straight")
         ]
 
         self.points = points

--- a/paramak/parametric_components/center_column_flat_top_hyperbola.py
+++ b/paramak/parametric_components/center_column_flat_top_hyperbola.py
@@ -84,14 +84,7 @@ class CenterColumnShieldFlatTopHyperbola(RotateMixedShape):
         self.outer_radius = outer_radius
         self.inner_radius = inner_radius
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
 
     @property
     def height(self):
@@ -166,8 +159,7 @@ class CenterColumnShieldFlatTopHyperbola(RotateMixedShape):
             (self.mid_radius, 0, "spline"),
             (self.outer_radius, -self.arc_height / 2, "straight"),
             (self.outer_radius, -self.height / 2, "straight"),
-            (self.inner_radius, -self.height / 2, "straight"),
-            (self.inner_radius, 0, "straight"),
+            (self.inner_radius , -self.height /2, "straight")
         ]
 
         self.points = points

--- a/paramak/parametric_components/center_column_hyperbola.py
+++ b/paramak/parametric_components/center_column_hyperbola.py
@@ -81,14 +81,7 @@ class CenterColumnShieldHyperbola(RotateMixedShape):
         self.mid_radius = mid_radius
         self.outer_radius = outer_radius
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
 
     @property
     def height(self):
@@ -146,8 +139,9 @@ class CenterColumnShieldHyperbola(RotateMixedShape):
             (self.outer_radius, self.height / 2, "spline"),
             (self.mid_radius, 0, "spline"),
             (self.outer_radius, -self.height / 2, "straight"),
-            (self.inner_radius, -self.height / 2, "straight"),
-            (self.inner_radius, 0, "straight"),
+            (self.inner_radius, -self.height / 2, "straight")
         ]
+
+        print(points)
 
         self.points = points

--- a/paramak/parametric_components/center_column_hyperbola.py
+++ b/paramak/parametric_components/center_column_hyperbola.py
@@ -142,6 +142,4 @@ class CenterColumnShieldHyperbola(RotateMixedShape):
             (self.inner_radius, -self.height / 2, "straight")
         ]
 
-        print(points)
-
         self.points = points

--- a/paramak/parametric_components/center_column_plasma_dependant.py
+++ b/paramak/parametric_components/center_column_plasma_dependant.py
@@ -95,14 +95,7 @@ class CenterColumnShieldPlasmaHyperbola(RotateMixedShape):
         self.mid_offset = mid_offset
         self.edge_offset = edge_offset
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
 
     @property
     def major_radius(self):
@@ -204,8 +197,7 @@ class CenterColumnShieldPlasmaHyperbola(RotateMixedShape):
             ),
             (plasma.low_point[0] - self.edge_offset, plasma.low_point[1], "straight"),
             (plasma.low_point[0] - self.edge_offset, -1 * self.height / 2, "straight"),
-            (self.inner_radius, -1 * self.height / 2, "straight"),
-            (self.inner_radius, 0, "straight"),
+            (self.inner_radius, -1 * self.height / 2, "straight")
         ]
 
         self.points = points

--- a/paramak/parametric_components/divertor_ITER.py
+++ b/paramak/parametric_components/divertor_ITER.py
@@ -126,14 +126,7 @@ class ITERtypeDivertor(RotateMixedShape):
         self.dome_pos = dome_pos
         self.dome_thickness = dome_thickness
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
 
     def create_vertical_target_points(
             self, anchor, coverage, tilt, radius, length):
@@ -311,7 +304,6 @@ class ITERtypeDivertor(RotateMixedShape):
 
         # append all points
         points = IVT_points + dome_points + OVT_points + casing_points
-        points.append(points[0])  # close surface
         self.points = points
 
 

--- a/paramak/parametric_components/inner_tf_coils_circular.py
+++ b/paramak/parametric_components/inner_tf_coils_circular.py
@@ -86,14 +86,7 @@ class InnerTfCoilsCircular(ExtrudeMixedShape):
         self.gap_size = gap_size
         self.distance = height
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
 
     @property
     def height(self):
@@ -223,9 +216,8 @@ class InnerTfCoilsCircular(ExtrudeMixedShape):
             (point_3[0], point_3[1], "straight"),
             (point_6[0], point_6[1], "circle"),
             (point_5[0], point_5[1], "circle"),
-            (point_4[0], point_4[1], "straight"),
-            (point_1[0], point_1[1], "straight"),
-        ]  # we have overwritten the setter which automatically adds the endpoint=first point, so we need to specify it explicitely
+            (point_4[0], point_4[1], "straight")
+        ]
 
         self.points = points
 

--- a/paramak/parametric_components/inner_tf_coils_flat.py
+++ b/paramak/parametric_components/inner_tf_coils_flat.py
@@ -86,14 +86,7 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
         self.gap_size = gap_size
         self.distance = height
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
 
     @property
     def height(self):
@@ -201,9 +194,8 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
             (point_1[0], point_1[1]),
             (point_3[0], point_3[1]),
             (point_6[0], point_6[1]),
-            (point_4[0], point_4[1]),
-            (point_1[0], point_1[1]),
-        ]  # we have overwritten the setter which automatically adds the endpoint=first point, so we need to specify it explicitely
+            (point_4[0], point_4[1])
+        ]
 
         self.points = points
 

--- a/paramak/parametric_components/poloidal_field_coil.py
+++ b/paramak/parametric_components/poloidal_field_coil.py
@@ -76,14 +76,7 @@ class PoloidalFieldCoil(RotateStraightShape):
         self.height = height
         self.width = width
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
 
     @property
     def center_point(self):
@@ -130,10 +123,6 @@ class PoloidalFieldCoil(RotateStraightShape):
                 self.center_point[0] - self.width / 2.0,
                 self.center_point[1] + self.height / 2.0,
             ),  # upper left
-            (
-                self.center_point[0] + self.width / 2.0,
-                self.center_point[1] + self.height / 2.0,
-            ),
         ]
 
         self.points = points

--- a/paramak/parametric_components/poloidal_field_coil_case.py
+++ b/paramak/parametric_components/poloidal_field_coil_case.py
@@ -6,8 +6,8 @@ class PoloidalFieldCoilCase(RotateStraightShape):
     describe the existing coil and the thickness of the casing required.
 
     Args:
-        height (float): the vertical (z axis) height of the coil (cm).
-        width (float): the horizontal(x axis) width of the coil (cm).
+        coil_height (float): the vertical (z axis) height of the coil (cm).
+        coil_width (float): the horizontal(x axis) width of the coil (cm).
         center_point (tuple of floats): the center of the coil (x,z) values (cm).
         casing_thickness (tuple of floats): the thickness of the coil casing (cm).
 
@@ -79,15 +79,8 @@ class PoloidalFieldCoilCase(RotateStraightShape):
         self.height = coil_height
         self.width = coil_width
         self.casing_thickness = casing_thickness
-
-    @property
-    def points(self):
+        
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, value):
-        self._points = value
 
     @property
     def center_point(self):
@@ -167,11 +160,7 @@ class PoloidalFieldCoilCase(RotateStraightShape):
                 (self.casing_thickness + self.width / 2.0),
                 self.center_point[1] + \
                 (self.casing_thickness + self.height / 2.0),
-            ),
-            (
-                self.center_point[0] + self.width / 2.0,
-                self.center_point[1] + self.height / 2.0,
-            ),  # upper right
+            )
         ]
 
         self.points = points

--- a/paramak/parametric_components/poloidal_field_coil_case.py
+++ b/paramak/parametric_components/poloidal_field_coil_case.py
@@ -79,7 +79,7 @@ class PoloidalFieldCoilCase(RotateStraightShape):
         self.height = coil_height
         self.width = coil_width
         self.casing_thickness = casing_thickness
-        
+
         self.find_points()
 
     @property

--- a/paramak/parametric_components/poloidal_field_coil_case_fc.py
+++ b/paramak/parametric_components/poloidal_field_coil_case_fc.py
@@ -77,14 +77,7 @@ class PoloidalFieldCoilCaseFC(RotateStraightShape):
         self.width = pf_coil.width
         self.casing_thickness = casing_thickness
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, value):
-        self._points = value
 
     @property
     def center_point(self):
@@ -164,11 +157,7 @@ class PoloidalFieldCoilCaseFC(RotateStraightShape):
                 (self.casing_thickness + self.width / 2.0),
                 self.center_point[1] + \
                 (self.casing_thickness + self.height / 2.0),
-            ),
-            (
-                self.center_point[0] + self.width / 2.0,
-                self.center_point[1] + self.height / 2.0,
-            ),  # upper right
+            )
         ]
 
         self.points = points

--- a/paramak/parametric_components/tokamak_plasma_from_points.py
+++ b/paramak/parametric_components/tokamak_plasma_from_points.py
@@ -101,14 +101,7 @@ class PlasmaFromPoints(Plasma):
         self.high_point = high_point
         self.lower_x_point, self.upper_x_point = self.compute_x_points()
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, value):
-        self._points = value
 
     @property
     def outer_equatorial_x_point(self):

--- a/paramak/parametric_components/tokamak_plasma_plasmaboundaries.py
+++ b/paramak/parametric_components/tokamak_plasma_plasmaboundaries.py
@@ -103,14 +103,7 @@ class PlasmaBoundaries(Plasma):
         self.low_point = None
         self.lower_x_point, self.upper_x_point = self.compute_x_points()
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, value):
-        self._points = value
 
     @property
     def vertical_displacement(self):

--- a/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
+++ b/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
@@ -95,14 +95,7 @@ class ToroidalFieldCoilCoatHanger(ExtrudeStraightShape):
         self.distance = distance
         self.number_of_coils = number_of_coils
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
 
     @property
     def azimuth_placement_angle(self):
@@ -174,7 +167,7 @@ class ToroidalFieldCoilCoatHanger(ExtrudeStraightShape):
             (
                 self.horizontal_start_point[0],
                 self.horizontal_start_point[1] + self.thickness,
-            ),  # upper right inner
+            )  # upper right inner
         ]
 
         self.points = points

--- a/paramak/parametric_components/toroidal_field_coil_princeton_d.py
+++ b/paramak/parametric_components/toroidal_field_coil_princeton_d.py
@@ -83,14 +83,7 @@ class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
         self.distance = distance
         self.number_of_coils = number_of_coils
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
 
     @property
     def azimuth_placement_angle(self):
@@ -192,7 +185,6 @@ class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
         outer_points[-1][2] = "straight"
 
         points = inner_points + outer_points
-        points.append(inner_points[0])
 
         self.points = points
 

--- a/paramak/parametric_components/toroidal_field_coil_rectangle.py
+++ b/paramak/parametric_components/toroidal_field_coil_rectangle.py
@@ -90,14 +90,7 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
         self.distance = distance
         self.number_of_coils = number_of_coils
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
 
     @property
     def azimuth_placement_angle(self):

--- a/paramak/parametric_components/toroidal_field_coil_triple_arc.py
+++ b/paramak/parametric_components/toroidal_field_coil_triple_arc.py
@@ -94,14 +94,7 @@ class ToroidalFieldCoilTripleArc(ExtrudeMixedShape):
         self.number_of_coils = number_of_coils
         self.vertical_displacement = vertical_displacement
 
-    @property
-    def points(self):
         self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
 
     @property
     def azimuth_placement_angle(self):
@@ -186,7 +179,6 @@ class ToroidalFieldCoilTripleArc(ExtrudeMixedShape):
         for i in range(len(R_outer)):
             points.append([R_outer[i], Z_outer[i], 'spline'])
         points[-1][2] = 'straight'
-        points.append(points[0])
         self.points = points
 
     def find_azimuth_placement_angle(self):


### PR DESCRIPTION
## Proposed changes

PR which removes the points getter/setter pair specified for each parametric component which overwrites the getter/setter pair in shape.py. As mentioned in #253, find_points() can be called directly outside a getter/setter and the points are checked for errors. 

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests
- [x] Code refactoring

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

A similar solution could be implemented for parametric components which overwrite the azimuth_placement_angle getter/setter pair when a method is called to calculate these angles.
