### PR TITLE
moved cut union intersect into shape

### DIFF
--- a/paramak/parametric_shapes/extruded_circle_shape.py
+++ b/paramak/parametric_shapes/extruded_circle_shape.py
@@ -68,39 +68,15 @@ class ExtrudeCircleShape(Shape):
             stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
+            cut=cut,
+            intersect=intersect,
+            union=union,
             **default_dict
         )
 
-        self.cut = cut
-        self.intersect = intersect
-        self.union = union
         self.radius = radius
         self.distance = distance
         self.solid = solid
-
-    @property
-    def cut(self):
-        return self._cut
-
-    @cut.setter
-    def cut(self, cut):
-        self._cut = cut
-
-    @property
-    def intersect(self):
-        return self._intersect
-
-    @intersect.setter
-    def intersect(self, value):
-        self._intersect = value
-
-    @property
-    def union(self):
-        return self._union
-
-    @union.setter
-    def union(self, value):
-        self._union = value
 
     @property
     def solid(self):

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -67,38 +67,14 @@ class ExtrudeMixedShape(Shape):
             stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
+            cut=cut,
+            intersect=intersect,
+            union=union,
             **default_dict
         )
 
-        self.cut = cut
-        self.intersect = intersect
-        self.union = union
         self.distance = distance
         self.solid = solid
-
-    @property
-    def cut(self):
-        return self._cut
-
-    @cut.setter
-    def cut(self, value):
-        self._cut = value
-
-    @property
-    def intersect(self):
-        return self._intersect
-
-    @intersect.setter
-    def intersect(self, value):
-        self._intersect = value
-
-    @property
-    def union(self):
-        return self._union
-
-    @union.setter
-    def union(self, value):
-        self._union = value
 
     @property
     def solid(self):

--- a/paramak/parametric_shapes/extruded_spline_shape.py
+++ b/paramak/parametric_shapes/extruded_spline_shape.py
@@ -65,38 +65,14 @@ class ExtrudeSplineShape(Shape):
             stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
+            cut=cut,
+            intersect=intersect,
+            union=union,
             **default_dict
         )
-
-        self.cut = cut
-        self.intersect = intersect
-        self.union = union
+        
         self.distance = distance
         self.solid = solid
-
-    @property
-    def cut(self):
-        return self._cut
-
-    @cut.setter
-    def cut(self, value):
-        self._cut = value
-
-    @property
-    def intersect(self):
-        return self._intersect
-
-    @intersect.setter
-    def intersect(self, value):
-        self._intersect = value
-
-    @property
-    def union(self):
-        return self._union
-
-    @union.setter
-    def union(self, value):
-        self._union = value
 
     @property
     def solid(self):

--- a/paramak/parametric_shapes/extruded_straight_shape.py
+++ b/paramak/parametric_shapes/extruded_straight_shape.py
@@ -66,38 +66,14 @@ class ExtrudeStraightShape(Shape):
             stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
+            cut=cut,
+            intersect=intersect,
+            union=union,
             **default_dict
         )
-
-        self.cut = cut
-        self.intersect = intersect
-        self.union = union
+        
         self.distance = distance
         self.solid = solid
-
-    @property
-    def cut(self):
-        return self._cut
-
-    @cut.setter
-    def cut(self, cut):
-        self._cut = cut
-
-    @property
-    def intersect(self):
-        return self._intersect
-
-    @intersect.setter
-    def intersect(self, value):
-        self._intersect = value
-
-    @property
-    def union(self):
-        return self._union
-
-    @union.setter
-    def union(self, value):
-        self._union = value
 
     @property
     def solid(self):

--- a/paramak/parametric_shapes/rotate_circle_shape.py
+++ b/paramak/parametric_shapes/rotate_circle_shape.py
@@ -65,39 +65,14 @@ class RotateCircleShape(Shape):
             stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
+            cut=cut,
+            intersect=intersect,
+            union=union,
             **default_dict
         )
-
-        self.cut = cut
-        self.intersect = intersect
-        self.union = union
         self.radius = radius
         self.rotation_angle = rotation_angle
         self.solid = solid
-
-    @property
-    def cut(self):
-        return self._cut
-
-    @cut.setter
-    def cut(self, value):
-        self._cut = value
-
-    @property
-    def intersect(self):
-        return self._intersect
-
-    @intersect.setter
-    def intersect(self, value):
-        self._intersect = value
-
-    @property
-    def union(self):
-        return self._union
-
-    @union.setter
-    def union(self, value):
-        self._union = value
 
     @property
     def solid(self):

--- a/paramak/parametric_shapes/rotate_mixed_shape.py
+++ b/paramak/parametric_shapes/rotate_mixed_shape.py
@@ -65,9 +65,9 @@ class RotateMixedShape(Shape):
             stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
-            cut=None,
-            intersect=None,
-            union=None,
+            cut=cut,
+            intersect=intersect,
+            union=union,
             **default_dict
         )
         self.rotation_angle = rotation_angle

--- a/paramak/parametric_shapes/rotate_mixed_shape.py
+++ b/paramak/parametric_shapes/rotate_mixed_shape.py
@@ -65,38 +65,13 @@ class RotateMixedShape(Shape):
             stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
+            cut=None,
+            intersect=None,
+            union=None,
             **default_dict
         )
-
-        self.cut = cut
-        self.intersect = intersect
-        self.union = union
         self.rotation_angle = rotation_angle
         self.solid = solid
-
-    @property
-    def cut(self):
-        return self._cut
-
-    @cut.setter
-    def cut(self, value):
-        self._cut = value
-
-    @property
-    def intersect(self):
-        return self._intersect
-
-    @intersect.setter
-    def intersect(self, value):
-        self._intersect = value
-
-    @property
-    def union(self):
-        return self._union
-
-    @union.setter
-    def union(self, value):
-        self._union = value
 
     @property
     def solid(self):

--- a/paramak/parametric_shapes/rotate_spline_shape.py
+++ b/paramak/parametric_shapes/rotate_spline_shape.py
@@ -63,38 +63,14 @@ class RotateSplineShape(Shape):
             stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
+            cut=cut,
+            intersect=intersect,
+            union=union,
             **default_dict
         )
 
-        self.cut = cut
-        self.intersect = intersect
-        self.union = union
         self.rotation_angle = rotation_angle
         self.solid = solid
-
-    @property
-    def cut(self):
-        return self._cut
-
-    @cut.setter
-    def cut(self, value):
-        self._cut = value
-
-    @property
-    def intersect(self):
-        return self._intersect
-
-    @intersect.setter
-    def intersect(self, value):
-        self._intersect = value
-
-    @property
-    def union(self):
-        return self._union
-
-    @union.setter
-    def union(self, value):
-        self._union = value
 
     @property
     def solid(self):

--- a/paramak/parametric_shapes/rotate_straight_shape.py
+++ b/paramak/parametric_shapes/rotate_straight_shape.py
@@ -64,38 +64,14 @@ class RotateStraightShape(Shape):
             stl_filename=stl_filename,
             azimuth_placement_angle=azimuth_placement_angle,
             workplane=workplane,
+            cut=cut,
+            intersect=intersect,
+            union=union,
             **default_dict
         )
 
-        self.cut = cut
-        self.intersect = intersect
-        self.union = union
         self.rotation_angle = rotation_angle
         self.solid = solid
-
-    @property
-    def cut(self):
-        return self._cut
-
-    @cut.setter
-    def cut(self, value):
-        self._cut = value
-
-    @property
-    def intersect(self):
-        return self._intersect
-
-    @intersect.setter
-    def intersect(self, value):
-        self._intersect = value
-
-    @property
-    def union(self):
-        return self._union
-
-    @union.setter
-    def union(self, value):
-        self._union = value
 
     @property
     def solid(self):

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -51,6 +51,9 @@ class Shape:
         tet_mesh=None,
         physical_groups=None,
         hash_value=None,
+        cut=None,
+        intersect=None,
+        union=None
     ):
 
         self.points = points
@@ -58,6 +61,10 @@ class Shape:
         self.stl_filename = stl_filename
         self.color = color
         self.name = name
+        
+        self.cut = cut
+        self.intersect = intersect
+        self.union = union
 
         self.azimuth_placement_angle = azimuth_placement_angle
         self.workplane = workplane
@@ -73,6 +80,31 @@ class Shape:
         self.render_mesh = None
         # self.volume = None
         self.hash_value = None
+
+
+    @property
+    def cut(self):
+        return self._cut
+
+    @cut.setter
+    def cut(self, value):
+        self._cut = value
+
+    @property
+    def intersect(self):
+        return self._intersect
+
+    @intersect.setter
+    def intersect(self, value):
+        self._intersect = value
+
+    @property
+    def union(self):
+        return self._union
+
+    @union.setter
+    def union(self, value):
+        self._union = value
 
     @property
     def workplane(self):


### PR DESCRIPTION
## Proposed changes

Code refactoring to move cut, union and intersect getter/setter pairs into shape.py and having each parametric shape inherit. This removes the need for boolean method getter/setter pairs in each parametric shape.
Ideally, the boolean commands for performing the operations should be moved out of create_solid() and into a common method in shape.py which is used in create_solid() by each parametric shape. This also allows the boolean operations to be used by Shape.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests
- [x] Code refactoring

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

No further comments
