### PR TITLE
moved boolean operations into shape

### DIFF
--- a/paramak/parametric_shapes/extruded_circle_shape.py
+++ b/paramak/parametric_shapes/extruded_circle_shape.py
@@ -5,7 +5,6 @@ from hashlib import blake2b
 import cadquery as cq
 
 from paramak import Shape
-from paramak.utils import cut_solid, intersect_solid, union_solid
 
 
 class ExtrudeCircleShape(Shape):
@@ -140,21 +139,6 @@ class ExtrudeCircleShape(Shape):
             solid = solid.rotate(
                 (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
 
-        # If a cut solid is provided then perform a boolean cut
-        if self.cut is not None:
-            solid = cut_solid(solid, self.cut)
-
-        # If an intersect is provided then perform a boolean intersect
-        if self.intersect is not None:
-            solid = intersect_solid(solid, self.intersect)
-
-        # If an intersect is provided then perform a boolean intersect
-        if self.union is not None:
-            solid = union_solid(solid, self.union)
-
-        self.solid = solid
-
-        # Calculate hash value for current solid
-        self.hash_value = self.get_hash()
+        self.perform_boolean_operations(solid)
 
         return solid

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -4,7 +4,6 @@ from hashlib import blake2b
 import cadquery as cq
 
 from paramak import Shape
-from paramak.utils import cut_solid, intersect_solid, union_solid
 
 
 class ExtrudeMixedShape(Shape):
@@ -163,21 +162,6 @@ class ExtrudeMixedShape(Shape):
             solid = solid.rotate(
                 (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
 
-        # If a cut solid is provided then perform a boolean cut
-        if self.cut is not None:
-            solid = cut_solid(solid, self.cut)
-
-        # If an intersect is provided then perform a boolean intersect
-        if self.intersect is not None:
-            solid = intersect_solid(solid, self.intersect)
-
-        # If an intersect is provided then perform a boolean intersect
-        if self.union is not None:
-            solid = union_solid(solid, self.union)
-
-        self.solid = solid
-
-        # Calculate hash value for current solid
-        self.hash_value = self.get_hash()
+        self.perform_boolean_operations(solid)
 
         return solid

--- a/paramak/parametric_shapes/extruded_spline_shape.py
+++ b/paramak/parametric_shapes/extruded_spline_shape.py
@@ -4,7 +4,6 @@ from hashlib import blake2b
 import cadquery as cq
 
 from paramak import Shape
-from paramak.utils import cut_solid, intersect_solid, union_solid
 
 
 class ExtrudeSplineShape(Shape):
@@ -128,21 +127,6 @@ class ExtrudeSplineShape(Shape):
             solid = solid.rotate(
                 (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
 
-        # If a cut solid is provided then perform a boolean cut
-        if self.cut is not None:
-            solid = cut_solid(solid, self.cut)
-
-        # If an intersect is provided then perform a boolean intersect
-        if self.intersect is not None:
-            solid = intersect_solid(solid, self.intersect)
-
-        # If an intersect is provided then perform a boolean intersect
-        if self.union is not None:
-            solid = union_solid(solid, self.union)
-
-        self.solid = solid
-
-        # Calculate hash value for current solid
-        self.hash_value = self.get_hash()
+        self.perform_boolean_operations(solid)
 
         return solid

--- a/paramak/parametric_shapes/extruded_straight_shape.py
+++ b/paramak/parametric_shapes/extruded_straight_shape.py
@@ -5,7 +5,6 @@ from hashlib import blake2b
 import cadquery as cq
 
 from paramak import Shape
-from paramak.utils import cut_solid, intersect_solid, union_solid
 
 
 class ExtrudeStraightShape(Shape):
@@ -129,21 +128,6 @@ class ExtrudeStraightShape(Shape):
             solid = solid.rotate(
                 (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
 
-        # If a cut solid is provided then perform a boolean cut
-        if self.cut is not None:
-            solid = cut_solid(solid, self.cut)
-
-        # If an intersect is provided then perform a boolean intersect
-        if self.intersect is not None:
-            solid = intersect_solid(solid, self.intersect)
-
-        # If an intersect is provided then perform a boolean intersect
-        if self.union is not None:
-            solid = union_solid(solid, self.union)
-
-        self.solid = solid
-
-        # Calculate hash value for current solid
-        self.hash_value = self.get_hash()
+        self.perform_boolean_operations(solid)
 
         return solid

--- a/paramak/parametric_shapes/rotate_circle_shape.py
+++ b/paramak/parametric_shapes/rotate_circle_shape.py
@@ -4,7 +4,6 @@ from hashlib import blake2b
 import cadquery as cq
 
 from paramak import Shape
-from paramak.utils import cut_solid, intersect_solid, union_solid
 
 
 class RotateCircleShape(Shape):
@@ -135,21 +134,6 @@ class RotateCircleShape(Shape):
             solid = solid.rotate(
                 (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
 
-        # If a cut solid is provided then perform a boolean cut
-        if self.cut is not None:
-            solid = cut_solid(solid, self.cut)
-
-        # If an intersect is provided then perform a boolean intersect
-        if self.intersect is not None:
-            solid = intersect_solid(solid, self.intersect)
-
-        # If an intersect is provided then perform a boolean intersect
-        if self.union is not None:
-            solid = union_solid(solid, self.union)
-
-        self.solid = solid
-
-        # Calculate hash value for current solid
-        self.hash_value = self.get_hash()
+        self.perform_boolean_operations(solid)
 
         return solid

--- a/paramak/parametric_shapes/rotate_mixed_shape.py
+++ b/paramak/parametric_shapes/rotate_mixed_shape.py
@@ -4,7 +4,6 @@ from hashlib import blake2b
 import cadquery as cq
 
 from paramak import Shape
-from paramak.utils import cut_solid, intersect_solid, union_solid
 
 
 class RotateMixedShape(Shape):
@@ -158,21 +157,6 @@ class RotateMixedShape(Shape):
             solid = solid.rotate(
                 (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
 
-        # If a cut solid is provided then perform a boolean cut
-        if self.cut is not None:
-            solid = cut_solid(solid, self.cut)
-
-        # If an intersect is provided then perform a boolean intersect
-        if self.intersect is not None:
-            solid = intersect_solid(solid, self.intersect)
-
-        # If an intersect is provided then perform a boolean intersect
-        if self.union is not None:
-            solid = union_solid(solid, self.union)
-
-        self.solid = solid
-
-        # Calculate hash value for current solid
-        self.hash_value = self.get_hash()
+        self.perform_boolean_operations(solid)
 
         return solid

--- a/paramak/parametric_shapes/rotate_spline_shape.py
+++ b/paramak/parametric_shapes/rotate_spline_shape.py
@@ -5,7 +5,6 @@ from hashlib import blake2b
 import cadquery as cq
 
 from paramak import Shape
-from paramak.utils import cut_solid, intersect_solid, union_solid
 
 
 class RotateSplineShape(Shape):
@@ -126,21 +125,6 @@ class RotateSplineShape(Shape):
             solid = solid.rotate(
                 (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
 
-        # If a cut solid is provided then perform a boolean cut
-        if self.cut is not None:
-            solid = cut_solid(solid, self.cut)
-
-        # If an intersect is provided then perform a boolean intersect
-        if self.intersect is not None:
-            solid = intersect_solid(solid, self.intersect)
-
-        # If an intersect is provided then perform a boolean intersect
-        if self.union is not None:
-            solid = union_solid(solid, self.union)
-
-        self.solid = solid
-
-        # Calculate hash value for current solid
-        self.hash_value = self.get_hash()
+        self.perform_boolean_operations(solid)
 
         return solid

--- a/paramak/parametric_shapes/rotate_straight_shape.py
+++ b/paramak/parametric_shapes/rotate_straight_shape.py
@@ -3,7 +3,6 @@ from collections import Iterable
 import cadquery as cq
 
 from paramak import Shape
-from paramak.utils import cut_solid, intersect_solid, union_solid
 
 
 class RotateStraightShape(Shape):
@@ -127,21 +126,6 @@ class RotateStraightShape(Shape):
             solid = solid.rotate(
                 (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
 
-        # If a cut solid is provided then perform a boolean cut
-        if self.cut is not None:
-            solid = cut_solid(solid, self.cut)
-
-        # If an intersect is provided then perform a boolean intersect
-        if self.intersect is not None:
-            solid = intersect_solid(solid, self.intersect)
-
-        # If an intersect is provided then perform a boolean intersect
-        if self.union is not None:
-            solid = union_solid(solid, self.union)
-
-        self.solid = solid
-
-        # Calculate hash value for current solid
-        self.hash_value = self.get_hash()
+        self.perform_boolean_operations(solid)
 
         return solid

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -13,6 +13,7 @@ from PIL import Image
 from hashlib import blake2b
 
 from cadquery import exporters
+from paramak.utils import cut_solid, intersect_solid, union_solid
 
 
 class Shape:
@@ -698,3 +699,24 @@ class Shape:
         hash_object.update(str(list(shape_dict.values())).encode("utf-8"))
         value = hash_object.hexdigest()
         return value
+
+    def perform_boolean_operations(self, solid):
+        """Performs boolean cut, intersect and union operations if shapes are provided"""
+
+        # If a cut solid is provided then perform a boolean cut
+        if self.cut is not None:
+            solid = cut_solid(solid, self.cut)
+
+        # If an intersect is provided then perform a boolean intersect
+        if self.intersect is not None:
+            solid = intersect_solid(solid, self.intersect)
+
+        # If an intersect is provided then perform a boolean intersect
+        if self.union is not None:
+            solid = union_solid(solid, self.union)
+
+        self.solid = solid
+
+        self.hash_value = self.get_hash()
+
+        return solid


### PR DESCRIPTION
## Proposed changes

PR which moves the boolean operations of cut, union and intersect into shape.py. create_solid() for each parametric_shape calls perform_boolean_operations() method which performs the operations if any of the boolean attributes of the Shape object have been set.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

No further comments
