### PR TITLE
added tests for azimuth_placement_angles as iterables

### DIFF
--- a/tests/test_RotateSplineShape.py
+++ b/tests/test_RotateSplineShape.py
@@ -42,6 +42,14 @@ class test_object_properties(unittest.TestCase):
         assert outer_shape_with_cut.volume == pytest.approx(
             2881.76 - 900.88, abs=0.2)
 
+    def test_shape_azimuth_placement_angles_iterabel(self):
+        """checks that azimuth_placement_angle can take an Iterable
+        """
+        test_shape = RotateSplineShape(
+            points=[(200, 100), (200, 200), (500, 200), (500, 100)],
+            azimuth_placement_angle=[0, 180])
+        assert test_shape.solid is not None
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_RotateStraightShape.py
+++ b/tests/test_RotateStraightShape.py
@@ -62,6 +62,14 @@ class test_object_properties(unittest.TestCase):
         test_shape.azimuth_placement_angle = [0, 90, 180, 360]
         assert test_shape.azimuth_placement_angle == [0, 90, 180, 360]
 
+    def test_shape_azimuth_placement_angles_iterabel(self):
+        """checks that azimuth_placement_angle can take an Iterable
+        """
+        test_shape = RotateStraightShape(
+            points=[(200, 100), (200, 200), (500, 200), (500, 100)],
+            azimuth_placement_angle=[0, 180])
+        assert test_shape.solid is not None
+
     def test_absolute_shape_volume(self):
         """creates a rotated straight shape using straight connections and checks that the
         volume is correct"""


### PR DESCRIPTION
## Proposed changes

This very small PR adds tests which check that `RotateSplineShape` and `RotateStraightShape `can accept iterables for `azimuth_placement_angles`. I ran the coverage locally and got 96%! 🟢 

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)