### PR TITLE
added segments maker feature

### DIFF
--- a/docs/source/example_parametric_components.rst
+++ b/docs/source/example_parametric_components.rst
@@ -42,3 +42,17 @@ make_demo_style_blankets.py
    :show-inheritance:
 
 `Link to script <https://github.com/ukaea/paramak/blob/main/examples/example_parametric_components/make_demo_style_blankets.py>`_
+
+make_firstwall_for_neutron_wall_loading.py
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. image:: https://user-images.githubusercontent.com/8583900/93807581-bc92cd80-fc42-11ea-8522-7fe14287b3c4.png
+   :width: 437
+   :height: 807
+   :align: center
+
+.. automodule:: examples.example_parametric_components.make_firstwall_for_neutron_wall_loading
+   :members:
+   :show-inheritance:
+
+`Link to script <https://github.com/ukaea/paramak/blob/main/examples/example_parametric_components/make_firstwall_for_neutron_wall_loading.py>`_

--- a/docs/source/paramak.parametric_components.rst
+++ b/docs/source/paramak.parametric_components.rst
@@ -222,6 +222,20 @@ PoloidalFieldCoilCase()
    :members:
    :show-inheritance:
 
+
+PoloidalSegmenter()
+^^^^^^^^^^^^^^^^^^^
+
+.. image:: https://user-images.githubusercontent.com/8583900/93811079-84da5480-fc47-11ea-9c6c-7fd132f6d72d.png
+    :width: 605px
+    :height: 563px
+    :align: center
+
+.. automodule:: paramak.parametric_components.poloidal_segmenter
+   :members:
+   :show-inheritance:
+
+
 Plasma()
 ^^^^^^^^
 

--- a/examples/example_parametric_components/make_demo_style_blankets.py
+++ b/examples/example_parametric_components/make_demo_style_blankets.py
@@ -9,7 +9,7 @@ import numpy as np
 import paramak
 
 
-def main():
+def make_demo_blanket(number_of_sections=8, gap_size=15, central_block_width=200):
 
     number_of_segments = 8
     gap_size = 15.
@@ -114,4 +114,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    make_demo_blanket()

--- a/examples/example_parametric_components/make_demo_style_blankets.py
+++ b/examples/example_parametric_components/make_demo_style_blankets.py
@@ -113,7 +113,7 @@ def make_demo_blanket(
     )
 
     # saves the blanket as an stp file
-    inboard_blanket.export_stp('segmented_blanket.stp')
+    inboard_blanket.export_stp('blanket.stp')
 
 
 if __name__ == "__main__":

--- a/examples/example_parametric_components/make_firstwall_for_neutron_wall_loading.py
+++ b/examples/example_parametric_components/make_firstwall_for_neutron_wall_loading.py
@@ -1,0 +1,37 @@
+
+"""
+For some neutronics tallies such as neutron wall loading it is necessary to 
+segment the geometry so that individual neutronics tallies can be recorded
+for each face. This can be done using the PoloidalSegments(). This geometry
+is then easier to find neutron wall loading as a function of poloidal angle.
+"""
+
+import math
+import numpy as np
+import paramak
+
+
+def make_segmented_firstwall():
+
+    # makes the firstwall 
+    firstwall = paramak.BlanketFP(minor_radius=150,
+                                  major_radius=450,
+                                  triangularity=0.55,
+                                  elongation=2.0,
+                                  thickness=2,
+                                  start_angle=270,
+                                  stop_angle=-90,
+                                  rotation_angle=10)
+
+    # segments the firstwall poloidally into 40 equal angle segments
+    segmented_firstwall = paramak.PoloidalSegments(
+            shape_to_segment=firstwall,
+            center_point=(450, 0),  # this is the middle of the plasma
+            number_of_segments=40,
+        )
+
+    # saves the segmented firstwall as an stp file
+    segmented_firstwall.export_stp('segmented_firstwall.stp')
+
+if __name__ == "__main__":
+    make_segmented_firstwall()

--- a/examples/example_parametric_reactors/make_all_parametric_reactors_images_for_docs.py
+++ b/examples/example_parametric_reactors/make_all_parametric_reactors_images_for_docs.py
@@ -17,6 +17,7 @@ def export_images():
         with open(reactor.name + ".svg", "w") as f:
             exporters.exportShape(reactor.solid, "SVG", f)
 
+        reactor.export_stp(output_folder=reactor.name)
 
 if __name__ == "__main__":
     export_images()

--- a/paramak/__init__.py
+++ b/paramak/__init__.py
@@ -47,6 +47,7 @@ from .parametric_components.center_column_flat_top_circular import (
 from .parametric_components.poloidal_field_coil import PoloidalFieldCoil
 from .parametric_components.poloidal_field_coil_case import PoloidalFieldCoilCase
 from .parametric_components.poloidal_field_coil_case_fc import PoloidalFieldCoilCaseFC
+from .parametric_components.poloidal_segmenter import PoloidalSegments
 
 from .parametric_components.inner_tf_coils_circular import InnerTfCoilsCircular
 from .parametric_components.inner_tf_coils_flat import InnerTfCoilsFlat

--- a/paramak/parametric_components/poloidal_segmenter.py
+++ b/paramak/parametric_components/poloidal_segmenter.py
@@ -7,7 +7,9 @@ from paramak.utils import rotate, intersect_solid, coefficients_of_line_from_poi
 
 
 class PoloidalSegments(RotateStraightShape):
-    """Creates a series of wedges from a central ring, useful for segmenting geometry poloidally.
+    """Creates a ring of wedges from a central point. When provided with a shape_to_segment the shape
+    will be segmented by the wedges. This is useful for segmenting geometry into equal poloidal angles.
+    Intended to segment the firstwall geometry for using in neutron wall loading simulations.
 
     Args:
         shape_to_segment (paramak.Shape): the Shape to segment, if None then the segmenting solids will be returned

--- a/paramak/parametric_components/poloidal_segmenter.py
+++ b/paramak/parametric_components/poloidal_segmenter.py
@@ -1,0 +1,190 @@
+import math
+import numpy as np
+import cadquery as cq
+
+from paramak import RotateStraightShape
+from paramak.utils import rotate
+
+
+class PoloidalSegments(RotateStraightShape):
+    """Creates a series of wedges from a central ring, useful for segmenting geometry poloidally.
+
+    Args:
+        height (float): the vertical (z axis) height of the segments (cm).
+        width (float): the maximum horizontal (x axis) width of the segments from the center_point outwards (cm).
+        center_point (tuple of floats): the center of the segmentation wedges (x,z) values (cm).
+        segments (int): the number of segments in 360 degrees.
+
+    Keyword Args:
+        name (str): the legend name used when exporting a html graph of the shape.
+        color (sequences of 3 or 4 floats each in the range 0-1): the color to use when
+            exportin as html graphs or png images.
+        material_tag (str): The material name to use when exporting the neutronics description.
+        stp_filename (str): The filename used when saving stp files as part of a reactor.
+        azimuth_placement_angle (float or iterable of floats): The angle or angles to use when
+            rotating the shape on the azimuthal axis.
+        rotation_angle (float): The rotation angle to use when revolving the solid (degrees).
+        workplane (str): The orientation of the CadQuery workplane. Options are XY, YZ or XZ.
+        intersect (CadQuery object): An optional CadQuery object to perform a boolean intersect with
+            this object.
+        cut (CadQuery object): An optional CadQuery object to perform a boolean cut with this object.
+        union (CadQuery object): An optional CadQuery object to perform a boolean union with this object.
+        tet_mesh (str): Insert description.
+        physical_groups (type): Insert description.
+
+    Returns:
+        a paramak shape object: A shape object that has generic functionality with points determined by the find_points() method. A CadQuery solid of the shape can be called via shape.solid.
+    """
+
+    def __init__(
+        self,
+        center_point,
+        segments=10,
+        max_distance_from_center=1000,
+        rotation_angle=360,
+        stp_filename="PoloidalSegmenter.stp",
+        stl_filename="PoloidalSegmenter.stl",
+        color=(0.5, 0.5, 0.5),
+        azimuth_placement_angle=0,
+        name="poloidal_segmenter",
+        material_tag="poloidal_segmenter_mat",
+        **kwargs
+    ):
+
+        default_dict = {
+            "points": None,
+            "workplane": "XZ",
+            "solid": None,
+            "intersect": None,
+            "cut": None,
+            "union": None,
+            "tet_mesh": None,
+            "physical_groups": None,
+        }
+
+        for arg in kwargs:
+            if arg in default_dict:
+                default_dict[arg] = kwargs[arg]
+
+        super().__init__(
+            name=name,
+            color=color,
+            material_tag=material_tag,
+            stp_filename=stp_filename,
+            stl_filename=stl_filename,
+            azimuth_placement_angle=azimuth_placement_angle,
+            rotation_angle=rotation_angle,
+            hash_value=None,
+            **default_dict
+        )
+
+        self.center_point = center_point
+        self.segments = segments
+        self.max_distance_from_center = max_distance_from_center
+
+        self.find_points()
+    
+    @property
+    def segments(self):
+        return self._segments
+
+    @segments.setter
+    def segments(self, value):
+        if isinstance(value, int) is False:
+            raise ValueError("PoloidalSegmenter.segments must be an int.")
+        if value < 1:
+            raise ValueError("PoloidalSegmenter.segments must be a minimum of 1.")
+        self._segments = value
+
+    @property
+    def center_point(self):
+        return self._center_point
+
+    @center_point.setter
+    def center_point(self, center_point):
+        self._center_point = center_point
+
+    @property
+    def max_distance_from_center(self):
+        return self._max_distance_from_center
+
+    @max_distance_from_center.setter
+    def max_distance_from_center(self, value):
+        self._max_distance_from_center = value
+
+    @property
+    def solid(self):
+        #TODO
+        #if self.get_hash() != self.hash_value:
+        self.create_solid()
+        return self._solid
+
+    @solid.setter
+    def solid(self, value):
+        self._solid = value
+
+    def find_points(self):
+        """Finds the XZ points joined by straight connections that describe the 2D
+        profile of the poloidal segmentation shape."""
+
+        angle_per_segment = 360. / self.segments
+
+        points = []
+
+        current_angle = 0
+        outer_point = (self.center_point[0]+self.max_distance_from_center, self.center_point[1])
+        for i in range(self.segments):
+            points.append(self.center_point)
+
+            outer_point_1 = rotate(self.center_point, outer_point, math.radians(current_angle))
+            outer_point_2 = rotate(self.center_point, outer_point, math.radians(current_angle + angle_per_segment))
+
+            if outer_point_1[0] < 0:
+                points.append((0, outer_point_1[1]))
+            else:
+                points.append(outer_point_1)
+
+            if outer_point_2[0] < 0:
+                points.append((0, outer_point_2[1]))
+            else:
+                points.append(outer_point_2)
+
+            current_angle = current_angle + angle_per_segment
+
+        self.points = points
+
+    def create_solid(self):
+        """Creates a 3d solid using points with straight connections
+           edges, azimuth_placement_angle and rotation angle.
+
+           individual solids in the compound can be accessed using .Solids()[i] where i is an int
+
+           Returns:
+              A CadQuery solid: A 3D solid volume
+        """
+
+        # Creates a cadquery solid from points and revolves
+
+        it = iter(self.points)
+        local_solids=[]
+        for p1, p2, p3 in zip(it, it, it):
+
+            solid = (
+                cq.Workplane(self.workplane)
+                .polyline([p1, p2, p3])
+                .close()
+                .revolve(self.rotation_angle)
+            )
+            local_solids.append(solid)
+
+        compound = cq.Compound.makeCompound(
+            [a.val() for a in local_solids]
+        )
+
+        self.solid = compound
+
+        #TODO
+        # # Calculate hash value for current solid
+        # self.hash_value = self.get_hash()
+
+        return solid

--- a/paramak/parametric_components/poloidal_segmenter.py
+++ b/paramak/parametric_components/poloidal_segmenter.py
@@ -3,17 +3,16 @@ import numpy as np
 import cadquery as cq
 
 from paramak import RotateStraightShape
-from paramak.utils import rotate
-
+from paramak.utils import rotate, intersect_solid, coefficients_of_line_from_points
 
 class PoloidalSegments(RotateStraightShape):
     """Creates a series of wedges from a central ring, useful for segmenting geometry poloidally.
 
     Args:
-        height (float): the vertical (z axis) height of the segments (cm).
-        width (float): the maximum horizontal (x axis) width of the segments from the center_point outwards (cm).
+        shape_to_segment (paramak.Shape): the Shape to segment, if None then the segmenting solids will be returned
+        max_distance_from_center (float): the maximum distance from the center_point outwards (cm).
         center_point (tuple of floats): the center of the segmentation wedges (x,z) values (cm).
-        segments (int): the number of segments in 360 degrees.
+        number_of_segments (int): the number of equal angles segments in 360 degrees.
 
     Keyword Args:
         name (str): the legend name used when exporting a html graph of the shape.
@@ -39,7 +38,8 @@ class PoloidalSegments(RotateStraightShape):
     def __init__(
         self,
         center_point,
-        segments=10,
+        shape_to_segment=None,
+        number_of_segments=10,
         max_distance_from_center=1000,
         rotation_angle=360,
         stp_filename="PoloidalSegmenter.stp",
@@ -79,22 +79,31 @@ class PoloidalSegments(RotateStraightShape):
         )
 
         self.center_point = center_point
-        self.segments = segments
+        self.shape_to_segment = shape_to_segment
+        self.number_of_segments = number_of_segments
         self.max_distance_from_center = max_distance_from_center
 
         self.find_points()
-    
-    @property
-    def segments(self):
-        return self._segments
 
-    @segments.setter
-    def segments(self, value):
+    @property
+    def number_of_segments(self):
+        return self._number_of_segments
+
+    @number_of_segments.setter
+    def number_of_segments(self, value):
         if isinstance(value, int) is False:
-            raise ValueError("PoloidalSegmenter.segments must be an int.")
+            raise ValueError("PoloidalSegmenter.number_of_segments must be an int.")
         if value < 1:
-            raise ValueError("PoloidalSegmenter.segments must be a minimum of 1.")
-        self._segments = value
+            raise ValueError("PoloidalSegmenter.number_of_segments must be a minimum of 1.")
+        self._number_of_segments = value
+
+    @property
+    def shape_to_segment(self):
+        return self._shape_to_segment
+
+    @shape_to_segment.setter
+    def shape_to_segment(self, value):
+        self._shape_to_segment = value
 
     @property
     def center_point(self):
@@ -127,25 +136,27 @@ class PoloidalSegments(RotateStraightShape):
         """Finds the XZ points joined by straight connections that describe the 2D
         profile of the poloidal segmentation shape."""
 
-        angle_per_segment = 360. / self.segments
+        angle_per_segment = 360. / self.number_of_segments
 
         points = []
 
         current_angle = 0
         outer_point = (self.center_point[0]+self.max_distance_from_center, self.center_point[1])
-        for i in range(self.segments):
+        for i in range(self.number_of_segments):
             points.append(self.center_point)
 
             outer_point_1 = rotate(self.center_point, outer_point, math.radians(current_angle))
             outer_point_2 = rotate(self.center_point, outer_point, math.radians(current_angle + angle_per_segment))
 
             if outer_point_1[0] < 0:
-                points.append((0, outer_point_1[1]))
+                m, c = coefficients_of_line_from_points(outer_point_1, self.center_point)
+                points.append((0, c))
             else:
                 points.append(outer_point_1)
 
             if outer_point_2[0] < 0:
-                points.append((0, outer_point_2[1]))
+                m, c = coefficients_of_line_from_points(outer_point_2, self.center_point)
+                points.append((0, c))
             else:
                 points.append(outer_point_2)
 
@@ -163,11 +174,9 @@ class PoloidalSegments(RotateStraightShape):
               A CadQuery solid: A 3D solid volume
         """
 
-        # Creates a cadquery solid from points and revolves
-
-        it = iter(self.points)
-        local_solids=[]
-        for p1, p2, p3 in zip(it, it, it):
+        iter_points = iter(self.points)
+        triangle_wedges = []
+        for p1, p2, p3 in zip(iter_points, iter_points, iter_points):
 
             solid = (
                 cq.Workplane(self.workplane)
@@ -175,11 +184,24 @@ class PoloidalSegments(RotateStraightShape):
                 .close()
                 .revolve(self.rotation_angle)
             )
-            local_solids.append(solid)
+            triangle_wedges.append(solid)
 
-        compound = cq.Compound.makeCompound(
-            [a.val() for a in local_solids]
-        )
+        if self.shape_to_segment is None:
+
+            compound = cq.Compound.makeCompound(
+                [a.val() for a in triangle_wedges]
+            )
+
+        else:
+
+            intersected_solids = []
+            for segment in triangle_wedges:
+                overlap = intersect_solid(segment, self.shape_to_segment)
+                intersected_solids.append(overlap)
+
+            compound = cq.Compound.makeCompound(
+                [a.val() for a in intersected_solids]
+            )
 
         self.solid = compound
 
@@ -187,4 +209,4 @@ class PoloidalSegments(RotateStraightShape):
         # # Calculate hash value for current solid
         # self.hash_value = self.get_hash()
 
-        return solid
+        return compound

--- a/paramak/parametric_shapes/rotate_straight_shape.py
+++ b/paramak/parametric_shapes/rotate_straight_shape.py
@@ -123,8 +123,6 @@ class RotateStraightShape(Shape):
               A CadQuery solid: A 3D solid volume
         """
 
-        # print('create_solid() has been called')
-
         # Creates a cadquery solid from points and revolves
         solid = (
             cq.Workplane(self.workplane)

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -95,7 +95,7 @@ class Reactor:
 
     @property
     def solid(self):
-        """This combines all the parametric shapes and compents in th reactor object
+        """This combines all the parametric shapes and compents in the reactor object
         and rotates the viewing angle so that .solid operations in jupyter notebook
         and svg exports are better orientation.
         """

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -165,3 +165,21 @@ def distance_between_two_points(A, B):
     xb, yb = B
     u_vec = [xb - xa, yb - ya]
     return np.linalg.norm(u_vec)
+
+
+def coefficients_of_line_from_points(point1, point2):
+    """Computes the m and c coefficients of the equation (y=mx+c) for
+    a straight line from two points
+
+    Args:
+        point1 (float, float): point 1 coordinates
+        point2 (float, float): point 2 coordinates
+
+    Returns:
+        (float, float): m coefficent and c coefficient 
+    """
+    points = [point1, point2]
+    x_coords, y_coords = zip(*points)
+    A = np.vstack([x_coords, np.ones(len(x_coords))]).T
+    m, c = np.linalg.lstsq(A, y_coords, rcond=None)[0]
+    return m, c

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -7,6 +7,24 @@ import pytest
 import paramak
 
 
+class test_PoloidalSegments(unittest.TestCase):
+    def test_PoloidalSegments_makes_correct_number_of_solids(self):
+        """creates a rotated ring and segments it into poloidal sections"""
+
+        test_shape_to_segment = paramak.PoloidalFieldCoil(height=100,
+                                                          width=100,
+                                                          center_point=(500, 500))
+
+        test_shape = paramak.BlanketFP(
+            shape_to_segment=test_shape_to_segment,
+            center_point=(500, 500),
+            number_of_segments=22,
+        )
+
+        assert test_shape.solid is not None
+        assert len(test_shape.Solids()) == 22
+
+
 class test_BlanketConstantThicknessArcV(unittest.TestCase):
     def test_BlanketConstantThickness_creation(self):
         """creates a blanket using the BlanketConstantThicknessArcV parametric component

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -8,6 +8,25 @@ import paramak
 
 
 class test_PoloidalSegments(unittest.TestCase):
+
+    def test_PoloidalSegments_solid_count_with_incorect_input(self):
+        """checks the segmenter does not take a float as an input"""
+        def create_shape():
+            test_shape_to_segment = paramak.PoloidalFieldCoil(
+                height=100,
+                width=100,
+                center_point=(500, 500)
+            )
+
+            paramak.PoloidalSegments(
+                shape_to_segment=test_shape_to_segment,
+                center_point=(500, 500),
+                number_of_segments=22.5,
+            )
+
+        self.assertRaises(
+            ValueError, create_shape)
+
     def test_PoloidalSegments_solid_count(self):
         """creates a rotated hollow ring and segments it into poloidal sections"""
 

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -15,7 +15,7 @@ class test_PoloidalSegments(unittest.TestCase):
                                                           width=100,
                                                           center_point=(500, 500))
 
-        test_shape = paramak.BlanketFP(
+        test_shape = paramak.PoloidalSegments(
             shape_to_segment=test_shape_to_segment,
             center_point=(500, 500),
             number_of_segments=22,

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -27,6 +27,24 @@ class test_PoloidalSegments(unittest.TestCase):
         self.assertRaises(
             ValueError, create_shape)
 
+    def test_PoloidalSegments_solid_count_with_incorect_inputs2(self):
+        """checks the segmenter does not take a negative int as an input"""
+        def create_shape():
+            test_shape_to_segment = paramak.PoloidalFieldCoil(
+                height=100,
+                width=100,
+                center_point=(500, 500)
+            )
+
+            paramak.PoloidalSegments(
+                shape_to_segment=test_shape_to_segment,
+                center_point=(500, 500),
+                number_of_segments=-5,
+            )
+
+        self.assertRaises(
+            ValueError, create_shape)
+
     def test_PoloidalSegments_solid_count(self):
         """creates a rotated hollow ring and segments it into poloidal sections"""
 

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -8,12 +8,19 @@ import paramak
 
 
 class test_PoloidalSegments(unittest.TestCase):
-    def test_PoloidalSegments_makes_correct_number_of_solids(self):
-        """creates a rotated ring and segments it into poloidal sections"""
+    def test_PoloidalSegments_solid_count(self):
+        """creates a rotated hollow ring and segments it into poloidal sections"""
 
-        test_shape_to_segment = paramak.PoloidalFieldCoil(height=100,
-                                                          width=100,
-                                                          center_point=(500, 500))
+        pf_coil = paramak.PoloidalFieldCoil(
+            height=100,
+            width=100,
+            center_point=(500, 500)
+        )
+
+        test_shape_to_segment = paramak.PoloidalFieldCoilCaseFC(
+            pf_coil=pf_coil,
+            casing_thickness=100
+        )
 
         test_shape = paramak.PoloidalSegments(
             shape_to_segment=test_shape_to_segment,
@@ -22,7 +29,25 @@ class test_PoloidalSegments(unittest.TestCase):
         )
 
         assert test_shape.solid is not None
-        assert len(test_shape.Solids()) == 22
+        assert len(test_shape.solid.Solids()) == 22
+
+    def test_PoloidalSegments_solid_count2(self):
+        """creates a rotated ring and segments it into poloidal sections"""
+
+        test_shape_to_segment = paramak.PoloidalFieldCoil(
+            height=100,
+            width=100,
+            center_point=(500, 500)
+        )
+
+        test_shape = paramak.PoloidalSegments(
+            shape_to_segment=test_shape_to_segment,
+            center_point=(500, 500),
+            number_of_segments=22,
+        )
+
+        assert test_shape.solid is not None
+        assert len(test_shape.solid.Solids()) == 22
 
 
 class test_BlanketConstantThicknessArcV(unittest.TestCase):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -228,6 +228,16 @@ class test_object_properties(unittest.TestCase):
         assert Path(output_filename).exists() is True
         os.system("rm " + output_filename)
 
+    def test_make_segmented_firstwall(self):
+        """Runs the example and checks the output files are produced"""
+        os.chdir(Path(cwd))
+        os.chdir(Path("examples/example_parametric_components"))
+        output_filename = "segmented_firstwall.stp"
+        os.system("rm " + output_filename)
+        os.system("python make_firstwall_for_neutron_wall_loading.py")
+        assert Path(output_filename).exists() is True
+        os.system("rm " + output_filename)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -218,11 +218,11 @@ class test_object_properties(unittest.TestCase):
             assert Path(output_filename).exists() is True
             os.system("rm " + output_filename)
 
-    def test_make_demo_style_segmented_blanket(self):
+    def test_make_demo_style_blanket(self):
         """Runs the example and checks the output files are produced"""
         os.chdir(Path(cwd))
         os.chdir(Path("examples/example_parametric_components"))
-        output_filename = "segmented_blanket.stp"
+        output_filename = "blanket.stp"
         os.system("rm " + output_filename)
         os.system("python make_demo_style_blankets.py")
         assert Path(output_filename).exists() is True


### PR DESCRIPTION
## Proposed changes

This adds a PoloidalSegmenter component that can be used to segment up other components poloidally

Future use of this PoloidalSegmenter would be to use an intersect method together with another component to segment the component up poloidally. This is useful for neutron wall loading tallies where the number of neutrons passing through the first wall is needed as a function of poloidal angle

![Screenshot from 2020-09-20 22-15-00](https://user-images.githubusercontent.com/8583900/93722454-cce97080-fb8e-11ea-968c-d001774c578e.png)


## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [x] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

There is still lots to do to make this complete. 
- A utility function must be added to allow the component to be intersected with this component.
- Tests
- Example in the documentation

