### PR TITLE
Improved magnet set example and code reduction using PoloidalFieldCoilSet

### DIFF
--- a/examples/example_parametric_components/make_magnet_set.py
+++ b/examples/example_parametric_components/make_magnet_set.py
@@ -45,10 +45,9 @@ def main():
 
     pf_coils_casing = paramak.PoloidalFieldCoilCaseSetFC(
         pf_coils=pf_coils,
-        casing_thicknesses=[10]*6,
+        casing_thicknesses=[10] * 6,
         rotation_angle=180
     )
-
 
     pf_coils.export_stp('pf_coils.stp')
     pf_coils_casing.export_stp('pf_coils_casing.stp')

--- a/examples/example_parametric_components/make_magnet_set.py
+++ b/examples/example_parametric_components/make_magnet_set.py
@@ -19,14 +19,16 @@ def main():
         outer_radius=430,
         number_of_coils=number_of_toroidal_field_coils,
         gap_size=5,
+        rotation_angle=180
     )
 
     outer_tf = paramak.ToroidalFieldCoilPrincetonD(
-        R1=410,
+        R1=400,
         R2=1500,  # height
         thickness=50,
         distance=130,
         number_of_coils=number_of_toroidal_field_coils,
+        rotation_angle=180,
         azimuth_placement_angle=np.linspace(
             0 + angle_offset, 360 + angle_offset,
             number_of_toroidal_field_coils,
@@ -34,54 +36,22 @@ def main():
         )
     )
 
-    pf_coil1 = paramak.PoloidalFieldCoil(
-        height=120,
-        width=120,
-        center_point=(530, 930),
+    pf_coils = paramak.PoloidalFieldCoilSet(
+        heights=[100, 120, 80, 80, 120, 180],
+        widths=[100, 120, 80, 80, 120, 180],
+        center_points=[(530, 930), (1370, 790), (1740, 250), (1750, -250), (1360, -780), (680, -1000)],
         rotation_angle=180
     )
 
-    pf_coil2 = paramak.PoloidalFieldCoil(
-        height=140,
-        width=140,
-        center_point=(1370, 790),
+    pf_coils_casing = paramak.PoloidalFieldCoilCaseSetFC(
+        pf_coils=pf_coils,
+        casing_thicknesses=[10]*6,
         rotation_angle=180
     )
 
-    pf_coil3 = paramak.PoloidalFieldCoil(
-        height=100,
-        width=100,
-        center_point=(1740, 250),
-        rotation_angle=180
-    )
 
-    pf_coil4 = paramak.PoloidalFieldCoil(
-        height=100,
-        width=100,
-        center_point=(1750, -250),
-        rotation_angle=180
-    )
-
-    pf_coil5 = paramak.PoloidalFieldCoil(
-        height=140,
-        width=140,
-        center_point=(1360, -780),
-        rotation_angle=180
-    )
-
-    pf_coil6 = paramak.PoloidalFieldCoil(
-        height=200,
-        width=200,
-        center_point=(680, -1000),
-        rotation_angle=180
-    )
-
-    pf_coil1.export_stp('pf_coil1.stp')
-    pf_coil2.export_stp('pf_coil2.stp')
-    pf_coil3.export_stp('pf_coil3.stp')
-    pf_coil4.export_stp('pf_coil4.stp')
-    pf_coil5.export_stp('pf_coil5.stp')
-    pf_coil6.export_stp('pf_coil6.stp')
+    pf_coils.export_stp('pf_coils.stp')
+    pf_coils_casing.export_stp('pf_coils_casing.stp')
     outer_tf.export_stp('outer_tf.stp')
     inner_tf.export_stp('inner_tf.stp')
 

--- a/examples/example_parametric_components/make_magnet_set.py
+++ b/examples/example_parametric_components/make_magnet_set.py
@@ -11,7 +11,7 @@ import paramak
 
 def main():
 
-    number_of_toroidal_field_coils = 5
+    number_of_toroidal_field_coils = 6
     angle_offset = (360 / number_of_toroidal_field_coils) / 2.
     inner_tf = paramak.InnerTfCoilsFlat(
         height=1800,

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -238,8 +238,7 @@ class BallReactor(paramak.Reactor):
                 )
             ) / (self._number_of_pf_coils + 1)
 
-            self._pf_coils_y_values = []
-            self._pf_coils_x_values = []
+            self._pf_coils_xy_values = []
             # adds in coils with equal spacing strategy, should be updated to
             # allow user positions
             for i in range(self._number_of_pf_coils):
@@ -253,8 +252,7 @@ class BallReactor(paramak.Reactor):
                     + self.pf_coil_to_rear_blanket_radial_gap
                     + 0.5 * self.pf_coil_radial_thicknesses[i]
                 )
-                self._pf_coils_y_values.append(y_value)
-                self._pf_coils_x_values.append(x_value)
+                self._pf_coils_xy_values.append((x_value, y_value))
 
             self._pf_coil_start_radius = (
                 self._blanket_read_wall_end_radius +
@@ -472,26 +470,18 @@ class BallReactor(paramak.Reactor):
             and self.pf_coil_to_rear_blanket_radial_gap is not None
         ):
 
-            for i, (rt, vt, y_value, x_value) in enumerate(
-                zip(
-                    self.pf_coil_radial_thicknesses,
-                    self.pf_coil_vertical_thicknesses,
-                    self._pf_coils_y_values,
-                    self._pf_coils_x_values,
-                )
-            ):
+            self._pf_coil = paramak.PoloidalFieldCoilSet(
+                heights=self.pf_coil_vertical_thicknesses,
+                widths=self.pf_coil_radial_thicknesses,
+                center_points=self._pf_coils_xy_values,
+                rotation_angle=self.rotation_angle,
+                stp_filename='pf_coils.stp',
+                stl_filename='pf_coils.stl',
+                name="pf_coil",
+                material_tag="pf_coil_mat",
+            )
 
-                self._pf_coil = paramak.PoloidalFieldCoil(
-                    width=rt,
-                    height=vt,
-                    center_point=(x_value, y_value),
-                    rotation_angle=self.rotation_angle,
-                    stp_filename="pf_coil_" + str(i) + ".stp",
-                    stl_filename="pf_coil_" + str(i) + ".stl",
-                    name="pf_coil",
-                    material_tag="pf_coil_mat",
-                )
-                shapes_or_components.append(self._pf_coil)
+            shapes_or_components.append(self._pf_coil)
 
             if (
                 self.pf_coil_to_tf_coil_radial_gap is not None

--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -270,8 +270,7 @@ class SubmersionTokamak(paramak.Reactor):
                 self._number_of_pf_coils + 1
             )
 
-            self._pf_coils_y_values = []
-            self._pf_coils_x_values = []
+            self._pf_coils_xy_values = []
             # adds in coils with equal spacing strategy, should be updated to
             # allow user positions
             for i in range(self._number_of_pf_coils):
@@ -285,8 +284,7 @@ class SubmersionTokamak(paramak.Reactor):
                     + self.pf_coil_to_tf_coil_radial_gap
                     + 0.5 * self.pf_coil_radial_thicknesses[i]
                 )
-                self._pf_coils_y_values.append(y_value)
-                self._pf_coils_x_values.append(x_value)
+                self._pf_coils_xy_values.append((x_value, y_value))
 
             self._pf_coil_start_radius = (
                 self._outboard_tf_coil_end_radius +
@@ -544,23 +542,14 @@ class SubmersionTokamak(paramak.Reactor):
 
             if self._pf_info_provided:
 
-                for i, (rt, vt, y_value, x_value) in enumerate(
-                    zip(
-                        self.pf_coil_radial_thicknesses,
-                        self.pf_coil_vertical_thicknesses,
-                        self._pf_coils_y_values,
-                        self._pf_coils_x_values,
-                    )
-                ):
-
-                    self._pf_coil = paramak.PoloidalFieldCoil(
-                        width=rt,
-                        height=vt,
-                        center_point=(x_value, y_value),
+                    self._pf_coil = paramak.PoloidalFieldCoilSet(
+                        heights=self.pf_coil_vertical_thicknesses,
+                        widths=self.pf_coil_radial_thicknesses,
+                        center_points=self._pf_coils_xy_values,
                         rotation_angle=self.rotation_angle,
-                        stp_filename="pf_coil_" + str(i) + ".stp",
-                        stl_filename="pf_coil_" + str(i) + ".stl",
+                        stp_filename='pf_coils.stp',
                         name="pf_coil",
                         material_tag="pf_coil_mat",
                     )
+
                     shapes_or_components.append(self._pf_coil)

--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -542,14 +542,14 @@ class SubmersionTokamak(paramak.Reactor):
 
             if self._pf_info_provided:
 
-                    self._pf_coil = paramak.PoloidalFieldCoilSet(
-                        heights=self.pf_coil_vertical_thicknesses,
-                        widths=self.pf_coil_radial_thicknesses,
-                        center_points=self._pf_coils_xy_values,
-                        rotation_angle=self.rotation_angle,
-                        stp_filename='pf_coils.stp',
-                        name="pf_coil",
-                        material_tag="pf_coil_mat",
-                    )
+                self._pf_coil = paramak.PoloidalFieldCoilSet(
+                    heights=self.pf_coil_vertical_thicknesses,
+                    widths=self.pf_coil_radial_thicknesses,
+                    center_points=self._pf_coils_xy_values,
+                    rotation_angle=self.rotation_angle,
+                    stp_filename='pf_coils.stp',
+                    name="pf_coil",
+                    material_tag="pf_coil_mat",
+                )
 
-                    shapes_or_components.append(self._pf_coil)
+                shapes_or_components.append(self._pf_coil)

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -501,8 +501,22 @@ class Reactor:
         # finds the largest dimenton in all the Shapes that are in the reactor
         largest_dimension = 0
         for component in self.shapes_and_components:
-            if component.solid.largestDimension() > largest_dimension:
-                largest_dimension = component.solid.largestDimension()
+
+            if isinstance(component.solid, cq.Compound):
+                for solid in component.solid.Solids():
+                    largestDimension = max(
+                        abs(solid.BoundingBox().xmax),
+                        abs(solid.BoundingBox().xmin),
+                        abs(solid.BoundingBox().ymax),
+                        abs(solid.BoundingBox().ymin),
+                        abs(solid.BoundingBox().zmax),
+                        abs(solid.BoundingBox().zmin)
+                    )
+                    if largestDimension > largest_dimension:
+                        largest_dimension = largestDimension
+            else:
+                if component.solid.largestDimension() > largest_dimension:
+                    largest_dimension = component.solid.largestDimension()
 
         # creates a small box that surrounds the geometry
         inner_box = cq.Workplane("front").box(

--- a/tests/test_BallReactor.py
+++ b/tests/test_BallReactor.py
@@ -114,7 +114,7 @@ class test_BallReactor(unittest.TestCase):
             rotation_angle=359,
         )
         test_reactor.export_stp()
-        assert len(test_reactor.shapes_and_components) == 11
+        assert len(test_reactor.shapes_and_components) == 8
 
     def test_BallReactor_with_pf_and_tf_coils(self):
         """checks whether a ball reactor with optional pf and tf coils can
@@ -144,7 +144,7 @@ class test_BallReactor(unittest.TestCase):
             rotation_angle=359,
         )
         test_reactor.export_stp()
-        assert len(test_reactor.shapes_and_components) == 12
+        assert len(test_reactor.shapes_and_components) == 9
 
     def test_BallReactor_with_pf_and_tf_coils_export_physical_groups(self):
         """creates a ball reactor using the BallReactor parametric_reactor and
@@ -204,7 +204,7 @@ class test_BallReactor(unittest.TestCase):
             divertor_position="lower",
             rotation_angle=359,
         )
-        assert len(test_reactor.shapes_and_components) == 12
+        assert len(test_reactor.shapes_and_components) == 9
 
     def test_single_null_ball_reactor_divertor_lower(self):
         """checks that a single null reactor with a lower divertor can be

--- a/tests/test_SubmersionTokamak.py
+++ b/tests/test_SubmersionTokamak.py
@@ -112,7 +112,7 @@ class test_SubmersionTokamak(unittest.TestCase):
             number_of_tf_coils=4,
             rotation_angle=359,
         )
-        assert len(test_reactor.shapes_and_components) == 14
+        assert len(test_reactor.shapes_and_components) == 10
 
     def test_minimal_SubmersionTokamak_stp_creation(self):
         """creates a submersion reactor using the SubmersionTokamak parameteric reactor and
@@ -277,7 +277,7 @@ class test_SubmersionTokamak(unittest.TestCase):
             support_position="upper",
             rotation_angle=359,
         )
-        assert len(test_reactor.shapes_and_components) == 13
+        assert len(test_reactor.shapes_and_components) == 10
 
     def test_SingleNullSubmersionTokamak_divertor_lower_support_lower(self):
         """creates a single null submersion reactor with lower supports and divertor using the

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -39,10 +39,7 @@ class test_object_properties(unittest.TestCase):
             "firstwall.stp",
             "Graveyard.stp",
             "inboard_tf_coils.stp",
-            "pf_coil_0.stp",
-            "pf_coil_1.stp",
-            "pf_coil_2.stp",
-            "pf_coil_3.stp",
+            "pf_coils.stp",
             "plasma.stp",
             "tf_coil.stp"
         ]
@@ -67,10 +64,7 @@ class test_object_properties(unittest.TestCase):
             'blanket.stp',
             'outboard_rear_blanket_wall.stp',
             'outboard_tf_coil.stp',
-            'pf_coil_0.stp',
-            'pf_coil_1.stp',
-            'pf_coil_2.stp',
-            'pf_coil_3.stp',
+            'pf_coils.stp',
             'Graveyard.stp'
         ]
         for output_filename in output_filenames:


### PR DESCRIPTION
## Proposed changes

This PR aims to provide an example set of magnets TF and PF for users that are just keen to make magnet geometry.

This update makes use of the new PoloidalFieldCoilSet() and PoloidalFieldCoilCaseSetFC() to reduce the number of lines in the draft magnet set example, in the submersion reactor and the ball reactor

![Screenshot from 2020-09-22 21-36-02](https://user-images.githubusercontent.com/8583900/93935351-61350e00-fd1c-11ea-9e29-4b9da62048c1.png)


## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [x] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Todo

- Add documentation
- Add tests

When  azimuth angles or offset can be user controled then rotate the InnerTfCoilsFlat by 0.5*(360/number of tf coils)

When the coordinates of the inboard connections of the ToroidalFieldCoilPrincetonD are known (perhaps due to another PR) then ...
- Add inboard TF coil legs
- Cut the existing InnerTfCoilsFlat with the new TF coil legs

