### PR TITLE
BlanketFP patch: variable offset + bugfixing

### DIFF
--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -188,8 +188,25 @@ class BlanketFP(RotateMixedShape):
         )
 
         # create inner points
+
+        def offset(theta):
+            if callable(self.offset_from_plasma):
+                print(self.offset_from_plasma(theta))
+                return self.offset_from_plasma(theta)
+            elif isinstance(self.offset_from_plasma, tuple):
+                # increase offset linearly
+                start_offset, stop_offset = self.offset_from_plasma
+                a = -(start_offset - stop_offset) / (
+                    self.stop_angle * conversion_factor
+                    - self.start_angle * conversion_factor
+                )
+                b = start_offset - self.start_angle* conversion_factor * a
+                return a * theta + b
+            else:
+                return self.offset_from_plasma
+
         inner_points = self.create_offset_points(
-            thetas, R, Z, self.offset_from_plasma
+            thetas, R, Z, offset
             )
         inner_points[-1][2] = "straight"
 
@@ -201,7 +218,7 @@ class BlanketFP(RotateMixedShape):
                     self.thickness(
                         theta /
                         conversion_factor) +
-                    self.offset_from_plasma)
+                    offset(theta))
             elif isinstance(self.thickness, tuple):
                 # increase thickness linearly
                 start_thickness, stop_thickness = self.thickness
@@ -210,10 +227,10 @@ class BlanketFP(RotateMixedShape):
                     - self.start_angle * conversion_factor
                 )
                 b = start_thickness - self.start_angle* conversion_factor * a
-                return a * theta + b + self.offset_from_plasma
+                return a * theta + b + offset(theta)
             else:
                 # use the constant value
-                return self.thickness + self.offset_from_plasma
+                return self.thickness + offset(theta)
 
         outer_points = self.create_offset_points(
             np.flip(thetas), R, Z, new_offset)

--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -62,7 +62,9 @@ class BlanketFP(RotateMixedShape):
         Others: see paramak.RotateMixedShape() attributes.
 
     Returns:
-        a paramak shape object: A shape object that has generic functionality with points determined by the find_points() method. A CadQuery solid of the shape can be called via shape.solid.
+        a paramak shape object: A shape object that has generic functionality
+            with points determined by the find_points() method. A CadQuery
+            solid of the shape can be called via shape.solid.
     """
 
     def __init__(
@@ -200,7 +202,7 @@ class BlanketFP(RotateMixedShape):
                     self.stop_angle * conversion_factor
                     - self.start_angle * conversion_factor
                 )
-                b = start_offset - self.start_angle* conversion_factor * a
+                b = start_offset - self.start_angle * conversion_factor * a
                 return a * theta + b
             else:
                 return self.offset_from_plasma
@@ -226,7 +228,7 @@ class BlanketFP(RotateMixedShape):
                     self.stop_angle * conversion_factor
                     - self.start_angle * conversion_factor
                 )
-                b = start_thickness - self.start_angle* conversion_factor * a
+                b = start_thickness - self.start_angle * conversion_factor * a
                 return a * theta + b + offset(theta)
             else:
                 # use the constant value

--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -31,8 +31,11 @@ class BlanketFP(RotateMixedShape):
             Defaults to 2.0.
         vertical_displacement (float, optional): the vertical_displacement of
             the plasma (cm). Defaults to 0.
-        offset_from_plasma (float, optional): the distance bettwen the plasma
-            and the blanket (cm). Defaults to 0.
+        offset_from_plasma (float, (float, float), callable): the distance
+            bettwen the plasma and the blanket (cm). If float, constant offset.
+            If tuple of floats, offset will vary linearly between the two
+            values. If callable, offset will be a function of poloidal angle
+            (in degrees) Defaults to 0.
         num_points (int, optional): number of points that will describe the
             shape. Defaults to 50.
         Others: see paramak.RotateMixedShape() arguments.
@@ -55,8 +58,11 @@ class BlanketFP(RotateMixedShape):
             Defaults to 2.0.
         vertical_displacement (float): the vertical_displacement of
             the plasma (cm).
-        offset_from_plasma (float): the distance bettwen the plasma
-            and the blanket (cm).
+        offset_from_plasma (float, (float, float), callable): the distance
+            bettwen the plasma and the blanket (cm). If float, constant offset.
+            If tuple of floats, offset will vary linearly between the two
+            values. If callable, offset will be a function of poloidal angle
+            (in degrees) Defaults to 0.
         num_points (int): number of points that will describe the
             shape.
         Others: see paramak.RotateMixedShape() attributes.

--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -258,7 +258,7 @@ class BlanketFP(RotateMixedShape):
         :type Z_fun: callable
         :param offset: offset value (cm). offset=0 will follow the parametric
          equations.
-        :type offset: float, callable
+        :type offset: callable
         :return: list of points [[R1, Z1, connection1], [R2, Z2, connection2],
             ...]
         :rtype: list
@@ -272,12 +272,6 @@ class BlanketFP(RotateMixedShape):
         R_derivative = sp.diff(R_sp, theta_sp)
         Z_derivative = sp.diff(Z_sp, theta_sp)
         points = []
-
-        def new_offset(theta):
-            if callable(offset):
-                return offset(theta)
-            else:
-                return offset
 
         for theta in thetas:
             # get local value of derivatives
@@ -294,8 +288,8 @@ class BlanketFP(RotateMixedShape):
             ny /= normal_vector_norm
 
             # calculate outer points
-            val_R_outer = R_fun(theta) + new_offset(theta) * nx
-            val_Z_outer = Z_fun(theta) + new_offset(theta) * ny
+            val_R_outer = R_fun(theta) + offset(theta) * nx
+            val_Z_outer = Z_fun(theta) + offset(theta) * ny
 
             points.append([float(val_R_outer), float(val_Z_outer), "spline"])
         return points

--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -129,15 +129,13 @@ class BlanketFP(RotateMixedShape):
             self.major_radius = major_radius
             self.triangularity = triangularity
             self.elongation = elongation
-            self.offset_from_plasma = 0
         else:  # if plasma object is given, use its parameters
             self.minor_radius = plasma.minor_radius
             self.major_radius = plasma.major_radius
             self.triangularity = plasma.triangularity
             self.elongation = plasma.elongation
-            self.offset_from_plasma = offset_from_plasma
+        self.offset_from_plasma = offset_from_plasma
         self.num_points = num_points
-        # self.points = points
         self.physical_groups = None
 
         self.find_points()
@@ -190,19 +188,8 @@ class BlanketFP(RotateMixedShape):
         )
 
         # create inner points
-        if self.plasma is None:
-            # if no plasma object is given simply use the equation
-            inner_points_R = R(thetas)
-            inner_points_Z = Z(thetas)
-
-            inner_points = [
-                [inner_points_R[i], inner_points_Z[i], "spline"]
-                for i in range(len(thetas))
-            ]
-        else:
-            # if a plasma is given
-            inner_points = self.create_offset_points(
-                thetas, R, Z, self.offset_from_plasma
+        inner_points = self.create_offset_points(
+            thetas, R, Z, self.offset_from_plasma
             )
         inner_points[-1][2] = "straight"
 

--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -209,7 +209,7 @@ class BlanketFP(RotateMixedShape):
                     self.stop_angle * conversion_factor
                     - self.start_angle * conversion_factor
                 )
-                b = start_thickness - self.start_angle * a
+                b = start_thickness - self.start_angle* conversion_factor * a
                 return a * theta + b + self.offset_from_plasma
             else:
                 # use the constant value

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -382,6 +382,45 @@ class test_BlanketFP(unittest.TestCase):
         assert test_shape.solid is not None
         assert test_shape.volume > 1000
 
+    def test_BlanketFP_creation_variable_offset_from_tuple(self):
+        """checks that a cadquery solid can be created using the BlanketFP
+        parametric component when a tuple of offsets is passed"""
+
+        test_shape = paramak.BlanketFP(
+            major_radius=300,
+            minor_radius=50,
+            triangularity=0.5,
+            elongation=2,
+            thickness=100,
+            offset_from_plasma=(0, 10),
+            stop_angle=90,
+            start_angle=270,
+        )
+
+        assert test_shape.solid is not None
+        assert test_shape.volume > 1000
+
+    def test_BlanketFP_creation_variable_offset_function(self):
+        """checks that a cadquery solid can be created using the BlanketFP
+        parametric component when a offset function is passed"""
+
+        def offset(theta):
+            return 100 + 3 * theta
+
+        test_shape = paramak.BlanketFP(
+            major_radius=300,
+            minor_radius=50,
+            triangularity=0.5,
+            elongation=2,
+            thickness=100,
+            stop_angle=90,
+            start_angle=270,
+            offset_from_plasma=offset
+        )
+
+        assert test_shape.solid is not None
+        assert test_shape.volume > 1000
+
     def test_BlanketFP_physical_groups(self):
         """creates a blanket using the BlanketFP parametric component and checks that
         physical groups can be exported using the export_physical_groups method"""


### PR DESCRIPTION
## Proposed changes

This PR includes a patch for the `BlanketFP` class.
- Bug fixing: #283 #250
- Feature: variable offset from plasma #251 

Usage:
```python
import paramak
import numpy as np


def fun(theta):
    conversion_factor = 2 * np.pi / 360
    return 20 + 20*np.sin(theta/conversion_factor)


blanket = paramak.BlanketFP(
    minor_radius=150.0,
    major_radius=450.0,
    triangularity=0.55,
    elongation=2.0,
    thickness=50,
    offset_from_plasma=fun,
    start_angle=0,
    stop_angle=160,
    rotation_angle=180
)
blanket.export_stp('blanquette.stp')
```
![image](https://user-images.githubusercontent.com/40028739/93993472-14d6e600-fd8f-11ea-82ab-6fce34b99180.png)

## Types of changes

What types of changes does your code introduce to the Paramak?

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)