### PR TITLE
adding list to offset and thickness to BlanketFP

### DIFF
--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -201,7 +201,7 @@ class BlanketFP(RotateMixedShape):
             if callable(self.offset_from_plasma):
                 print(self.offset_from_plasma(theta))
                 return self.offset_from_plasma(theta)
-            elif isinstance(self.offset_from_plasma, tuple):
+            elif isinstance(self.offset_from_plasma, (tuple, list)):
                 # increase offset linearly
                 start_offset, stop_offset = self.offset_from_plasma
                 a = -(start_offset - stop_offset) / (
@@ -227,7 +227,7 @@ class BlanketFP(RotateMixedShape):
                         theta /
                         conversion_factor) +
                     offset(theta))
-            elif isinstance(self.thickness, tuple):
+            elif isinstance(self.thickness, (tuple, list)):
                 # increase thickness linearly
                 start_thickness, stop_thickness = self.thickness
                 a = (stop_thickness - start_thickness) / (


### PR DESCRIPTION
## Proposed changes

Currently BlanketFP accepts a tuple for offset_from_plasma and thickness. This tiny PR adds support for lists (still of length 2). Lists behave the same as tuples in this case and I think lists are generally more used by users.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ x Pep8 applied
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
