### PR TITLE
Fix azimuthal placement

### DIFF
--- a/paramak/parametric_components/inner_tf_coils_circular.py
+++ b/paramak/parametric_components/inner_tf_coils_circular.py
@@ -40,13 +40,13 @@ class InnerTfCoilsCircular(ExtrudeMixedShape):
         height,
         inner_radius,
         outer_radius,
-        number_of_coils,
         gap_size,
         distance=None,
         stp_filename="InnerTfCoilsCircular.stp",
         stl_filename="InnerTfCoilsCircular.stl",
         color=(0.5, 0.5, 0.5),
-        azimuth_placement_angle=0,
+        azimuth_placement_angle=None,
+        number_of_coils=None,
         material_tag="inner_tf_coil_mat",
         name=None,
         **kwargs
@@ -86,8 +86,8 @@ class InnerTfCoilsCircular(ExtrudeMixedShape):
         self.gap_size = gap_size
         self.distance = height
 
-        self.find_points()
         self.find_azimuth_placement_angle()
+        self.find_points()
 
     @property
     def height(self):
@@ -214,13 +214,23 @@ class InnerTfCoilsCircular(ExtrudeMixedShape):
         self.points = points
 
     def find_azimuth_placement_angle(self):
-        """Calculates the azimuth placement angles based on the number of tf coils"""
 
-        angles = list(
-            np.linspace(
-                0,
-                360,
-                self.number_of_coils,
-                endpoint=False))
-
-        self.azimuth_placement_angle = angles
+        if self.azimuth_placement_angle is None:
+            if self.number_of_coils is None:
+                raise ValueError('azimuth_placement_angle or number_of_coils must be specified')
+            else:
+                angles = list(
+                    np.linspace(
+                        0, 360,
+                        self.number_of_coils,
+                        endpoint=False
+                    )
+                )
+                self.azimuth_placement_angle = angles
+        
+        else:
+            if self.number_of_coils is None:
+                self.number_of_coils = len(self.azimuth_placement_angle)
+            else:
+                if self.number_of_coils != len(self.azimuth_placement_angle):
+                    raise ValueError('number of azimuthal placement angles should equal number of coils')

--- a/paramak/parametric_components/inner_tf_coils_flat.py
+++ b/paramak/parametric_components/inner_tf_coils_flat.py
@@ -42,13 +42,13 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
         height,
         inner_radius,
         outer_radius,
-        number_of_coils,
         gap_size,
         distance=None,
         stp_filename="InnerTfCoilsFlat.stp",
         stl_filename="InnerTfCoilsFlat.stl",
         color=(0.5, 0.5, 0.5),
-        azimuth_placement_angle=0,
+        azimuth_placement_angle=None,
+        number_of_coils=None,
         material_tag="inner_tf_coil_mat",
         name=None,
         **kwargs
@@ -88,8 +88,8 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
         self.gap_size = gap_size
         self.distance = height
 
-        self.find_points()
         self.find_azimuth_placement_angle()
+        self.find_points()
 
     @property
     def height(self):
@@ -98,6 +98,14 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
     @height.setter
     def height(self, height):
         self._height = height
+
+    @property
+    def number_of_coils(self):
+        return self._number_of_coils
+
+    @number_of_coils.setter
+    def number_of_coils(self, value):
+        self._number_of_coils = value
 
     @property
     def distance(self):
@@ -122,14 +130,6 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
     @outer_radius.setter
     def outer_radius(self, outer_radius):
         self._outer_radius = outer_radius
-
-    @property
-    def number_of_coils(self):
-        return self._number_of_coils
-
-    @number_of_coils.setter
-    def number_of_coils(self, number_of_coils):
-        self._number_of_coils = number_of_coils
 
     @property
     def gap_size(self):
@@ -194,13 +194,23 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
         self.points = points
 
     def find_azimuth_placement_angle(self):
-        """Calculates the azimuth placement angles based on the number of tf coils"""
 
-        angles = list(
-            np.linspace(
-                0,
-                360,
-                self.number_of_coils,
-                endpoint=False))
-
-        self.azimuth_placement_angle = angles
+        if self.azimuth_placement_angle is None:
+            if self.number_of_coils is None:
+                raise ValueError('azimuth_placement_angle or number_of_coils must be specified')
+            else:
+                angles = list(
+                    np.linspace(
+                        0, 360,
+                        self.number_of_coils,
+                        endpoint=False
+                    )
+                )
+                self.azimuth_placement_angle = angles
+        
+        else:
+            if self.number_of_coils is None:
+                self.number_of_coils = len(self.azimuth_placement_angle)
+            else:
+                if self.number_of_coils != len(self.azimuth_placement_angle):
+                    raise ValueError('number of azimuthal placement angles should equal number of coils')

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -354,7 +354,7 @@ class Shape:
 
     @azimuth_placement_angle.setter
     def azimuth_placement_angle(self, value):
-        if isinstance(value, (int, float, Iterable)):
+        if isinstance(value, (int, float, Iterable)) or value is None:
             if isinstance(value, Iterable):
                 for i in value:
                     if isinstance(i, (int, float)) is False:

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -921,7 +921,7 @@ class test_InnerTfCoilsFlat(unittest.TestCase):
         assert test_shape.volume > 1000
 
     def test_number_of_coils_and_azimuth_placement_angle(self):
-        """checks that the tf coils are placed correctly given the combination of the parameters 
+        """checks that the tf coils are placed correctly given the combination of the parameters
         number_of_coils and azimuth_placement_angle, or that the correct errors are raised"""
 
         def no_number_of_coils_or_azimuth_placement_angle():

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -921,6 +921,8 @@ class test_InnerTfCoilsFlat(unittest.TestCase):
         assert test_shape.volume > 1000
 
     def test_number_of_coils_and_azimuth_placement_angle(self):
+        """checks that the tf coils are placed correctly given the combination of the parameters 
+        number_of_coils and azimuth_placement_angle, or that the correct errors are raised"""
 
         def no_number_of_coils_or_azimuth_placement_angle():
             test_shape = paramak.InnerTfCoilsFlat(

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -920,6 +920,49 @@ class test_InnerTfCoilsFlat(unittest.TestCase):
         assert test_shape.solid is not None
         assert test_shape.volume > 1000
 
+    def test_number_of_coils_and_azimuth_placement_angle(self):
+
+        def no_number_of_coils_or_azimuth_placement_angle():
+            test_shape = paramak.InnerTfCoilsFlat(
+                height=500,
+                inner_radius=50,
+                outer_radius=150,
+                gap_size=5
+            )
+        
+        self.assertRaises(ValueError, no_number_of_coils_or_azimuth_placement_angle)
+
+        def number_of_coils_not_equal_azimuth_placement_angles():
+            test_shape = paramak.InnerTfCoilsFlat(
+                height=500,
+                inner_radius=50,
+                outer_radius = 150,
+                gap_size=5,
+                number_of_coils=8,
+                azimuth_placement_angle=[0, 90, 180, 270]
+            )
+
+        self.assertRaises(ValueError, number_of_coils_not_equal_azimuth_placement_angles)
+
+        test_shape = paramak.InnerTfCoilsFlat(
+            height=500,
+            inner_radius=50,
+            outer_radius=150,
+            gap_size=5,
+            number_of_coils = 8
+        )
+
+        assert test_shape.azimuth_placement_angle == [0, 45, 90, 135, 180, 225, 270, 315]
+
+        test_shape = paramak.InnerTfCoilsFlat(
+            height=500,
+            inner_radius=50,
+            outer_radius=150,
+            gap_size=5,
+            azimuth_placement_angle=[0, 90, 180, 270]
+        )
+
+        assert test_shape.number_of_coils == len(test_shape.azimuth_placement_angle)
 
 class test_InnerTfCoilsCircular(unittest.TestCase):
     def test_InnerTfCoilsCircular_creation(self):
@@ -936,6 +979,50 @@ class test_InnerTfCoilsCircular(unittest.TestCase):
 
         assert test_shape.solid is not None
         assert test_shape.volume > 1000
+
+    def test_number_of_coils_and_azimuth_placement_angle(self):
+
+        def no_number_of_coils_or_azimuth_placement_angle():
+            test_shape = paramak.InnerTfCoilsCircular(
+                height=500,
+                inner_radius=50,
+                outer_radius=150,
+                gap_size=5
+            )
+        
+        self.assertRaises(ValueError, no_number_of_coils_or_azimuth_placement_angle)
+
+        def number_of_coils_not_equal_azimuth_placement_angles():
+            test_shape = paramak.InnerTfCoilsCircular(
+                height=500,
+                inner_radius=50,
+                outer_radius = 150,
+                gap_size=5,
+                number_of_coils=8,
+                azimuth_placement_angle=[0, 90, 180, 270]
+            )
+
+        self.assertRaises(ValueError, number_of_coils_not_equal_azimuth_placement_angles)
+
+        test_shape = paramak.InnerTfCoilsCircular(
+            height=500,
+            inner_radius=50,
+            outer_radius=150,
+            gap_size=5,
+            number_of_coils = 8
+        )
+
+        assert test_shape.azimuth_placement_angle == [0, 45, 90, 135, 180, 225, 270, 315]
+
+        test_shape = paramak.InnerTfCoilsCircular(
+            height=500,
+            inner_radius=50,
+            outer_radius=150,
+            gap_size=5,
+            azimuth_placement_angle=[0, 90, 180, 270]
+        )
+
+        assert test_shape.number_of_coils == len(test_shape.azimuth_placement_angle)
 
 
 class test_ParametricComponents(unittest.TestCase):


### PR DESCRIPTION
## Proposed changes

PR which allows the number of inner tf coils to be controlled by the azimuth_placement_angle parameter.
if number_of_coils = value and azimuth_placement_angle = None: value number of tf coils spaced evenly over 360 degrees.
if number_of_coils = value and azimuth_placement_angle = different value: error raised. (both values must be the same).
if number_of_coils = None and azimuth_placement_angle = None: error raised. (at least one must be specified).
if number_of_coils = None and azimuth_placement_angle = value: coils placed at values specified.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

No further comments
