### PR TITLE
Fix parametric components shape

### DIFF
--- a/paramak/parametric_components/blanket_constant_thickness_arc_h.py
+++ b/paramak/parametric_components/blanket_constant_thickness_arc_h.py
@@ -89,15 +89,6 @@ class BlanketConstantThicknessArcH(RotateMixedShape):
         self.inner_mid_point = inner_mid_point
         self.thickness = thickness
 
-    @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
     def find_points(self):
 
         self.points = [
@@ -118,6 +109,5 @@ class BlanketConstantThicknessArcH(RotateMixedShape):
                 self.inner_upper_point[0] + abs(self.thickness),
                 self.inner_upper_point[1],
                 "straight",
-            ),
-            (self.inner_upper_point[0], self.inner_upper_point[1])
+            )
         ]

--- a/paramak/parametric_components/blanket_constant_thickness_arc_v.py
+++ b/paramak/parametric_components/blanket_constant_thickness_arc_v.py
@@ -91,15 +91,6 @@ class BlanketConstantThicknessArcV(RotateMixedShape):
         self.inner_mid_point = inner_mid_point
         self.thickness = thickness
 
-    @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
     def find_points(self):
 
         self.points = [
@@ -120,6 +111,5 @@ class BlanketConstantThicknessArcV(RotateMixedShape):
                 self.inner_upper_point[0],
                 self.inner_upper_point[1] + abs(self.thickness),
                 "straight",
-            ),
-            (self.inner_upper_point[0], self.inner_upper_point[1])
+            )
         ]

--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -147,15 +147,6 @@ class BlanketFP(RotateMixedShape):
         self.physical_groups = None
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def physical_groups(self):
         self.create_physical_groups()
         return self._physical_groups
@@ -251,7 +242,6 @@ class BlanketFP(RotateMixedShape):
             np.flip(thetas), R, Z, new_offset)
         points = inner_points + outer_points
         points[-1][2] = "straight"
-        points.append(inner_points[0])
         self.points = points
 
     def create_offset_points(self, thetas, R_fun, Z_fun, offset):

--- a/paramak/parametric_components/center_column_circular.py
+++ b/paramak/parametric_components/center_column_circular.py
@@ -84,15 +84,6 @@ class CenterColumnShieldCircular(RotateMixedShape):
         self.outer_radius = outer_radius
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def height(self):
         return self._height
 
@@ -134,8 +125,7 @@ class CenterColumnShieldCircular(RotateMixedShape):
             (self.outer_radius, self.height / 2, "circle"),
             (self.mid_radius, 0, "circle"),
             (self.outer_radius, -self.height / 2, "straight"),
-            (self.inner_radius, -self.height / 2, "straight"),
-            (self.inner_radius, 0, "straight")
+            (self.inner_radius, -self.height / 2, "straight")
         ]
 
         self.points = points

--- a/paramak/parametric_components/center_column_cylinder.py
+++ b/paramak/parametric_components/center_column_cylinder.py
@@ -71,15 +71,6 @@ class CenterColumnShieldCylinder(RotateStraightShape):
         self.outer_radius = outer_radius
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def height(self):
         return self._height
 
@@ -123,7 +114,6 @@ class CenterColumnShieldCylinder(RotateStraightShape):
             (self.outer_radius, self.height / 2),
             (self.outer_radius, -self.height / 2),
             (self.inner_radius, -self.height / 2),
-            (self.inner_radius, self.height / 2)
         ]
 
         self.points = points

--- a/paramak/parametric_components/center_column_flat_top_circular.py
+++ b/paramak/parametric_components/center_column_flat_top_circular.py
@@ -87,15 +87,6 @@ class CenterColumnShieldFlatTopCircular(RotateMixedShape):
         self.inner_radius = inner_radius
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def height(self):
         return self._height
 
@@ -147,8 +138,7 @@ class CenterColumnShieldFlatTopCircular(RotateMixedShape):
             (self.mid_radius, 0, "circle"),
             (self.outer_radius, -self.arc_height / 2, "straight"),
             (self.outer_radius, -self.height / 2, "straight"),
-            (self.inner_radius, -self.height / 2, "straight"),
-            (self.inner_radius, 0, "straight")
+            (self.inner_radius, -self.height / 2, "straight")
         ]
 
         self.points = points

--- a/paramak/parametric_components/center_column_flat_top_hyperbola.py
+++ b/paramak/parametric_components/center_column_flat_top_hyperbola.py
@@ -87,15 +87,6 @@ class CenterColumnShieldFlatTopHyperbola(RotateMixedShape):
         self.inner_radius = inner_radius
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def height(self):
         return self._height
 
@@ -168,8 +159,7 @@ class CenterColumnShieldFlatTopHyperbola(RotateMixedShape):
             (self.mid_radius, 0, "spline"),
             (self.outer_radius, -self.arc_height / 2, "straight"),
             (self.outer_radius, -self.height / 2, "straight"),
-            (self.inner_radius, -self.height / 2, "straight"),
-            (self.inner_radius, 0, "straight")
+            (self.inner_radius, -self.height / 2, "straight")
         ]
 
         self.points = points

--- a/paramak/parametric_components/center_column_hyperbola.py
+++ b/paramak/parametric_components/center_column_hyperbola.py
@@ -83,8 +83,6 @@ class CenterColumnShieldHyperbola(RotateMixedShape):
         self.mid_radius = mid_radius
         self.outer_radius = outer_radius
 
-        self.find_points()
-
     @property
     def height(self):
         return self._height
@@ -141,8 +139,7 @@ class CenterColumnShieldHyperbola(RotateMixedShape):
             (self.outer_radius, self.height / 2, "spline"),
             (self.mid_radius, 0, "spline"),
             (self.outer_radius, -self.height / 2, "straight"),
-            (self.inner_radius, -self.height / 2, "straight"),
-            (self.inner_radius, 0, "straight")
+            (self.inner_radius, -self.height / 2, "straight")
         ]
 
         self.points = points

--- a/paramak/parametric_components/center_column_plasma_dependant.py
+++ b/paramak/parametric_components/center_column_plasma_dependant.py
@@ -96,15 +96,6 @@ class CenterColumnShieldPlasmaHyperbola(RotateMixedShape):
         self.edge_offset = edge_offset
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def major_radius(self):
         return self._major_radius
 
@@ -204,8 +195,7 @@ class CenterColumnShieldPlasmaHyperbola(RotateMixedShape):
             ),
             (plasma.low_point[0] - self.edge_offset, plasma.low_point[1], "straight"),
             (plasma.low_point[0] - self.edge_offset, -1 * self.height / 2, "straight"),
-            (self.inner_radius, -1 * self.height / 2, "straight"),
-            (self.inner_radius, 0, "straight")
+            (self.inner_radius, -1 * self.height / 2, "straight")
         ]
 
         self.points = points

--- a/paramak/parametric_components/divertor_ITER.py
+++ b/paramak/parametric_components/divertor_ITER.py
@@ -126,15 +126,6 @@ class ITERtypeDivertor(RotateMixedShape):
         self.dome_pos = dome_pos
         self.dome_thickness = dome_thickness
 
-    @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
     def create_vertical_target_points(
             self, anchor, coverage, tilt, radius, length):
         """Creates a list of points for a vertical target
@@ -311,7 +302,6 @@ class ITERtypeDivertor(RotateMixedShape):
 
         # append all points
         points = IVT_points + dome_points + OVT_points + casing_points
-        points.append(points[0])
         self.points = points
 
 

--- a/paramak/parametric_components/inner_tf_coils_circular.py
+++ b/paramak/parametric_components/inner_tf_coils_circular.py
@@ -86,15 +86,6 @@ class InnerTfCoilsCircular(ExtrudeMixedShape):
         self.distance = height
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def azimuth_placement_angle(self):
         self.find_azimuth_placement_angle()
         return self._azimuth_placement_angle
@@ -223,8 +214,7 @@ class InnerTfCoilsCircular(ExtrudeMixedShape):
             (point_6[0], point_6[1], "circle"),
             (point_5[0], point_5[1], "circle"),
             (point_4[0], point_4[1], "straight"),
-            (point_1[0], point_1[1], "straight")
-        ]   # we have overwritten the setter which automatically adds the endpoint
+        ]
 
         self.points = points
 

--- a/paramak/parametric_components/inner_tf_coils_flat.py
+++ b/paramak/parametric_components/inner_tf_coils_flat.py
@@ -88,15 +88,6 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
         self.distance = height
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def azimuth_placement_angle(self):
         self.find_azimuth_placement_angle()
         return self._azimuth_placement_angle
@@ -203,8 +194,7 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
             (point_3[0], point_3[1]),
             (point_6[0], point_6[1]),
             (point_4[0], point_4[1]),
-            (point_1[0], point_1[1])
-        ]   # we have overwritten the setter which automatically adds the endpoint
+        ]
 
         self.points = points
 

--- a/paramak/parametric_components/poloidal_field_coil.py
+++ b/paramak/parametric_components/poloidal_field_coil.py
@@ -76,8 +76,6 @@ class PoloidalFieldCoil(RotateStraightShape):
         self.height = height
         self.width = width
 
-        self.find_points()
-
     @property
     def center_point(self):
         return self._center_point
@@ -122,10 +120,6 @@ class PoloidalFieldCoil(RotateStraightShape):
             (
                 self.center_point[0] - self.width / 2.0,
                 self.center_point[1] + self.height / 2.0,
-            ),  # upper left
-            (
-                self.center_point[0] + self.width / 2.0,
-                self.center_point[1] + self.height / 2.0
             )
         ]
 

--- a/paramak/parametric_components/poloidal_field_coil_case.py
+++ b/paramak/parametric_components/poloidal_field_coil_case.py
@@ -81,15 +81,6 @@ class PoloidalFieldCoilCase(RotateStraightShape):
         self.casing_thickness = casing_thickness
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def center_point(self):
         return self._center_point
 
@@ -167,10 +158,6 @@ class PoloidalFieldCoilCase(RotateStraightShape):
                 (self.casing_thickness + self.width / 2.0),
                 self.center_point[1] + \
                 (self.casing_thickness + self.height / 2.0),
-            ),
-            (
-                self.center_point[0] + self.width / 2.0,
-                self.center_point[1] + self.height / 2.0
             )
         ]
 

--- a/paramak/parametric_components/poloidal_field_coil_case_fc.py
+++ b/paramak/parametric_components/poloidal_field_coil_case_fc.py
@@ -80,15 +80,6 @@ class PoloidalFieldCoilCaseFC(RotateStraightShape):
         self.casing_thickness = casing_thickness
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def center_point(self):
         return self._center_point
 
@@ -166,10 +157,6 @@ class PoloidalFieldCoilCaseFC(RotateStraightShape):
                 (self.casing_thickness + self.width / 2.0),
                 self.center_point[1] + \
                 (self.casing_thickness + self.height / 2.0),
-            ),
-            (
-                self.center_point[0] + self.width / 2.0,
-                self.center_point[1] + self.height / 2.0
             )
         ]
 

--- a/paramak/parametric_components/poloidal_field_coil_case_set.py
+++ b/paramak/parametric_components/poloidal_field_coil_case_set.py
@@ -84,15 +84,6 @@ class PoloidalFieldCoilCaseSet(RotateStraightShape):
         self.casing_thicknesses = casing_thicknesses
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def solid(self):
         if self.get_hash() != self.hash_value:
             self.create_solid()

--- a/paramak/parametric_components/poloidal_field_coil_case_set_fc.py
+++ b/paramak/parametric_components/poloidal_field_coil_case_set_fc.py
@@ -76,15 +76,6 @@ class PoloidalFieldCoilCaseSetFC(RotateStraightShape):
         self.casing_thicknesses = casing_thicknesses
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def solid(self):
         if self.get_hash() != self.hash_value:
             self.create_solid()

--- a/paramak/parametric_components/poloidal_field_coil_set.py
+++ b/paramak/parametric_components/poloidal_field_coil_set.py
@@ -86,8 +86,6 @@ class PoloidalFieldCoilSet(RotateStraightShape):
             raise ValueError("The length of widthts, height and center_points \
                 must be the same when making a PoloidalFieldCoilSet")
 
-        self.find_points()
-
     @property
     def solid(self):
         """Returns a CadQuery compound object consisting of 1 or more 3d volumes"""

--- a/paramak/parametric_components/poloidal_segmenter.py
+++ b/paramak/parametric_components/poloidal_segmenter.py
@@ -87,15 +87,6 @@ class PoloidalSegments(RotateStraightShape):
         self.max_distance_from_center = max_distance_from_center
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def number_of_segments(self):
         return self._number_of_segments
 

--- a/paramak/parametric_components/tokamak_plasma.py
+++ b/paramak/parametric_components/tokamak_plasma.py
@@ -125,6 +125,7 @@ class Plasma(RotateSplineShape):
         self.low_point = None
         self.lower_x_point, self.upper_x_point = self.compute_x_points()
 
+    # overwrite points setter in Shape (error returned if not overwritten)
     @property
     def points(self):
         self.find_points()

--- a/paramak/parametric_components/tokamak_plasma_from_points.py
+++ b/paramak/parametric_components/tokamak_plasma_from_points.py
@@ -102,15 +102,6 @@ class PlasmaFromPoints(Plasma):
         self.lower_x_point, self.upper_x_point = self.compute_x_points()
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def outer_equatorial_x_point(self):
         return self._outer_equatorial_x_point
 

--- a/paramak/parametric_components/tokamak_plasma_plasmaboundaries.py
+++ b/paramak/parametric_components/tokamak_plasma_plasmaboundaries.py
@@ -104,15 +104,6 @@ class PlasmaBoundaries(Plasma):
         self.lower_x_point, self.upper_x_point = self.compute_x_points()
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def vertical_displacement(self):
         return self._vertical_displacement
 

--- a/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
+++ b/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
@@ -96,15 +96,6 @@ class ToroidalFieldCoilCoatHanger(ExtrudeStraightShape):
         self.number_of_coils = number_of_coils
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def azimuth_placement_angle(self):
         self.find_azimuth_placement_angle()
         return self._azimuth_placement_angle
@@ -174,7 +165,7 @@ class ToroidalFieldCoilCoatHanger(ExtrudeStraightShape):
             (
                 self.horizontal_start_point[0],
                 self.horizontal_start_point[1] + self.thickness,
-            )  # upper right inner
+            )
         ]
 
         self.points = points

--- a/paramak/parametric_components/toroidal_field_coil_princeton_d.py
+++ b/paramak/parametric_components/toroidal_field_coil_princeton_d.py
@@ -84,15 +84,6 @@ class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
         self.number_of_coils = number_of_coils
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def azimuth_placement_angle(self):
         self.find_azimuth_placement_angle()
         return self._azimuth_placement_angle
@@ -192,7 +183,6 @@ class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
         outer_points[-1][2] = "straight"
 
         points = inner_points + outer_points
-        points.append(inner_points[0])
 
         self.points = points
 

--- a/paramak/parametric_components/toroidal_field_coil_rectangle.py
+++ b/paramak/parametric_components/toroidal_field_coil_rectangle.py
@@ -91,15 +91,6 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
         self.number_of_coils = number_of_coils
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def azimuth_placement_angle(self):
         self.find_azimuth_placement_angle()
         return self._azimuth_placement_angle

--- a/paramak/parametric_components/toroidal_field_coil_triple_arc.py
+++ b/paramak/parametric_components/toroidal_field_coil_triple_arc.py
@@ -95,15 +95,6 @@ class ToroidalFieldCoilTripleArc(ExtrudeMixedShape):
         self.vertical_displacement = vertical_displacement
 
     @property
-    def points(self):
-        self.find_points()
-        return self._points
-
-    @points.setter
-    def points(self, points):
-        self._points = points
-
-    @property
     def azimuth_placement_angle(self):
         self.find_azimuth_placement_angle()
         return self._azimuth_placement_angle
@@ -186,7 +177,6 @@ class ToroidalFieldCoilTripleArc(ExtrudeMixedShape):
         for i in range(len(R_outer)):
             points.append([R_outer[i], Z_outer[i], 'spline'])
         points[-1][2] = 'straight'
-        points.append(points[0])
         self.points = points
 
     def find_azimuth_placement_angle(self):

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -210,6 +210,8 @@ class Shape:
         Raises:
             incorrect type: only list of lists or tuples are accepted
         """
+        if hasattr(self, 'find_points'):
+            self.find_points()
 
         return self._points
 


### PR DESCRIPTION
## Proposed changes

Following suggestions from @RemiTheWarrior , a conditional call of find_points() has been added to the points getter in the Shape class. This removes the need to specify new points getters and setters in each parametric component class as find_points() is conditionally called as part of the Shape getters and setters. 
As the points setter also adds final point = start point automatically, having this inheritance removes the need to specify the end point when making parametric components.
find_points() is called conditionally meaning classes with no find_points() method, such as the parametric shapes, are unaffected

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
