### PR TITLE
Adding vertical build to center column study

### DIFF
--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -12,10 +12,12 @@ class BlanketFP(RotateMixedShape):
     """A blanket volume created from plasma parameters.
 
     Args:
-        thickness (float, (float, float), callable): the thickness of the
-            blanket (cm). If float, constant thickness. If tuple of floats,
-            thickness will vary linearly between the two values. If callable,
-            thickness will be a function of poloidal angle (in degrees).
+        thickness (float or [float] or callable or [(float), (float)]): 
+            the thickness of the blanket (cm). If float, constant thickness.
+            If tuple of floats, thickness will vary linearly between the two
+            values. If callable, thickness will be a function of poloidal
+            angle (in degrees). If a list of of two lists (thicknesses and angles)
+            then these will be used together with linear interpolation.
         start_angle (float): the angle in degrees to start the blanket,
             measured anti clockwise from 3 o'clock
         stop_angle (float): the angle in degrees to stop the blanket, measured
@@ -32,11 +34,12 @@ class BlanketFP(RotateMixedShape):
             Defaults to 2.0.
         vertical_displacement (float, optional): the vertical_displacement of
             the plasma (cm). Defaults to 0.
-        offset_from_plasma (float, (float, float), callable): the distance
-            bettwen the plasma and the blanket (cm). If float, constant offset.
-            If tuple of floats, offset will vary linearly between the two
+        offset_from_plasma (float or [float] or callable or [(float), (float)]): 
+            the distance bettwen the plasma and the blanket (cm). If float,
+            constant offset. If list of floats, offset will vary linearly between the
             values. If callable, offset will be a function of poloidal angle
-            (in degrees) Defaults to 0.
+            (in degrees) Defaults to 0. If a list of of two lists (offsets and angles)
+            then these will be used together with linear interpolation.
         num_points (int, optional): number of points that will describe the
             shape. Defaults to 50.
         Others: see paramak.RotateMixedShape() arguments.

--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -42,10 +42,12 @@ class BlanketFP(RotateMixedShape):
         Others: see paramak.RotateMixedShape() arguments.
 
     Keyword Args:
-        thickness (float, (float, float), callable): the thickness of the
-            blanket (cm). If float, constant thickness. If tuple of floats,
-            thickness will vary linearly between the two values. If callable,
-            thickness will be a function of poloidal angle (in degrees).
+        thickness (float or [float] or callable or [(float), (float)]): 
+            the thickness of the blanket (cm). If float, constant thickness.
+            If tuple of floats, thickness will vary linearly between the two
+            values. If callable, thickness will be a function of poloidal
+            angle (in degrees). If a list of of two lists (thicknesses and angles)
+            then these will be used together with linear interpolation.
         start_angle (float): the angle in degrees to start the blanket,
             measured anti clockwise from 3 o'clock
         stop_angle (float): the angle in degrees to stop the blanket, measured
@@ -59,11 +61,12 @@ class BlanketFP(RotateMixedShape):
             Defaults to 2.0.
         vertical_displacement (float): the vertical_displacement of
             the plasma (cm).
-        offset_from_plasma (float, (float, float), callable): the distance
-            bettwen the plasma and the blanket (cm). If float, constant offset.
-            If tuple of floats, offset will vary linearly between the two
+        offset_from_plasma (float or [float] or callable or [(float), (float)]): 
+            the distance bettwen the plasma and the blanket (cm). If float,
+            constant offset. If list of floats, offset will vary linearly between the
             values. If callable, offset will be a function of poloidal angle
-            (in degrees) Defaults to 0.
+            (in degrees) Defaults to 0. If a list of of two lists (offsets and angles)
+            then these will be used together with linear interpolation.
         num_points (int): number of points that will describe the
             shape.
         Others: see paramak.RotateMixedShape() attributes.

--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -12,7 +12,7 @@ class BlanketFP(RotateMixedShape):
     """A blanket volume created from plasma parameters.
 
     Args:
-        thickness (float or [float] or callable or [(float), (float)]): 
+        thickness (float or [float] or callable or [(float), (float)]):
             the thickness of the blanket (cm). If float, constant thickness.
             If tuple of floats, thickness will vary linearly between the two
             values. If callable, thickness will be a function of poloidal
@@ -34,7 +34,7 @@ class BlanketFP(RotateMixedShape):
             Defaults to 2.0.
         vertical_displacement (float, optional): the vertical_displacement of
             the plasma (cm). Defaults to 0.
-        offset_from_plasma (float or [float] or callable or [(float), (float)]): 
+        offset_from_plasma (float or [float] or callable or [(float), (float)]):
             the distance bettwen the plasma and the blanket (cm). If float,
             constant offset. If list of floats, offset will vary linearly between the
             values. If callable, offset will be a function of poloidal angle
@@ -45,7 +45,7 @@ class BlanketFP(RotateMixedShape):
         Others: see paramak.RotateMixedShape() arguments.
 
     Keyword Args:
-        thickness (float or [float] or callable or [(float), (float)]): 
+        thickness (float or [float] or callable or [(float), (float)]):
             the thickness of the blanket (cm). If float, constant thickness.
             If tuple of floats, thickness will vary linearly between the two
             values. If callable, thickness will be a function of poloidal
@@ -64,7 +64,7 @@ class BlanketFP(RotateMixedShape):
             Defaults to 2.0.
         vertical_displacement (float): the vertical_displacement of
             the plasma (cm).
-        offset_from_plasma (float or [float] or callable or [(float), (float)]): 
+        offset_from_plasma (float or [float] or callable or [(float), (float)]):
             the distance bettwen the plasma and the blanket (cm). If float,
             constant offset. If list of floats, offset will vary linearly between the
             values. If callable, offset will be a function of poloidal angle

--- a/paramak/parametric_reactors/center_column_study_reactor.py
+++ b/paramak/parametric_reactors/center_column_study_reactor.py
@@ -242,9 +242,14 @@ class CenterColumnStudyReactor(paramak.Reactor):
         self._blanket = paramak.BlanketFP(
             plasma=self._plasma,
             thickness=100.,
-            offset_from_plasma=self.outer_plasma_gap_radial_thickness,
-            start_angle=-160,
-            stop_angle=160,
+            offset_from_plasma=[
+                self.inner_plasma_gap_radial_thickness,
+                self.plasma_gap_vertical_thickness,
+                self.outer_plasma_gap_radial_thickness,
+                self.plasma_gap_vertical_thickness,
+                self.inner_plasma_gap_radial_thickness],
+            start_angle=-179,
+            stop_angle=179,
             rotation_angle=self.rotation_angle,
             cut=center_column_cutter
         )

--- a/tests/test_CenterColumnStudyReactor.py
+++ b/tests/test_CenterColumnStudyReactor.py
@@ -24,7 +24,8 @@ class test_CenterColumnStudyReactor(unittest.TestCase):
             inner_plasma_gap_radial_thickness=80,
             plasma_radial_thickness=200,
             outer_plasma_gap_radial_thickness=90,
-            plasma_high_point=(245, 240), # first number must be between plasma inner/outer radius
+            # first number must be between plasma inner/outer radius
+            plasma_high_point=(245, 240),
             plasma_gap_vertical_thickness=40,
             center_column_arc_vertical_thickness=520,
             rotation_angle=180)
@@ -49,7 +50,8 @@ class test_CenterColumnStudyReactor(unittest.TestCase):
             inner_plasma_gap_radial_thickness=80,
             plasma_radial_thickness=200,
             outer_plasma_gap_radial_thickness=90,
-            plasma_high_point=(245, 240), # first number must be between plasma inner/outer radius
+            # first number must be between plasma inner/outer radius
+            plasma_high_point=(245, 240),
             plasma_gap_vertical_thickness=40,
             center_column_arc_vertical_thickness=520,
             rotation_angle=180)
@@ -75,7 +77,8 @@ class test_CenterColumnStudyReactor(unittest.TestCase):
                     inner_plasma_gap_radial_thickness=80,
                     plasma_radial_thickness=200,
                     outer_plasma_gap_radial_thickness=90,
-                    plasma_high_point=(245, 240), # first number must be between plasma inner/outer radius
+                    # first number must be between plasma inner/outer radius
+                    plasma_high_point=(245, 240),
                     plasma_gap_vertical_thickness=40,
                     center_column_arc_vertical_thickness=520,
                     rotation_angle=360)

--- a/tests/test_CenterColumnStudyReactor.py
+++ b/tests/test_CenterColumnStudyReactor.py
@@ -21,12 +21,11 @@ class test_CenterColumnStudyReactor(unittest.TestCase):
             center_column_shield_radial_thickness_upper=100,
             inboard_firstwall_radial_thickness=20,
             divertor_radial_thickness=100,
-            inner_plasma_gap_radial_thickness=40,
+            inner_plasma_gap_radial_thickness=80,
             plasma_radial_thickness=200,
-            outer_plasma_gap_radial_thickness=30,
-            # first number must be between plasma inner/outer radius
-            plasma_high_point=(20 + 50 + 100 + 10 + 20 + 30, 240),
-            plasma_gap_vertical_thickness=20,
+            outer_plasma_gap_radial_thickness=90,
+            plasma_high_point=(245, 240), # first number must be between plasma inner/outer radius
+            plasma_gap_vertical_thickness=40,
             center_column_arc_vertical_thickness=520,
             rotation_angle=180)
 
@@ -41,17 +40,17 @@ class test_CenterColumnStudyReactor(unittest.TestCase):
         os.system("rm test_CenterColumnStudyReactor_image.svg")
 
         test_reactor = paramak.CenterColumnStudyReactor(
-            inner_bore_radial_thickness=20,
+            inner_bore_radial_thickness=30,
             inboard_tf_leg_radial_thickness=50,
             center_column_shield_radial_thickness_mid=50,
             center_column_shield_radial_thickness_upper=100,
-            inboard_firstwall_radial_thickness=20,
-            divertor_radial_thickness=100,
-            inner_plasma_gap_radial_thickness=40,
+            inboard_firstwall_radial_thickness=30,
+            divertor_radial_thickness=10,
+            inner_plasma_gap_radial_thickness=80,
             plasma_radial_thickness=200,
-            outer_plasma_gap_radial_thickness=30,
-            plasma_high_point=(20 + 50 + 100 + 20, 240),
-            plasma_gap_vertical_thickness=20,
+            outer_plasma_gap_radial_thickness=90,
+            plasma_high_point=(245, 240), # first number must be between plasma inner/outer radius
+            plasma_gap_vertical_thickness=40,
             center_column_arc_vertical_thickness=520,
             rotation_angle=180)
 
@@ -66,18 +65,18 @@ class test_CenterColumnStudyReactor(unittest.TestCase):
 
         def warning_trigger():
             try:
-                paramak.CenterColumnStudyReactor(
+                test_reactor = paramak.CenterColumnStudyReactor(
                     inner_bore_radial_thickness=20,
                     inboard_tf_leg_radial_thickness=50,
                     center_column_shield_radial_thickness_mid=50,
                     center_column_shield_radial_thickness_upper=100,
                     inboard_firstwall_radial_thickness=20,
                     divertor_radial_thickness=100,
-                    inner_plasma_gap_radial_thickness=40,
+                    inner_plasma_gap_radial_thickness=80,
                     plasma_radial_thickness=200,
-                    outer_plasma_gap_radial_thickness=30,
-                    plasma_high_point=(20 + 50 + 100 + 20, 240),
-                    plasma_gap_vertical_thickness=20,
+                    outer_plasma_gap_radial_thickness=90,
+                    plasma_high_point=(245, 240), # first number must be between plasma inner/outer radius
+                    plasma_gap_vertical_thickness=40,
                     center_column_arc_vertical_thickness=520,
                     rotation_angle=360)
 


### PR DESCRIPTION
## Proposed changes

A new feature for in BlanketFP that accepts a list of offsets_from_plasma allows the vertical build for the CenterColumnStudyReactor to be made from a simple list. This has been implemented and is and the vertical build is now working for CenterColumnStudyReactor. 

Docstrings have also been updated on BlanketFP

Perhaps other parametric reactors can be improved to utilise this feature.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [x] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
