### PR TITLE
Tf coil offset angle

### DIFF
--- a/paramak/parametric_components/inner_tf_coils_circular.py
+++ b/paramak/parametric_components/inner_tf_coils_circular.py
@@ -42,10 +42,11 @@ class InnerTfCoilsCircular(ExtrudeMixedShape):
         outer_radius,
         number_of_coils,
         gap_size,
+        azimuth_start_angle=0,
         stp_filename="InnerTfCoilsCircular.stp",
         stl_filename="InnerTfCoilsCircular.stl",
         color=(0.5, 0.5, 0.5),
-        azimuth_placement_angle=0,
+        azimuth_placement_angle=0,   # cannot be controlled by user
         material_tag="inner_tf_coil_mat",
         name=None,
         **kwargs
@@ -78,12 +79,21 @@ class InnerTfCoilsCircular(ExtrudeMixedShape):
             **default_dict
         )
 
+        self.azimuth_start_angle = azimuth_start_angle
         self.height = height
         self.inner_radius = inner_radius
         self.outer_radius = outer_radius
         self.number_of_coils = number_of_coils
         self.gap_size = gap_size
         self.distance = height
+
+    @property
+    def azimuth_start_angle(self):
+        return self._azimuth_start_angle
+
+    @azimuth_start_angle.setter
+    def azimuth_start_angle(self, value):
+        self._azimuth_start_angle = value
 
     @property
     def azimuth_placement_angle(self):
@@ -223,8 +233,8 @@ class InnerTfCoilsCircular(ExtrudeMixedShape):
 
         angles = list(
             np.linspace(
-                0,
-                360,
+                0 + self.azimuth_start_angle,
+                360 + self.azimuth_start_angle,
                 self.number_of_coils,
                 endpoint=False))
 

--- a/paramak/parametric_components/inner_tf_coils_flat.py
+++ b/paramak/parametric_components/inner_tf_coils_flat.py
@@ -44,10 +44,11 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
         outer_radius,
         number_of_coils,
         gap_size,
+        azimuth_start_angle=0,
         stp_filename="InnerTfCoilsFlat.stp",
         stl_filename="InnerTfCoilsFlat.stl",
         color=(0.5, 0.5, 0.5),
-        azimuth_placement_angle=0,
+        azimuth_placement_angle=0,   # cannot be controlled by user
         material_tag="inner_tf_coil_mat",
         name=None,
         **kwargs
@@ -80,12 +81,21 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
             **default_dict
         )
 
+        self.azimuth_start_angle = azimuth_start_angle
         self.height = height
         self.inner_radius = inner_radius
         self.outer_radius = outer_radius
         self.number_of_coils = number_of_coils
         self.gap_size = gap_size
         self.distance = height
+
+    @property
+    def azimuth_start_angle(self):
+        return self._azimuth_start_angle
+
+    @azimuth_start_angle.setter
+    def azimuth_start_angle(self, value):
+        self._azimuth_start_angle = value
 
     @property
     def azimuth_placement_angle(self):
@@ -203,8 +213,8 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
 
         angles = list(
             np.linspace(
-                0,
-                360,
+                0 + self.azimuth_start_angle,
+                360 + self.azimuth_start_angle,
                 self.number_of_coils,
                 endpoint=False))
 

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -1098,6 +1098,22 @@ class test_InnerTfCoilsFlat(unittest.TestCase):
         assert test_shape.solid is not None
         assert test_shape.volume > 1000
 
+    def test_InnerTfCoilsFlat_azimuth_offset(self):
+        """creates an inner tf coil using the InnerTfCoilsFlat parametric component and checks
+        that the azimuthal start angle can be changed correctly"""
+
+        test_shape = paramak.InnerTfCoilsFlat(
+            height=500,
+            inner_radius=50,
+            outer_radius=150,
+            number_of_coils=6,
+            gap_size=5
+        )
+
+        assert test_shape.azimuth_placement_angle == [0, 60, 120, 180, 240, 300]
+        test_shape.azimuth_start_angle = 20
+        assert test_shape.azimuth_placement_angle == [20, 80, 140, 200, 260, 320]
+
 
 class test_InnerTfCoilsCircular(unittest.TestCase):
     def test_InnerTfCoilsCircular_creation(self):
@@ -1114,6 +1130,22 @@ class test_InnerTfCoilsCircular(unittest.TestCase):
 
         assert test_shape.solid is not None
         assert test_shape.volume > 1000
+
+    def test_InnerTfCoilsCircular_azimuth_offset(self):
+        """creates an inner tf coil using the InnerTfCoilsCircular parametric component and checks
+        that the azimuthal start angle can be changed correctly"""
+
+        test_shape = paramak.InnerTfCoilsCircular(
+            height=500,
+            inner_radius=50,
+            outer_radius=150,
+            number_of_coils=6,
+            gap_size=5
+        )
+
+        assert test_shape.azimuth_placement_angle == [0, 60, 120, 180, 240, 300]
+        test_shape.azimuth_start_angle = 20
+        assert test_shape.azimuth_placement_angle == [20, 80, 140, 200, 260, 320]
 
 
 class test_ParametricComponents(unittest.TestCase):

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -1110,9 +1110,11 @@ class test_InnerTfCoilsFlat(unittest.TestCase):
             gap_size=5
         )
 
-        assert test_shape.azimuth_placement_angle == [0, 60, 120, 180, 240, 300]
+        assert test_shape.azimuth_placement_angle == [
+            0, 60, 120, 180, 240, 300]
         test_shape.azimuth_start_angle = 20
-        assert test_shape.azimuth_placement_angle == [20, 80, 140, 200, 260, 320]
+        assert test_shape.azimuth_placement_angle == [
+            20, 80, 140, 200, 260, 320]
 
 
 class test_InnerTfCoilsCircular(unittest.TestCase):
@@ -1143,9 +1145,11 @@ class test_InnerTfCoilsCircular(unittest.TestCase):
             gap_size=5
         )
 
-        assert test_shape.azimuth_placement_angle == [0, 60, 120, 180, 240, 300]
+        assert test_shape.azimuth_placement_angle == [
+            0, 60, 120, 180, 240, 300]
         test_shape.azimuth_start_angle = 20
-        assert test_shape.azimuth_placement_angle == [20, 80, 140, 200, 260, 320]
+        assert test_shape.azimuth_placement_angle == [
+            20, 80, 140, 200, 260, 320]
 
 
 class test_ParametricComponents(unittest.TestCase):


### PR DESCRIPTION
## Proposed changes

Adds azimuth_start_angle attribute to inner tf coil parametric components which allows the tf coils to be rotated by a given amount.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
