### PR TITLE
added inner leg to ToroidalFieldCoilPrincetonD

### DIFF
--- a/docs/source/paramak.parametric_components.rst
+++ b/docs/source/paramak.parametric_components.rst
@@ -330,10 +330,14 @@ ToroidalFieldCoilCoatHanger()
 ToroidalFieldCoilPrincetonD()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. image:: https://user-images.githubusercontent.com/56687624/92124475-bd7bd080-edf5-11ea-9c49-1db6422d77a0.png
+|ToroidalFieldCoilPrincetonDallstp| |ToroidalFieldCoilPrincetonDsvg| |ToroidalFieldCoilPrincetonDastp|
+
+.. |ToroidalFieldCoilPrincetonDallstp| image:: https://user-images.githubusercontent.com/56687624/92124475-bd7bd080-edf5-11ea-9c49-1db6422d77a0.png
    :width: 250
-   :height: 200
-   :align: center
+.. |ToroidalFieldCoilPrincetonDsvg| image:: https://user-images.githubusercontent.com/8583900/94529559-cd8aa280-0231-11eb-9919-48d3c642a5d7.png
+   :width: 250
+.. |ToroidalFieldCoilPrincetonDastp| image:: https://user-images.githubusercontent.com/8583900/94479853-4c012900-01cd-11eb-9b59-0fcd5f4dc531.png
+   :width: 250
 
 .. automodule:: paramak.parametric_components.toroidal_field_coil_princeton_d
    :members:

--- a/examples/example_parametric_components/make_all_parametric_components.py
+++ b/examples/example_parametric_components/make_all_parametric_components.py
@@ -160,16 +160,6 @@ def main():
     )
     all_components.append(component)
 
-    # component = paramak.DivertorBlock(
-    #     major_radius = 800,
-    #     minor_radius = 400,
-    #     triangularity = 1.2,
-    #     elongation = 0.9,
-    #     thickness = 50,
-    #     offset_from_plasma = 20,
-    #     start
-    # )
-
     component = paramak.InnerTfCoilsCircular(
         inner_radius=25,
         outer_radius=100,
@@ -283,7 +273,7 @@ def main():
         thickness=150,
         distance=60,
         stp_filename="tf_coil_rectangle.stp",
-        number_of_coils=6,
+        number_of_coils=1,
     )
     all_components.append(component)
 
@@ -295,7 +285,7 @@ def main():
         thickness=50,
         distance=50,
         stp_filename="toroidal_field_coil_coat_hanger.stp",
-        number_of_coils=6,
+        number_of_coils=1,
     )
     all_components.append(component)
 
@@ -306,7 +296,7 @@ def main():
         coverages=(60, 60),
         thickness=30,
         distance=30,
-        number_of_coils=6,
+        number_of_coils=1,
         stp_filename="toroidal_field_coil_triple_arc.stp"
     )
     all_components.append(component)
@@ -316,7 +306,7 @@ def main():
         R2=300,
         thickness=30,
         distance=30,
-        number_of_coils=6,
+        number_of_coils=1,
         stp_filename="toroidal_field_coil_princeton_d.stp"
     )
     all_components.append(component)

--- a/examples/example_parametric_components/make_magnet_set.py
+++ b/examples/example_parametric_components/make_magnet_set.py
@@ -11,13 +11,12 @@ import paramak
 
 def main():
 
-    number_of_toroidal_field_coils = 1
+    number_of_toroidal_field_coils = 8
     angle_offset = (360 / number_of_toroidal_field_coils) / 2.
-    tf_coil_case_thickness = 10
     tf_coil_thickness = 50
     tf_coil_distance = 130
 
-    inner_tf = paramak.InnerTfCoilsFlat(
+    inner_tf_case = paramak.InnerTfCoilsFlat(
         height=1800,
         inner_radius=330,
         outer_radius=430,
@@ -27,23 +26,13 @@ def main():
         azimuth_start_angle=angle_offset
     )
 
-    outer_tf = paramak.ToroidalFieldCoilPrincetonD(
+    tf_coils = paramak.ToroidalFieldCoilPrincetonD(
         R1=400,
         R2=1500,  # height
         thickness=tf_coil_thickness,
         distance=tf_coil_distance,
         number_of_coils=number_of_toroidal_field_coils,
         rotation_angle=180,
-    )
-
-    outer_tf_case = paramak.ToroidalFieldCoilPrincetonD(
-        R1=400,
-        R2=1500,  # height
-        thickness=tf_coil_thickness + tf_coil_case_thickness,
-        distance=tf_coil_distance + tf_coil_case_thickness,
-        number_of_coils=number_of_toroidal_field_coils,
-        rotation_angle=180,
-        cut =outer_tf
     )
 
     pf_coils = paramak.PoloidalFieldCoilSet(
@@ -60,10 +49,10 @@ def main():
     )
 
     pf_coils.export_stp('pf_coils.stp')
-    pf_coils_casing.export_stp('pf_coils_casing.stp')
-    outer_tf.export_stp('outer_tf.stp')
-    inner_tf.export_stp('inner_tf.stp')
-    outer_tf_case.export_stp('tf_case.stp')
+    pf_coils_casing.export_stp('pf_coils_case.stp')
+
+    tf_coils.export_stp('tf_coil.stp')
+    inner_tf_case.export_stp('inner_tf_case.stp')
 
 
 if __name__ == "__main__":

--- a/examples/example_parametric_components/make_magnet_set.py
+++ b/examples/example_parametric_components/make_magnet_set.py
@@ -2,6 +2,7 @@
 """
 This script makes a blanket and then segments it in a similar
 manner to the EU DEMO segmentation for remote maintainance.
+This takes sometime to compute so 
 """
 
 import math
@@ -11,39 +12,39 @@ import paramak
 
 def main():
 
-    number_of_toroidal_field_coils = 8
+    number_of_toroidal_field_coils = 1
     angle_offset = (360 / number_of_toroidal_field_coils) / 2.
+    tf_coil_case_thickness = 10
+    tf_coil_thickness = 50
+    tf_coil_distance = 130
+
     inner_tf = paramak.InnerTfCoilsFlat(
         height=1800,
         inner_radius=330,
         outer_radius=430,
         number_of_coils=number_of_toroidal_field_coils,
         gap_size=5,
-        rotation_angle=180
+        rotation_angle=180,
+        azimuth_start_angle=angle_offset
     )
 
     outer_tf = paramak.ToroidalFieldCoilPrincetonD(
         R1=400,
         R2=1500,  # height
-        thickness=50,
-        distance=130,
+        thickness=tf_coil_thickness,
+        distance=tf_coil_distance,
         number_of_coils=number_of_toroidal_field_coils,
         rotation_angle=180,
-        azimuth_placement_angle=np.linspace(
-            0 + angle_offset, 360 + angle_offset,
-            number_of_toroidal_field_coils,
-            endpoint=False
-        )
     )
 
-    inner_leg = paramak.ExtrudeStraightShape(
-        points=outer_tf.inner_leg_connection_points,
-        distance=130,
-        azimuth_placement_angle=np.linspace(
-            0, 360,
-            number_of_toroidal_field_coils,
-            endpoint=False
-        )
+    outer_tf_case = paramak.ToroidalFieldCoilPrincetonD(
+        R1=400,
+        R2=1500,  # height
+        thickness=tf_coil_thickness + tf_coil_case_thickness,
+        distance=tf_coil_distance + tf_coil_case_thickness,
+        number_of_coils=number_of_toroidal_field_coils,
+        rotation_angle=180,
+        cut =outer_tf
     )
 
     pf_coils = paramak.PoloidalFieldCoilSet(
@@ -63,7 +64,7 @@ def main():
     pf_coils_casing.export_stp('pf_coils_casing.stp')
     outer_tf.export_stp('outer_tf.stp')
     inner_tf.export_stp('inner_tf.stp')
-    inner_leg.export_stp('leg.stp')
+    outer_tf_case.export_stp('tf_case.stp')
 
 
 if __name__ == "__main__":

--- a/examples/example_parametric_components/make_magnet_set.py
+++ b/examples/example_parametric_components/make_magnet_set.py
@@ -2,7 +2,6 @@
 """
 This script makes a blanket and then segments it in a similar
 manner to the EU DEMO segmentation for remote maintainance.
-This takes sometime to compute so 
 """
 
 import math

--- a/paramak/parametric_components/toroidal_field_coil_princeton_d.py
+++ b/paramak/parametric_components/toroidal_field_coil_princeton_d.py
@@ -8,7 +8,6 @@ from scipy.optimize import minimize
 from paramak import ExtrudeMixedShape, ExtrudeStraightShape
 
 
-
 class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
     """Toroidal field coil based on Princeton-D curve
 

--- a/paramak/parametric_components/toroidal_field_coil_princeton_d.py
+++ b/paramak/parametric_components/toroidal_field_coil_princeton_d.py
@@ -6,7 +6,7 @@ from scipy import integrate
 from scipy.optimize import minimize
 
 from paramak import ExtrudeMixedShape, ExtrudeStraightShape
-from paramak.utils import union_solid
+
 
 class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
     """Toroidal field coil based on Princeton-D curve

--- a/paramak/parametric_components/toroidal_field_coil_princeton_d.py
+++ b/paramak/parametric_components/toroidal_field_coil_princeton_d.py
@@ -8,6 +8,7 @@ from scipy.optimize import minimize
 from paramak import ExtrudeMixedShape, ExtrudeStraightShape
 
 
+
 class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
     """Toroidal field coil based on Princeton-D curve
 
@@ -264,8 +265,10 @@ class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
         if self.with_inner_leg is True:
             inner_leg_solid = cq.Workplane(self.workplane)
             inner_leg_solid.moveTo(XZ_points[0][0], XZ_points[0][1])
-            inner_leg_solid = inner_leg_solid.polyline(self.inner_leg_connection_points)
-            inner_leg_solid = inner_leg_solid.close().extrude(distance=-self.distance / 2.0, both=True)
+            inner_leg_solid = inner_leg_solid.polyline(
+                self.inner_leg_connection_points)
+            inner_leg_solid = inner_leg_solid.close().extrude(
+                distance=-self.distance / 2.0, both=True)
 
             solid = cq.Compound.makeCompound(
                 [a.val() for a in [inner_leg_solid, solid]]
@@ -290,6 +293,5 @@ class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
                 (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
 
         self.perform_boolean_operations(solid)
-
 
         return solid

--- a/paramak/parametric_components/toroidal_field_coil_princeton_d.py
+++ b/paramak/parametric_components/toroidal_field_coil_princeton_d.py
@@ -1,9 +1,12 @@
+from collections import Iterable
+
+import cadquery as cq
 import numpy as np
 from scipy import integrate
 from scipy.optimize import minimize
 
-from paramak import ExtrudeMixedShape
-
+from paramak import ExtrudeMixedShape, ExtrudeStraightShape
+from paramak.utils import union_solid
 
 class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
     """Toroidal field coil based on Princeton-D curve
@@ -16,6 +19,7 @@ class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
         number_of_coils (int): the number of tf coils. This changes by the
             azimuth_placement_angle dividing up 360 degrees by the number of
             coils.
+        with_inner_leg (Boolean): Include the inner tf leg (default True)
 
     Keyword Args:
         stp_filename (str, optional): The filename used when saving stp files
@@ -47,6 +51,7 @@ class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
         azimuth_placement_angle=0,
         name=None,
         material_tag="outer_tf_coil_mat",
+        with_inner_leg=True,
         **kwargs
     ):
 
@@ -82,15 +87,7 @@ class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
         self.thickness = thickness
         self.distance = distance
         self.number_of_coils = number_of_coils
-
-    @property
-    def inner_leg_connection_points(self):
-        self.find_points()
-        return self._inner_leg_connection_points
-
-    @inner_leg_connection_points.setter
-    def inner_leg_connection_points(self, value):
-        self._inner_leg_connection_points = value
+        self.with_inner_leg = with_inner_leg
 
     @property
     def azimuth_placement_angle(self):
@@ -219,3 +216,80 @@ class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
                 endpoint=False))
 
         self.azimuth_placement_angle = angles
+
+    def create_solid(self):
+        """Creates a 3d solid using points with straight and spline
+        connections edges, azimuth_placement_angle and distance.
+
+        :return: a 3d solid volume
+        :rtype: a cadquery solid
+        """
+
+        # obtains the first two values of the points list
+        XZ_points = [(p[0], p[1]) for p in self.points]
+
+        # obtains the last values of the points list
+        connections = [p[2] for p in self.points[:-1]]
+
+        current_linetype = connections[0]
+        current_points_list = []
+        instructions = []
+        # groups together common connection types
+        for i, c in enumerate(connections):
+            if c == current_linetype:
+                current_points_list.append(XZ_points[i])
+            else:
+                current_points_list.append(XZ_points[i])
+                instructions.append({current_linetype: current_points_list})
+                current_linetype = c
+                current_points_list = [XZ_points[i]]
+        instructions.append({current_linetype: current_points_list})
+
+        if list(instructions[-1].values())[0][-1] != XZ_points[0]:
+            keyname = list(instructions[-1].keys())[0]
+            instructions[-1][keyname].append(XZ_points[0])
+
+        solid = cq.Workplane(self.workplane)
+        solid.moveTo(XZ_points[0][0], XZ_points[0][1])
+
+        for entry in instructions:
+            if list(entry.keys())[0] == "spline":
+                solid = solid.spline(listOfXYTuple=list(entry.values())[0])
+            if list(entry.keys())[0] == "straight":
+                solid = solid.polyline(list(entry.values())[0])
+
+        # performs extrude in both directions, hence distance / 2
+        solid = solid.close().extrude(distance=-self.distance / 2.0, both=True)
+
+        if self.with_inner_leg is True:
+            inner_leg_solid = cq.Workplane(self.workplane)
+            inner_leg_solid.moveTo(XZ_points[0][0], XZ_points[0][1])
+            inner_leg_solid = inner_leg_solid.polyline(self.inner_leg_connection_points)
+            inner_leg_solid = inner_leg_solid.close().extrude(distance=-self.distance / 2.0, both=True)
+
+            solid = cq.Compound.makeCompound(
+                [a.val() for a in [inner_leg_solid, solid]]
+            )
+
+        # Checks if the azimuth_placement_angle is a list of angles
+        if isinstance(self.azimuth_placement_angle, Iterable):
+            rotated_solids = []
+            # Perform seperate rotations for each angle
+            for angle in self.azimuth_placement_angle:
+                rotated_solids.append(
+                    solid.rotate(
+                        (0, 0, -1), (0, 0, 1), angle))
+            solid = cq.Workplane(self.workplane)
+
+            # Joins the seperate solids together
+            for i in rotated_solids:
+                solid = solid.union(i)
+        else:
+            # Peform rotations for a single azimuth_placement_angle angle
+            solid = solid.rotate(
+                (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
+
+        self.perform_boolean_operations(solid)
+
+
+        return solid

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -6,6 +6,7 @@ import pytest
 
 import paramak
 
+
 class test_attribute_propagation_to_solid(unittest.TestCase):
     def test_InnerTfCoilsCircular_attributes(self):
         """checks that changing the attributes of InnerTfCoilsCircular affects the
@@ -20,13 +21,13 @@ class test_attribute_propagation_to_solid(unittest.TestCase):
         )
         test_shape_volume = test_shape.volume
 
-        test_shape.height=1000
+        test_shape.height = 1000
         assert test_shape_volume == test_shape.volume * 0.5
-        test_shape.height=500
-        test_shape.inner_radius=30
+        test_shape.height = 500
+        test_shape.inner_radius = 30
         assert test_shape_volume < test_shape.volume
-        test_shape.inner_radius=50
-        test_shape.outer_radius=170
+        test_shape.inner_radius = 50
+        test_shape.outer_radius = 170
         assert test_shape_volume < test_shape.volume
 
     def test_InnerTfCoilsFlat_attributes(self):
@@ -42,14 +43,15 @@ class test_attribute_propagation_to_solid(unittest.TestCase):
         )
         test_shape_volume = test_shape.volume
 
-        test_shape.height=1000
+        test_shape.height = 1000
         assert test_shape_volume == test_shape.volume * 0.5
-        test_shape.height=500
-        test_shape.inner_radius=30
+        test_shape.height = 500
+        test_shape.inner_radius = 30
         assert test_shape_volume < test_shape.volume
-        test_shape.inner_radius=50
-        test_shape.outer_radius=170
+        test_shape.inner_radius = 50
+        test_shape.outer_radius = 170
         assert test_shape_volume < test_shape.volume
+
 
 class test_InboardFirstwallFCCS(unittest.TestCase):
     def test_construction_with_CenterColumnShieldCylinder(self):
@@ -1159,7 +1161,6 @@ class test_InnerTfCoilsFlat(unittest.TestCase):
         test_shape.azimuth_start_angle = 20
         assert test_shape.azimuth_placement_angle == [
             20, 80, 140, 200, 260, 320]
-
 
 
 class test_InnerTfCoilsCircular(unittest.TestCase):


### PR DESCRIPTION
## Proposed changes

This PR makes use of the new azimuth_start_angle in the InnerTfCoilsFlat parametric component to line up the TF coils and the inner TF coil cases

Also this adds the inner tf coil leg to the tf coil magnets for ToroidalFieldCoilPrincetonD, perhaps this can be done for the other magnets

The make_mangnet_example is not missing the tests, docs, rotation angle and the wedge cutter to finish the example


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I've also tried to document the TF coil with a few more diagrams, see #310 


ToDo
For the magnet example an image is missing, tests are missing and the rotation angle parameter is missing