### PR TITLE
fix azimuthal placement angle sense

### DIFF
--- a/paramak/parametric_components/cutting_wedge_fs.py
+++ b/paramak/parametric_components/cutting_wedge_fs.py
@@ -105,7 +105,9 @@ class CuttingWedgeFS(RotateStraightShape):
             ]
 
             rotation_angle = 360 - self.shape.rotation_angle
-            azimuth_placement_angle = 360 - self.shape.rotation_angle
+            
+            azimuth_placement_angle = self.shape.azimuth_placement_angle + self.shape.rotation_angle
+            # azimuth_placement_angle setter allows > 360
 
         self.points = points
         self.rotation_angle = rotation_angle

--- a/paramak/parametric_components/cutting_wedge_fs.py
+++ b/paramak/parametric_components/cutting_wedge_fs.py
@@ -105,7 +105,7 @@ class CuttingWedgeFS(RotateStraightShape):
             ]
 
             rotation_angle = 360 - self.shape.rotation_angle
-            
+
             azimuth_placement_angle = self.shape.azimuth_placement_angle + self.shape.rotation_angle
             # azimuth_placement_angle setter allows > 360
 

--- a/paramak/parametric_shapes/extruded_circle_shape.py
+++ b/paramak/parametric_shapes/extruded_circle_shape.py
@@ -139,7 +139,7 @@ class ExtrudeCircleShape(Shape):
         else:
             # Peform rotations for a single azimuth_placement_angle angle
             solid = solid.rotate(
-                (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
+                (0, 0, -1), (0, 0, 1), self.azimuth_placement_angle)
 
         self.perform_boolean_operations(solid)
 

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -162,7 +162,7 @@ class ExtrudeMixedShape(Shape):
         else:
             # Peform rotations for a single azimuth_placement_angle angle
             solid = solid.rotate(
-                (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
+                (0, 0, -1), (0, 0, 1), self.azimuth_placement_angle)
 
         self.perform_boolean_operations(solid)
 

--- a/paramak/parametric_shapes/extruded_spline_shape.py
+++ b/paramak/parametric_shapes/extruded_spline_shape.py
@@ -127,7 +127,7 @@ class ExtrudeSplineShape(Shape):
         else:
             # Peform rotations for a single azimuth_placement_angle angle
             solid = solid.rotate(
-                (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
+                (0, 0, -1), (0, 0, 1), self.azimuth_placement_angle)
 
         self.perform_boolean_operations(solid)
 

--- a/paramak/parametric_shapes/extruded_straight_shape.py
+++ b/paramak/parametric_shapes/extruded_straight_shape.py
@@ -127,7 +127,7 @@ class ExtrudeStraightShape(Shape):
         else:
             # Peform rotations for a single azimuth_placement_angle angle
             solid = solid.rotate(
-                (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
+                (0, 0, -1), (0, 0, 1), self.azimuth_placement_angle)
 
         self.perform_boolean_operations(solid)
 

--- a/paramak/parametric_shapes/rotate_circle_shape.py
+++ b/paramak/parametric_shapes/rotate_circle_shape.py
@@ -134,7 +134,7 @@ class RotateCircleShape(Shape):
         else:
             # Peform rotations for a single azimuth_placement_angle angle
             solid = solid.rotate(
-                (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
+                (0, 0, -1), (0, 0, 1), self.azimuth_placement_angle)
 
         self.perform_boolean_operations(solid)
 

--- a/paramak/parametric_shapes/rotate_mixed_shape.py
+++ b/paramak/parametric_shapes/rotate_mixed_shape.py
@@ -157,7 +157,7 @@ class RotateMixedShape(Shape):
         else:
             # Peform rotations for a single azimuth_placement_angle angle
             solid = solid.rotate(
-                (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
+                (0, 0, -1), (0, 0, 1), self.azimuth_placement_angle)
 
         self.perform_boolean_operations(solid)
 

--- a/paramak/parametric_shapes/rotate_spline_shape.py
+++ b/paramak/parametric_shapes/rotate_spline_shape.py
@@ -126,7 +126,7 @@ class RotateSplineShape(Shape):
         else:
             # Peform rotations for a single azimuth_placement_angle angle
             solid = solid.rotate(
-                (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
+                (0, 0, -1), (0, 0, 1), self.azimuth_placement_angle)
 
         self.perform_boolean_operations(solid)
 

--- a/paramak/parametric_shapes/rotate_straight_shape.py
+++ b/paramak/parametric_shapes/rotate_straight_shape.py
@@ -126,7 +126,7 @@ class RotateStraightShape(Shape):
         else:
             # Peform rotations for a single azimuth_placement_angle angle
             solid = solid.rotate(
-                (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
+                (0, 0, -1), (0, 0, 1), self.azimuth_placement_angle)
 
         self.perform_boolean_operations(solid)
 


### PR DESCRIPTION
## Proposed changes

PR which solves the discrepancy in placement between iterable and non-iterable azimuthal placement angles. Error in codes resulted in azimuthal placements occurring in opposite directions (clockwise/anticlockwise) depending on whether azimuthal_placement_angle was given as a single number or iterable. azimuthal placement should occur in the same sense as rotation_angle.
This PR also fixes CuttingWedgeFS with respect to this fix.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
