### PR TITLE
New component: Vacuum Vessel with ports

### DIFF
--- a/paramak/__init__.py
+++ b/paramak/__init__.py
@@ -56,3 +56,5 @@ from .parametric_reactors.submersion_reactor import SubmersionTokamak
 from .parametric_reactors.single_null_submersion_reactor import SingleNullSubmersionTokamak
 from .parametric_reactors.single_null_ball_reactor import SingleNullBallReactor
 from .parametric_reactors.center_column_study_reactor import CenterColumnStudyReactor
+
+from .parametric_components.vacuum_vessel import VacuumVessel

--- a/paramak/parametric_components/vacuum_vessel.py
+++ b/paramak/parametric_components/vacuum_vessel.py
@@ -98,19 +98,22 @@ class VacuumVessel(RotateStraightShape):
     def find_points(self):
         """Finds the XZ points joined by straight connections that describe the
             2D profile of the vessel shape."""
+        thickness = self.thickness
+        inner_radius = self.inner_radius
+        height = self.height
 
         inner_points = [
-            (0, self.height / 2),
-            (self.inner_radius, self.height / 2),
-            (self.inner_radius, -self.height / 2),
-            (0, -self.height / 2),
+            (0, height / 2),
+            (inner_radius, height / 2),
+            (inner_radius, -height / 2),
+            (0, -height / 2),
         ]
 
         outer_points = [
-            (0, self.height / 2 + self.thickness),
-            (self.inner_radius + self.thickness, self.height / 2 + self.thickness),
-            (self.inner_radius + self.thickness, -(self.height / 2 + self.thickness)),
-            (0, -(self.height / 2 + self.thickness)),
+            (0, height / 2 + thickness),
+            (inner_radius + thickness, height / 2 + thickness),
+            (inner_radius + thickness, -(height / 2 + thickness)),
+            (0, -(height / 2 + thickness)),
         ]
         self.points = inner_points + outer_points[::-1]
 

--- a/paramak/parametric_components/vacuum_vessel.py
+++ b/paramak/parametric_components/vacuum_vessel.py
@@ -1,4 +1,5 @@
-from paramak import RotateStraightShape
+from paramak import \
+    RotateStraightShape, ExtrudeCircleShape, ExtrudeStraightShape
 
 
 class VacuumVessel(RotateStraightShape):
@@ -32,6 +33,7 @@ class VacuumVessel(RotateStraightShape):
         height,
         inner_radius,
         thickness,
+        circular_ports,
         name=None,
         color=(0.5, 0.5, 0.5),
         stp_filename="CenterColumnShieldCylinder.stp",
@@ -72,6 +74,8 @@ class VacuumVessel(RotateStraightShape):
         self.height = height
         self.inner_radius = inner_radius
         self.thickness = thickness
+        self.circular_ports = circular_ports
+        self.add_ports()
 
     @property
     def height(self):
@@ -107,3 +111,20 @@ class VacuumVessel(RotateStraightShape):
             (0, -(self.height / 2 + self.thickness)),
         ]
         self.points = inner_points + outer_points[::-1]
+
+    def add_ports(self):
+        cutter_shapes = []
+        safety_factor = 1.001
+        # circular ports
+        for port in self.circular_ports:
+            port_height, placement_angle, radius = port
+            shape = ExtrudeCircleShape(
+                points=[(0, port_height)],
+                distance=2*(self.inner_radius+self.thickness*safety_factor),
+                radius=radius,
+                azimuth_placement_angle=placement_angle - 90,
+                extrude_both=False)
+            cutter_shapes.append(shape)
+
+        # rectangular ports
+        self.cut = cutter_shapes

--- a/paramak/parametric_components/vacuum_vessel.py
+++ b/paramak/parametric_components/vacuum_vessel.py
@@ -9,6 +9,14 @@ class VacuumVessel(RotateStraightShape):
         height (float): height of the vessel.
         inner_radius (float): the inner radius of the vessel.
         thickness (float): thickness of the vessel
+        circular_ports (list): list of iterables containing floats describing
+            the ports for, in order:
+            (z position, azimuth placement angle, radius)
+        rectangular_ports (list): list of iterables containing floats
+            describing the ports for, in order:
+            (port z position, azimuth placement angle, widht, height,
+            fillet_radius)
+            If no fillet_radius is specified, the port won't be filleted.
 
     Keyword Args:
         workplane (str): The orientation of the CadQuery workplane. Options are

--- a/paramak/parametric_components/vacuum_vessel.py
+++ b/paramak/parametric_components/vacuum_vessel.py
@@ -34,6 +34,7 @@ class VacuumVessel(RotateStraightShape):
         inner_radius,
         thickness,
         circular_ports,
+        rectangular_ports,
         name=None,
         color=(0.5, 0.5, 0.5),
         stp_filename="CenterColumnShieldCylinder.stp",
@@ -75,6 +76,7 @@ class VacuumVessel(RotateStraightShape):
         self.inner_radius = inner_radius
         self.thickness = thickness
         self.circular_ports = circular_ports
+        self.rectangular_ports = rectangular_ports
         self.add_ports()
 
     @property
@@ -117,9 +119,9 @@ class VacuumVessel(RotateStraightShape):
         safety_factor = 1.001
         # circular ports
         for port in self.circular_ports:
-            port_height, placement_angle, radius = port
+            port_z_pos, placement_angle, radius = port
             shape = ExtrudeCircleShape(
-                points=[(0, port_height)],
+                points=[(0, port_z_pos)],
                 distance=2*(self.inner_radius+self.thickness*safety_factor),
                 radius=radius,
                 azimuth_placement_angle=placement_angle - 90,
@@ -127,4 +129,20 @@ class VacuumVessel(RotateStraightShape):
             cutter_shapes.append(shape)
 
         # rectangular ports
+        for port in self.rectangular_ports:
+            port_z_pos, placement_angle, port_width, port_height = port
+            points = [
+                (-port_width/2, -port_height/2),
+                (port_width/2, -port_height/2),
+                (port_width/2, port_height/2),
+                (-port_width/2, port_height/2),
+            ]
+            shape = ExtrudeStraightShape(
+                points=points,
+                distance=2*(self.inner_radius+self.thickness*safety_factor),
+                azimuth_placement_angle=placement_angle - 90,
+                extrude_both=False
+                )
+            cutter_shapes.append(shape)
+
         self.cut = cutter_shapes

--- a/paramak/parametric_components/vacuum_vessel.py
+++ b/paramak/parametric_components/vacuum_vessel.py
@@ -23,7 +23,7 @@ class VacuumVessel(RotateStraightShape):
         rotated_ports (list): list of iterables containing floats
             describing the ports for, in order:
             (center_point, polar_coverage_angle, polar_placement_angle,
-            rotation_angle, fillet_radius)
+            rotation_angle, azimuth_placement_angle, fillet_radius)
             If no fillet_radius is specified, the port won't be filleted.
             Defaults to [].
 
@@ -175,19 +175,20 @@ class VacuumVessel(RotateStraightShape):
         # rotated ports
         for port in self.rotated_ports:
             center_point, polar_coverage_angle, polar_placement_angle, \
-                rotation_angle = port[:4]
+                rotation_angle, azimuth_placement_angle = port[:5]
             shape = PortCutterRotated(
                 center_point=center_point,
                 polar_coverage_angle=polar_coverage_angle,
                 polar_placement_angle=polar_placement_angle,
                 max_distance_from_center=2*(
                     self.inner_radius+self.thickness*safety_factor),
-                rotation_angle=rotation_angle
+                rotation_angle=rotation_angle,
+                azimuth_placement_angle=azimuth_placement_angle,
                 )
 
             # add fillet
-            if len(port) == 5:
-                shape.solid = shape.solid.edges().fillet(port[4])
+            if len(port) == 6:
+                shape.solid = shape.solid.edges().fillet(port[5])
             cutter_shapes.append(shape)
 
         self.cut = cutter_shapes

--- a/paramak/parametric_components/vacuum_vessel.py
+++ b/paramak/parametric_components/vacuum_vessel.py
@@ -1,0 +1,109 @@
+from paramak import RotateStraightShape
+
+
+class VacuumVessel(RotateStraightShape):
+    """A cylindrical vessel volume with constant thickness.
+
+    Arguments:
+        height (float): height of the vessel.
+        inner_radius (float): the inner radius of the vessel.
+        thickness (float): thickness of the vessel
+
+    Keyword Args:
+        workplane (str): The orientation of the CadQuery workplane. Options are
+            XY, YZ or XZ.
+        intersect (CadQuery object): An optional CadQuery object to perform a
+            boolean intersect with this object.
+        cut (CadQuery object): An optional CadQuery object to perform a boolean
+            cut with this object.
+        union (CadQuery object): An optional CadQuery object to perform a
+            boolean union with this object.
+        tet_mesh (str): Insert description.
+        physical_groups (type): Insert description.
+
+    Returns:
+        a paramak shape object: A shape object that has generic functionality
+        with points determined by the find_points() method. A CadQuery solid
+        of the shape can be called via shape.solid.
+    """
+
+    def __init__(
+        self,
+        height,
+        inner_radius,
+        thickness,
+        name=None,
+        color=(0.5, 0.5, 0.5),
+        stp_filename="CenterColumnShieldCylinder.stp",
+        stl_filename="CenterColumnShieldCylinder.stl",
+        rotation_angle=360,
+        material_tag="center_column_shield_mat",
+        azimuth_placement_angle=0,
+        **kwargs
+    ):
+
+        default_dict = {
+            "points": None,
+            "workplane": "XZ",
+            "solid": None,
+            "intersect": None,
+            "cut": None,
+            "union": None,
+            "tet_mesh": None,
+            "physical_groups": None,
+        }
+
+        for arg in kwargs:
+            if arg in default_dict:
+                default_dict[arg] = kwargs[arg]
+
+        super().__init__(
+            name=name,
+            color=color,
+            material_tag=material_tag,
+            stp_filename=stp_filename,
+            stl_filename=stl_filename,
+            azimuth_placement_angle=azimuth_placement_angle,
+            rotation_angle=rotation_angle,
+            hash_value=None,
+            **default_dict
+        )
+
+        self.height = height
+        self.inner_radius = inner_radius
+        self.thickness = thickness
+
+    @property
+    def height(self):
+        return self._height
+
+    @height.setter
+    def height(self, height):
+        self._height = height
+
+    @property
+    def inner_radius(self):
+        return self._inner_radius
+
+    @inner_radius.setter
+    def inner_radius(self, inner_radius):
+        self._inner_radius = inner_radius
+
+    def find_points(self):
+        """Finds the XZ points joined by straight connections that describe the
+            2D profile of the vessel shape."""
+
+        inner_points = [
+            (0, self.height / 2),
+            (self.inner_radius, self.height / 2),
+            (self.inner_radius, -self.height / 2),
+            (0, -self.height / 2),
+        ]
+
+        outer_points = [
+            (0, self.height / 2 + self.thickness),
+            (self.inner_radius + self.thickness, self.height / 2 + self.thickness),
+            (self.inner_radius + self.thickness, -(self.height / 2 + self.thickness)),
+            (0, -(self.height / 2 + self.thickness)),
+        ]
+        self.points = inner_points + outer_points[::-1]

--- a/paramak/parametric_components/vacuum_vessel.py
+++ b/paramak/parametric_components/vacuum_vessel.py
@@ -18,6 +18,11 @@ class VacuumVessel(RotateStraightShape):
             (port z position, azimuth placement angle, widht, height,
             fillet_radius)
             If no fillet_radius is specified, the port won't be filleted.
+        rotated_ports (list): list of iterables containing floats
+            describing the ports for, in order:
+            (center_point, polar_coverage_angle, polar_placement_angle,
+            rotation_angle, fillet_radius)
+            If no fillet_radius is specified, the port won't be filleted.
 
     Keyword Args:
         workplane (str): The orientation of the CadQuery workplane. Options are

--- a/paramak/parametric_components/vacuum_vessel.py
+++ b/paramak/parametric_components/vacuum_vessel.py
@@ -1,5 +1,6 @@
 from paramak import \
-    RotateStraightShape, ExtrudeCircleShape, ExtrudeStraightShape
+    RotateStraightShape, ExtrudeCircleShape, \
+    ExtrudeStraightShape, PortCutterRotated
 
 
 class VacuumVessel(RotateStraightShape):
@@ -43,6 +44,7 @@ class VacuumVessel(RotateStraightShape):
         thickness,
         circular_ports=[],
         rectangular_ports=[],
+        rotated_ports=[],
         name=None,
         color=(0.5, 0.5, 0.5),
         stp_filename="CenterColumnShieldCylinder.stp",
@@ -85,6 +87,7 @@ class VacuumVessel(RotateStraightShape):
         self.thickness = thickness
         self.circular_ports = circular_ports
         self.rectangular_ports = rectangular_ports
+        self.rotated_ports = rotated_ports
         self.add_ports()
 
     @property
@@ -159,7 +162,24 @@ class VacuumVessel(RotateStraightShape):
             # add fillet
             if len(port) == 5:
                 shape.solid = shape.solid.edges('#Z').fillet(port[4])
-            shape.export_stp("cutter.stp")
+            cutter_shapes.append(shape)
+
+        # rotated ports
+        for port in self.rotated_ports:
+            center_point, polar_coverage_angle, polar_placement_angle, \
+                rotation_angle = port[:4]
+            shape = PortCutterRotated(
+                center_point=center_point,
+                polar_coverage_angle=polar_coverage_angle,
+                polar_placement_angle=polar_placement_angle,
+                max_distance_from_center=2*(
+                    self.inner_radius+self.thickness*safety_factor),
+                rotation_angle=rotation_angle
+                )
+
+            # add fillet
+            if len(port) == 5:
+                shape.solid = shape.solid.edges().fillet(port[4])
             cutter_shapes.append(shape)
 
         self.cut = cutter_shapes

--- a/paramak/parametric_components/vacuum_vessel.py
+++ b/paramak/parametric_components/vacuum_vessel.py
@@ -13,16 +13,19 @@ class VacuumVessel(RotateStraightShape):
         circular_ports (list): list of iterables containing floats describing
             the ports for, in order:
             (z position, azimuth placement angle, radius)
+            Defaults to [].
         rectangular_ports (list): list of iterables containing floats
             describing the ports for, in order:
             (port z position, azimuth placement angle, widht, height,
             fillet_radius)
             If no fillet_radius is specified, the port won't be filleted.
+            Defaults to [].
         rotated_ports (list): list of iterables containing floats
             describing the ports for, in order:
             (center_point, polar_coverage_angle, polar_placement_angle,
             rotation_angle, fillet_radius)
             If no fillet_radius is specified, the port won't be filleted.
+            Defaults to [].
 
     Keyword Args:
         workplane (str): The orientation of the CadQuery workplane. Options are

--- a/paramak/parametric_shapes/extruded_circle_shape.py
+++ b/paramak/parametric_shapes/extruded_circle_shape.py
@@ -14,6 +14,8 @@ class ExtrudeCircleShape(Shape):
             of a single XZ coordinate which is the central point of the circle.
             For example [(10, 10)]
         radius (float): the radius of the circle
+        extrude_both (bool): if set to True, the extrusion will occur in both
+            directions. Defaults to True.
         stp_filename (str): the filename used when saving stp files as part of a
             reactor
         color (RGB or RGBA - sequences of 3 or 4 floats, respectively, each in the range 0-1):

--- a/paramak/parametric_shapes/extruded_circle_shape.py
+++ b/paramak/parametric_shapes/extruded_circle_shape.py
@@ -40,6 +40,7 @@ class ExtrudeCircleShape(Shape):
         points,
         distance,
         radius,
+        extrude_both=True,
         workplane="XZ",
         stp_filename="ExtrudeCircleShape.stp",
         stl_filename="ExtrudeCircleShape.stl",
@@ -80,6 +81,7 @@ class ExtrudeCircleShape(Shape):
         self.radius = radius
         self.distance = distance
         self.solid = solid
+        self.extrude_both = extrude_both
 
     @property
     def solid(self):
@@ -120,7 +122,7 @@ class ExtrudeCircleShape(Shape):
             cq.Workplane(self.workplane)
             .moveTo(self.points[0][0], self.points[0][1])
             .circle(self.radius)
-            .extrude(distance=-self.distance / 2.0, both=True)
+            .extrude(distance=-self.distance / 2.0, both=self.extrude_both)
         )
 
         # Checks if the azimuth_placement_angle is a list of angles

--- a/paramak/parametric_shapes/extruded_straight_shape.py
+++ b/paramak/parametric_shapes/extruded_straight_shape.py
@@ -37,6 +37,7 @@ class ExtrudeStraightShape(Shape):
         self,
         points,
         distance,
+        extrude_both=True,
         workplane="XZ",
         stp_filename="ExtrudeStraightShape.stp",
         stl_filename="ExtrudeStraightShape.stl",
@@ -76,6 +77,7 @@ class ExtrudeStraightShape(Shape):
 
         self.distance = distance
         self.solid = solid
+        self.extrude_both = extrude_both
 
     @property
     def solid(self):
@@ -108,7 +110,7 @@ class ExtrudeStraightShape(Shape):
             cq.Workplane(self.workplane)
             .polyline(self.points)
             .close()
-            .extrude(distance=-self.distance / 2.0, both=True)
+            .extrude(distance=-self.distance / 2.0, both=self.extrude_both)
         )
 
         # Checks if the azimuth_placement_angle is a list of angles

--- a/paramak/parametric_shapes/extruded_straight_shape.py
+++ b/paramak/parametric_shapes/extruded_straight_shape.py
@@ -18,6 +18,8 @@ class ExtrudeStraightShape(Shape):
         color (RGB or RGBA - sequences of 3 or 4 floats, respectively, each in the range 0-1):
             the color to use when exporting as html graphs or png images
         distance (float): the extrusion distance to use (cm units if used for neutronics)
+        extrude_both (bool): if set to True, the extrusion will occur in both
+            directions. Defaults to True.
         azimuth_placement_angle (float or iterable of floats): the angle or
             angles to use when rotating the shape on the azimuthal axis
         cut (CadQuery object): an optional CadQuery object to perform a boolean

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -1314,5 +1314,29 @@ class test_ParametricComponents(unittest.TestCase):
         assert initial_hash_value != test_shape.hash_value
 
 
+class test_VacuumVessel(unittest.TestCase):
+    def test_VacuumVessel_creation(self):
+        """creates an inner tf coil using the VacuumVessel parametric
+        component and checks that a cadquery solid is created"""
+
+        rectangular_ports = [
+            # port z position, azimuth placement angle, widht, height, fillet_radius
+            (0, 90, 0.2, 0.1),
+            (0.5, 120, 0.1, 0.3, 0.02),
+        ]
+        circular_ports = [
+            # port z position, azimuth placement angle, radius
+            (0.5, 25, 0.2),
+            (-0.5, 75, 0.1),
+            ]
+        test_shape = paramak.VacuumVessel(
+            height=2, inner_radius=1, thickness=0.2,
+            circular_ports=circular_ports,
+            rectangular_ports=rectangular_ports
+            )
+
+        assert test_shape.solid is not None
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -1320,27 +1320,9 @@ class test_VacuumVessel(unittest.TestCase):
         """creates an inner tf coil using the VacuumVessel parametric
         component and checks that a cadquery solid is created"""
 
-        rectangular_ports = [
-            # port z position, azimuth placement angle, widht, height, fillet_radius
-            (0, 90, 0.2, 0.1),
-            (0.5, 120, 0.1, 0.3, 0.02),
-        ]
-        circular_ports = [
-            # port z position, azimuth placement angle, radius
-            (0.5, 25, 0.2),
-            (-0.5, 75, 0.1),
-            ]
-        rotated_ports = [
-            # center_point, polar_coverage_angle, polar_placement_angle, rotation_angle, fillet_radius
-            ((0, 0), 10, 10, 10, 40, 0.02)
-        ]
         test_shape = paramak.VacuumVessel(
             height=2, inner_radius=1, thickness=0.2,
-            circular_ports=circular_ports,
-            rectangular_ports=rectangular_ports,
-            rotated_ports=rotated_ports
             )
-
         assert test_shape.solid is not None
 
 

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -1330,10 +1330,15 @@ class test_VacuumVessel(unittest.TestCase):
             (0.5, 25, 0.2),
             (-0.5, 75, 0.1),
             ]
+        rotated_ports = [
+            # center_point, polar_coverage_angle, polar_placement_angle, rotation_angle, fillet_radius
+            ((0, 0), 10, 10, 10, 0.02)
+        ]
         test_shape = paramak.VacuumVessel(
             height=2, inner_radius=1, thickness=0.2,
             circular_ports=circular_ports,
-            rectangular_ports=rectangular_ports
+            rectangular_ports=rectangular_ports,
+            rotated_ports=rotated_ports
             )
 
         assert test_shape.solid is not None

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -1332,7 +1332,7 @@ class test_VacuumVessel(unittest.TestCase):
             ]
         rotated_ports = [
             # center_point, polar_coverage_angle, polar_placement_angle, rotation_angle, fillet_radius
-            ((0, 0), 10, 10, 10, 0.02)
+            ((0, 0), 10, 10, 10, 40, 0.02)
         ]
         test_shape = paramak.VacuumVessel(
             height=2, inner_radius=1, thickness=0.2,


### PR DESCRIPTION
## Proposed changes

This PR solves #339 and adds a new parametric component VacuumVessel.
The vacuum vessel is cylindrical and holes for portplugs can be made in it.

The ports section can be circular or rectangular. Rectangular ports can be filleted by specifying a fillet radius. The rotated ports from #337 can also be added.

Usage:
```python
import paramak


vessel = paramak.VacuumVessel(
    height=2, inner_radius=1, thickness=0.2,
    )

vessel.export_stp('vessel.stp')

```


## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

This PR also adds a new attribute to ExtrudeCircleShape and ExtrudeStraightShape that makes the extrusion in both directions optional. Defaults is True.
