### PR TITLE
New components: RectangularPortCutter and CircularPortCutter

### DIFF
--- a/paramak/__init__.py
+++ b/paramak/__init__.py
@@ -41,7 +41,7 @@ from .parametric_components.poloidal_field_coil_case_set import PoloidalFieldCoi
 from .parametric_components.poloidal_field_coil_case_set_fc import PoloidalFieldCoilCaseSetFC
 
 from .parametric_components.poloidal_segmenter import PoloidalSegments
-from .parametric_components.port_cutters import PortCutterRotated, RectangularPortCutter
+from .parametric_components.port_cutters import PortCutterRotated, RectangularPortCutter, CircularPortCutter
 from .parametric_components.cutting_wedge import CuttingWedge
 from .parametric_components.cutting_wedge_fs import CuttingWedgeFS
 

--- a/paramak/__init__.py
+++ b/paramak/__init__.py
@@ -41,7 +41,7 @@ from .parametric_components.poloidal_field_coil_case_set import PoloidalFieldCoi
 from .parametric_components.poloidal_field_coil_case_set_fc import PoloidalFieldCoilCaseSetFC
 
 from .parametric_components.poloidal_segmenter import PoloidalSegments
-from .parametric_components.port_cutters import PortCutterRotated
+from .parametric_components.port_cutters import PortCutterRotated, RectangularPortCutter
 from .parametric_components.cutting_wedge import CuttingWedge
 from .parametric_components.cutting_wedge_fs import CuttingWedgeFS
 

--- a/paramak/parametric_components/port_cutters.py
+++ b/paramak/parametric_components/port_cutters.py
@@ -19,6 +19,8 @@ class PortCutterRotated(RotateStraightShape):
             on the polar axis. 0 degrees is the outboard equatorial point.
         max_distance_from_center (float): the maximum distance from the center
             point outwards (cm). Default 3000
+        fillet_radius (float): If not None, radius (cm) of fillets added to
+            all edges. Defaults to None.
 
     Keyword Args:
         name (str): the legend name used when exporting a html graph of the
@@ -57,6 +59,7 @@ class PortCutterRotated(RotateStraightShape):
         polar_placement_angle=0,
         max_distance_from_center=3000,
         rotation_angle=0,
+        fillet_radius=None,
         stp_filename="PortCutter.stp",
         stl_filename="PortCutter.stl",
         color=(0.5, 0.5, 0.5),
@@ -97,6 +100,9 @@ class PortCutterRotated(RotateStraightShape):
         self.polar_coverage_angle = polar_coverage_angle
         self.polar_placement_angle = polar_placement_angle
         self.max_distance_from_center = max_distance_from_center
+        self.fillet_radius = fillet_radius
+
+        self.add_fillet()
 
     @property
     def center_point(self):
@@ -163,6 +169,11 @@ class PortCutterRotated(RotateStraightShape):
             points.append(outer_point_2)
 
         self.points = points
+
+    def add_fillet(self):
+        """adds fillets to all edges"""
+        if self.fillet_radius is not None and self.fillet_radius != 0:
+            self.solid = self.solid.edges().fillet(self.fillet_radius)
 
 
 class RectangularPortCutter(ExtrudeStraightShape):

--- a/paramak/parametric_components/port_cutters.py
+++ b/paramak/parametric_components/port_cutters.py
@@ -1,7 +1,7 @@
 import math
 import cadquery as cq
 
-from paramak import RotateStraightShape
+from paramak import RotateStraightShape, ExtrudeStraightShape
 from paramak.utils import rotate, coefficients_of_line_from_points
 
 
@@ -163,3 +163,68 @@ class PortCutterRotated(RotateStraightShape):
             points.append(outer_point_2)
 
         self.points = points
+
+
+class RectangularPortCutter(ExtrudeStraightShape):
+    def __init__(
+        self,
+        z_pos,
+        height,
+        width,
+        distance,
+        fillet_radius=None,
+        stp_filename="RectangularPortCutter.stp",
+        stl_filename="RectangularPortCutter.stl",
+        color=(0.5, 0.5, 0.5),
+        azimuth_placement_angle=0,
+        name="rectangular_port_cutter",
+        material_tag="rectangular_port_cutter_mat",
+        **kwargs
+    ):
+
+        default_dict = {
+            "points": None,
+            "workplane": "XZ",
+            "solid": None,
+            "intersect": None,
+            "cut": None,
+            "union": None,
+            "tet_mesh": None,
+            "physical_groups": None,
+        }
+
+        for arg in kwargs:
+            if arg in default_dict:
+                default_dict[arg] = kwargs[arg]
+
+        super().__init__(
+            name=name,
+            color=color,
+            material_tag=material_tag,
+            stp_filename=stp_filename,
+            stl_filename=stl_filename,
+            azimuth_placement_angle=azimuth_placement_angle,
+            distance=distance,
+            hash_value=None,
+            **default_dict
+        )
+
+        self.z_pos = z_pos
+        self.height = height
+        self.width = width
+        self.fillet_radius = fillet_radius
+        self.add_fillet()
+
+    def find_points(self):
+        points = [
+            (-self.width/2, -self.height/2),
+            (self.width/2, -self.height/2),
+            (self.width/2, self.height/2),
+            (-self.width/2, self.height/2),
+        ]
+        points = [(e[0], e[1] + self.z_pos) for e in points]
+        self.points = points
+
+    def add_fillet(self):
+        if self.fillet_radius is not None and self.fillet_radius != 0:
+            self.solid = self.solid.edges('#Z').fillet(self.fillet_radius)

--- a/paramak/parametric_components/port_cutters.py
+++ b/paramak/parametric_components/port_cutters.py
@@ -1,7 +1,7 @@
 import math
 import cadquery as cq
 
-from paramak import RotateStraightShape, ExtrudeStraightShape
+from paramak import RotateStraightShape, ExtrudeStraightShape, ExtrudeCircleShape
 from paramak.utils import rotate, coefficients_of_line_from_points
 
 
@@ -198,12 +198,13 @@ class RectangularPortCutter(ExtrudeStraightShape):
                 default_dict[arg] = kwargs[arg]
 
         super().__init__(
+            extrude_both=False,
             name=name,
             color=color,
             material_tag=material_tag,
             stp_filename=stp_filename,
             stl_filename=stl_filename,
-            azimuth_placement_angle=azimuth_placement_angle,
+            azimuth_placement_angle=azimuth_placement_angle-90,
             distance=distance,
             hash_value=None,
             **default_dict
@@ -228,3 +229,54 @@ class RectangularPortCutter(ExtrudeStraightShape):
     def add_fillet(self):
         if self.fillet_radius is not None and self.fillet_radius != 0:
             self.solid = self.solid.edges('#Z').fillet(self.fillet_radius)
+
+
+class CircularPortCutter(ExtrudeCircleShape):
+    def __init__(
+        self,
+        z_pos,
+        radius,
+        distance,
+        stp_filename="CircularPortCutter.stp",
+        stl_filename="CircularPortCutter.stl",
+        color=(0.5, 0.5, 0.5),
+        azimuth_placement_angle=0,
+        name="circular_port_cutter",
+        material_tag="circular_port_cutter_mat",
+        **kwargs
+    ):
+
+        default_dict = {
+            "points": None,
+            "workplane": "XZ",
+            "solid": None,
+            "intersect": None,
+            "cut": None,
+            "union": None,
+            "tet_mesh": None,
+            "physical_groups": None,
+        }
+
+        for arg in kwargs:
+            if arg in default_dict:
+                default_dict[arg] = kwargs[arg]
+
+        super().__init__(
+            radius=radius,
+            extrude_both=False,
+            name=name,
+            color=color,
+            material_tag=material_tag,
+            stp_filename=stp_filename,
+            stl_filename=stl_filename,
+            azimuth_placement_angle=azimuth_placement_angle - 90,
+            distance=distance,
+            hash_value=None,
+            **default_dict
+        )
+
+        self.z_pos = z_pos
+        self.radius = radius
+
+    def find_points(self):
+        self.points = [(0, self.z_pos)]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="paramak",
-    version="0.0.17",
+    version="0.0.18",
     author="The Paramak Development Team",
     author_email="jonathan.shimwell@ukaea.uk",
     description="Create 3D fusion reactor CAD models based on input parameters",

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -134,7 +134,7 @@ class test_VacuumVessel(unittest.TestCase):
 
         cutter4 = paramak.CircularPortCutter(distance=3, z_pos=0.25, radius=0.1, azimuth_placement_angle=45)
 
-        cutter5 = paramak.PortCutterRotated((0, 0), azimuth_placement_angle=-90)
+        cutter5 = paramak.PortCutterRotated((0, 0), azimuth_placement_angle=-90, rotation_angle=10, fillet_radius=0.01)
         self.test_shape.cut = [cutter1, cutter2, cutter3, cutter4, cutter5]
         assert self.test_shape.solid is not None
 

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -130,11 +130,11 @@ class test_VacuumVessel(unittest.TestCase):
 
         cutter1 = paramak.RectangularPortCutter(distance=3, z_pos=0, height=0.2, width=0.4, fillet_radius=0.01)
         cutter2 = paramak.RectangularPortCutter(distance=3, z_pos=0.1, height=0.2, width=0.4, fillet_radius=0.00)
-        cutter3 = paramak.RectangularPortCutter(distance=3, z_pos=-0.1, height=0.2, width=0.4)
+        cutter3 = paramak.RectangularPortCutter(distance=3, z_pos=-0.1, height=0.2, width=0.4, physical_groups=None)
 
-        cutter4 = paramak.CircularPortCutter(distance=3, z_pos=0.25, radius=0.1, azimuth_placement_angle=45)
+        cutter4 = paramak.CircularPortCutter(distance=3, z_pos=0.25, radius=0.1, azimuth_placement_angle=45, physical_groups=None)
 
-        cutter5 = paramak.PortCutterRotated((0, 0), azimuth_placement_angle=-90, rotation_angle=10, fillet_radius=0.01)
+        cutter5 = paramak.PortCutterRotated((0, 0), azimuth_placement_angle=-90, rotation_angle=10, fillet_radius=0.01, physical_groups=None)
         self.test_shape.cut = [cutter1, cutter2, cutter3, cutter4, cutter5]
         assert self.test_shape.solid is not None
 

--- a/tests/test_ParametricComponents.py
+++ b/tests/test_ParametricComponents.py
@@ -114,14 +114,29 @@ class test_ParametricComponents(unittest.TestCase):
 
 
 class test_VacuumVessel(unittest.TestCase):
+    test_shape = paramak.VacuumVessel(
+        height=2, inner_radius=1, thickness=0.2,
+    )
+
     def test_VacuumVessel_creation(self):
-        """creates an inner tf coil using the VacuumVessel parametric
+        """creates a shape using the VacuumVessel parametric
         component and checks that a cadquery solid is created"""
 
-        test_shape = paramak.VacuumVessel(
-            height=2, inner_radius=1, thickness=0.2,
-        )
-        assert test_shape.solid is not None
+        assert self.test_shape.solid is not None
+
+    def test_VacuumVessel_ports(self):
+        """Creates a vacuum vessel cuts ports in it and cheks that a caquery
+        solid is created"""
+
+        cutter1 = paramak.RectangularPortCutter(distance=3, z_pos=0, height=0.2, width=0.4, fillet_radius=0.01)
+        cutter2 = paramak.RectangularPortCutter(distance=3, z_pos=0.1, height=0.2, width=0.4, fillet_radius=0.00)
+        cutter3 = paramak.RectangularPortCutter(distance=3, z_pos=-0.1, height=0.2, width=0.4)
+
+        cutter4 = paramak.CircularPortCutter(distance=3, z_pos=0.25, radius=0.1, azimuth_placement_angle=45)
+
+        cutter5 = paramak.PortCutterRotated((0, 0), azimuth_placement_angle=-90)
+        self.test_shape.cut = [cutter1, cutter2, cutter3, cutter4, cutter5]
+        assert self.test_shape.solid is not None
 
 
 if __name__ == "__main__":

--- a/tests/test_parametric_components/test_PortCutterRotated.py
+++ b/tests/test_parametric_components/test_PortCutterRotated.py
@@ -144,3 +144,15 @@ class test_PortCutterRotated(unittest.TestCase):
         )
 
         assert large_ports.volume > small_ports.volume
+
+    def test_PortCutterRotated_outerpoint_negative(self):
+        """Tests that when the outerpoints x pos is negative no error is
+        raised"""
+        shape = paramak.PortCutterRotated(
+            center_point=(1, 1),
+            polar_coverage_angle=181,
+            polar_placement_angle=0,
+            rotation_angle=10,
+
+        )
+        assert shape.solid is not None


### PR DESCRIPTION
## Proposed changes

This issue solves #347 

Usage:

```python
from paramak import RectangularPortCutter, CircularPortCutter, VacuumVessel, PortCutterRotated


cutter1 = RectangularPortCutter(distance=3, z_pos=0, height=0.2, width=0.4, fillet_radius=0.01)

cutter2 = CircularPortCutter(distance=3, z_pos=0.25, radius=0.1, azimuth_placement_angle=45)

cutter5 =PortCutterRotated((0, 0), azimuth_placement_angle=-90, rotation_angle=10, fillet_radius=0.05)

vessel = VacuumVessel(1, 1, 0.1)
vessel.cut = [cutter1, cutter2, cutter5]
vessel.export_stl('vessel.stl')

```

This PR also adds the possibility to fillet the PortCutterRotated shape.


## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

