### PR TITLE
Major refactoring of the parametric shapes and parametric components default parameters

### DIFF
--- a/paramak/parametric_components/tokamak_plasma.py
+++ b/paramak/parametric_components/tokamak_plasma.py
@@ -73,37 +73,15 @@ class Plasma(RotateSplineShape):
         material_tag="DT_plasma",
         stp_filename="plasma.stp",
         stl_filename="plasma.stl",
-        color=(0.5, 0.5, 0.5),
-        rotation_angle=360,
-        azimuth_placement_angle=0,
         **kwargs
     ):
 
-        default_dict = {
-            "points": None,
-            "workplane": "XZ",
-            "solid": None,
-            "intersect": None,
-            "cut": None,
-            "union": None,
-            "tet_mesh": None,
-            "physical_groups": None,
-        }
-
-        for arg in kwargs:
-            if arg in default_dict:
-                default_dict[arg] = kwargs[arg]
-
         super().__init__(
             name=name,
-            color=color,
             material_tag=material_tag,
             stp_filename=stp_filename,
             stl_filename=stl_filename,
-            azimuth_placement_angle=azimuth_placement_angle,
-            rotation_angle=rotation_angle,
-            hash_value=None,
-            **default_dict
+            **kwargs
         )
 
         # properties needed for plasma shapes

--- a/paramak/parametric_components/tokamak_plasma_from_points.py
+++ b/paramak/parametric_components/tokamak_plasma_from_points.py
@@ -11,35 +11,17 @@ class PlasmaFromPoints(Plasma):
             plasma (cm).
         inner_equatorial_x_point (float): the x value of the inner equatorial of the
             plasma (cm).
-        heigh_point (tuple of 2 floats): the (x,z) coordinate values of the top of the
+        high_point (tuple of 2 floats): the (x,z) coordinate values of the top of the
             plasma (cm).
+        Others: see paramak.Plasma() arguments.
 
     Keyword Args:
-        name (str): the legend name used when exporting a html graph of the
-            shape.
-        color (sequences of 3 or 4 floats each in the range 0-1): the color to
-            use when exporting as html graphs or png images.
-        material_tag (str): The material name to use when exporting the
-            neutronics description.
-        stp_filename (str): The filename used when saving stp files as part of a
-            reactor.
-        azimuth_placement_angle (float or iterable of floats): The angle or
-            angles to use when rotating the shape on the azimuthal axis.
-        rotation_angle (float): The rotation angle to use when revolving the
-            solid (degrees).
-        workplane (str): The orientation of the CadQuery workplane. Options are
-            XY, YZ or XZ.
-        intersect (CadQuery object): An optional CadQuery object to perform a
-            boolean intersect with this object.
-        cut (CadQuery object): An optional CadQuery object to perform a boolean
-            cut with this object.
-        union (CadQuery object): An optional CadQuery object to perform a
-            boolean union with this object.
-        tet_mesh (str): Insert description.
-        physical_groups (type): Insert description.
+        Others: see paramak.Plasma() attributes.
 
     Returns:
-        a paramak shape object: A shape object that has generic functionality with points determined by the find_points() method. A CadQuery solid of the shape can be called via shape.solid.
+        a paramak shape object: A shape object that has generic functionality
+            with points determined by the find_points() method. A CadQuery
+            solid of the shape can be called via shape.solid.
     """
 
     def __init__(
@@ -47,31 +29,8 @@ class PlasmaFromPoints(Plasma):
         outer_equatorial_x_point,
         inner_equatorial_x_point,
         high_point,
-        x_point_shift=0.1,
-        configuration="non-null",
-        name="plasma",
-        material_tag="DT_plasma",
-        num_points=50,
-        stp_filename="plasma.stp",
-        color=(0.5, 0.5, 0.5),
-        rotation_angle=360,
-        azimuth_placement_angle=0,
         **kwargs
     ):
-        default_dict = {
-            "points": None,
-            "workplane": "XZ",
-            "solid": None,
-            "intersect": None,
-            "cut": None,
-            "union": None,
-            "tet_mesh": None,
-            "physical_groups": None,
-        }
-
-        for arg in kwargs:
-            if arg in default_dict:
-                default_dict[arg] = kwargs[arg]
 
         minor_radius = (outer_equatorial_x_point -
                         inner_equatorial_x_point) / 2.0
@@ -80,22 +39,11 @@ class PlasmaFromPoints(Plasma):
         triangularity = (major_radius - high_point[0]) / minor_radius
 
         super().__init__(
-            name=name,
-            material_tag=material_tag,
             elongation=elongation,
             major_radius=major_radius,
             minor_radius=minor_radius,
             triangularity=triangularity,
-            vertical_displacement=0,
-            num_points=50,
-            configuration=configuration,
-            x_point_shift=x_point_shift,
-            stp_filename="plasma.stp",
-            color=color,
-            rotation_angle=rotation_angle,
-            azimuth_placement_angle=azimuth_placement_angle,
-            hash_value=None,
-            **default_dict
+            **kwargs
         )
 
         self.outer_equatorial_x_point = outer_equatorial_x_point

--- a/paramak/parametric_components/tokamak_plasma_plasmaboundaries.py
+++ b/paramak/parametric_components/tokamak_plasma_plasmaboundaries.py
@@ -14,10 +14,10 @@ class PlasmaBoundaries(Plasma):
                 Defaults to 0.05.
             elongation (float, optional): the elongation of the plasma.
                 Defaults to 2.0.
-            major_radius (float, optional): the major radius of the plasma (cm).
-                Defaults to 450.
-            minor_radius (float, optional): the minor radius of the plasma (cm).
-                Defaults to 150.
+            major_radius (float, optional): the major radius of the plasma
+                (cm). Defaults to 450.
+            minor_radius (float, optional): the minor radius of the plasma
+                (cm). Defaults to 150.
             triangularity (float, optional): the triangularity of the plasma.
                 Defaults to 0.55.
             vertical_displacement (float, optional): the vertical_displacement
@@ -123,9 +123,10 @@ class PlasmaBoundaries(Plasma):
         lower_point_y = (
             -self.elongation * self.minor_radius + self.vertical_displacement
         )
-        upper_point_y = self.elongation * self.minor_radius + self.vertical_displacement
+        upper_point_y = self.elongation * self.minor_radius + \
+            self.vertical_displacement
         # else use x points
-        if self.configuration == "single-null" or self.configuration == "double-null":
+        if self.configuration in ["single-null", "double-null"]:
             lower_point_y = lower_x_point[1]
             if self.configuration == "double-null":
                 upper_point_y = upper_x_point[1]

--- a/paramak/parametric_components/tokamak_plasma_plasmaboundaries.py
+++ b/paramak/parametric_components/tokamak_plasma_plasmaboundaries.py
@@ -8,7 +8,7 @@ class PlasmaBoundaries(Plasma):
     """Creates a double null tokamak plasma shape that is controlled
        by 5 shaping parameters using the plasmaboundaries package to calculate
        points. For more details see:
-       http://github.com/RemiTheWarrior/plasma-boundaries
+       http://github.com/RemDelaporteMathurin/plasma-boundaries
         Args:
             A (float, optional): plasma parameter see plasmaboundaries doc.
                 Defaults to 0.05.
@@ -22,19 +22,16 @@ class PlasmaBoundaries(Plasma):
                 Defaults to 0.55.
             vertical_displacement (float, optional): the vertical_displacement
                 of the plasma (cm). Defaults to 0.
-            num_points (int, optional): number of points to described the
-                shape. Defaults to 50.
             configuration (str, optional): plasma configuration
                 ("non-null", "single-null", "double-null").
                 Defaults to "non-null".
             x_point_shift (float, optional): Shift parameters for locating the
                 X points in [0, 1]. Defaults to 0.1.
-            Others: see paramak.RotateSplineShape() arguments.
+            Others: see paramak.Plasma() arguments.
 
         Attributes:
             A: plasma parameter see plasmaboundaries doc.
-            Others: see paramak.RotateSplineShape() and paramak.Plasma()
-                attributes.
+            Others: see paramak.Plasma() attributes.
     """
 
     def __init__(
@@ -45,53 +42,18 @@ class PlasmaBoundaries(Plasma):
         minor_radius=150,
         triangularity=0.55,
         vertical_displacement=0,
-        num_points=50,
         configuration="non-null",
         x_point_shift=0.1,
-        name="plasma",
-        material_tag="DT_plasma",
-        stp_filename="plasma.stp",
-        color=(0.5, 0.5, 0.5),
-        rotation_angle=360,
-        azimuth_placement_angle=0,
         **kwargs
     ):
 
-        default_dict = {
-            "points": None,
-            "workplane": "XZ",
-            "solid": None,
-            "intersect": None,
-            "cut": None,
-            "tet_mesh": None,
-            "physical_groups": None,
-        }
-
-        for arg in kwargs:
-            if arg in default_dict:
-                default_dict[arg] = kwargs[arg]
-
         super().__init__(
-            name=name,
-            color=color,
-            material_tag=material_tag,
-            stp_filename=stp_filename,
-            azimuth_placement_angle=azimuth_placement_angle,
-            rotation_angle=rotation_angle,
-            hash_value=None,
-            **default_dict
+            **kwargs
         )
 
         # properties needed for plasma shapes
         self.A = A
-        self.elongation = elongation
-        self.major_radius = major_radius
-        self.minor_radius = minor_radius
-        self.triangularity = triangularity
         self.vertical_displacement = vertical_displacement
-        self.num_points = num_points
-        self.configuration = configuration
-        self.x_point_shift = x_point_shift
 
         self.outer_equatorial_point = None
         self.inner_equatorial_point = None

--- a/paramak/parametric_components/tokamak_plasma_plasmaboundaries.py
+++ b/paramak/parametric_components/tokamak_plasma_plasmaboundaries.py
@@ -48,6 +48,13 @@ class PlasmaBoundaries(Plasma):
     ):
 
         super().__init__(
+            elongation=elongation,
+            major_radius=major_radius,
+            minor_radius=minor_radius,
+            triangularity=triangularity,
+            vertical_displacement=vertical_displacement,
+            configuration=configuration,
+            x_point_shift=x_point_shift,
             **kwargs
         )
 

--- a/paramak/parametric_shapes/extruded_circle_shape.py
+++ b/paramak/parametric_shapes/extruded_circle_shape.py
@@ -39,45 +39,19 @@ class ExtrudeCircleShape(Shape):
 
     def __init__(
         self,
-        points,
         distance,
         radius,
         extrude_both=True,
-        workplane="XZ",
         stp_filename="ExtrudeCircleShape.stp",
         stl_filename="ExtrudeCircleShape.stl",
         solid=None,
-        color=(0.5, 0.5, 0.5),
-        azimuth_placement_angle=0,
-        cut=None,
-        intersect=None,
-        union=None,
-        material_tag=None,
-        name=None,
         **kwargs
     ):
 
-        default_dict = {"tet_mesh": None,
-                        "physical_groups": None,
-                        "hash_value": None}
-
-        for arg in kwargs:
-            if arg in default_dict:
-                default_dict[arg] = kwargs[arg]
-
         super().__init__(
-            points=points,
-            name=name,
-            color=color,
-            material_tag=material_tag,
             stp_filename=stp_filename,
             stl_filename=stl_filename,
-            azimuth_placement_angle=azimuth_placement_angle,
-            workplane=workplane,
-            cut=cut,
-            intersect=intersect,
-            union=union,
-            **default_dict
+            **kwargs
         )
 
         self.radius = radius

--- a/paramak/parametric_shapes/extruded_circle_shape.py
+++ b/paramak/parametric_shapes/extruded_circle_shape.py
@@ -10,28 +10,10 @@ class ExtrudeCircleShape(Shape):
     """Extrudes a circular 3d CadQuery solid from a central point and a radius
 
     Args:
-        points (tuple containing X (float), Z (float) value for the central point): a list
-            of a single XZ coordinate which is the central point of the circle.
-            For example [(10, 10)]
-        radius (float): the radius of the circle
+        distance (float): the extrusion distance to use (cm units if used for neutronics)
         extrude_both (bool): if set to True, the extrusion will occur in both
             directions. Defaults to True.
-        stp_filename (str): the filename used when saving stp files as part of a
-            reactor
-        color (RGB or RGBA - sequences of 3 or 4 floats, respectively, each in the range 0-1):
-            the color to use when exporting as html graphs or png images
-        distance (float): the extrusion distance to use (cm units if used for
-            neutronics)
-        azimuth_placement_angle (float or iterable of floats): the angle or
-            angles to use when rotating the shape on the azimuthal axis
-        cut (CadQuery object): an optional CadQuery object to perform a boolean
-            cut with this object
-        material_tag (str): the material name to use when exporting the
-            neutronics descrption
-        name (str): the legend name used when exporting a html graph of the
-            shape
-        workplane (str): the orientation of the CadQuery workplane. Options are
-            XY, YZ, XZ.
+        Others: see paramak.Shape() arguments.
 
     Returns:
         a paramak shape object: a Shape object that has generic functionality

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -10,26 +10,10 @@ class ExtrudeMixedShape(Shape):
     and spline connections
 
     Args:
-        points (list of tuples each containing X (float), Z (float), connection (str)):
-            a list of XZ coordinates and connection types. The connection types
-            are either 'straight', 'spline' or 'circle'. For example [(2., 1.,
-            'straight'), (2.,2.,'straight'), (1.,2.,'spline'), (1.,1.,'spline'),
-            (2.,1.,'spline')].
-        stp_filename (str): the filename used when saving stp files as part of a
-            reactor
-        color (RGB or RGBA - sequences of 3 or 4 floats, respectively, each in the range 0-1):
-            the color to use when exporting as html graphs or png images
         distance (float): the extrusion distance to use (cm units if used for neutronics)
-        azimuth_placement_angle (float or iterable of floats): the angle or
-            angles to use when rotating the shape on the azimuthal axis
-        cut (CadQuery object): an optional CadQuery object to perform a boolean
-            cut with this object
-        material_tag (str): the material name to use when exporting the
-            neutronics descrption
-        name (str): the legend name used when exporting a html graph of the
-            shape
-        workplane (str): the orientation of the CadQuery workplane. Options are
-            XY, YZ, XZ.
+        extrude_both (bool): if set to True, the extrusion will occur in both
+            directions. Defaults to True.
+        Others: see paramak.Shape() arguments.
 
     Returns:
         a paramak shape object: a Shape object that has generic functionality

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -37,43 +37,17 @@ class ExtrudeMixedShape(Shape):
 
     def __init__(
         self,
-        points,
         distance,
-        workplane="XZ",
         stp_filename="ExtrudeMixedShape.stp",
         stl_filename="ExtrudeMixedShape.stl",
         solid=None,
-        color=(0.5, 0.5, 0.5),
-        azimuth_placement_angle=0,
-        cut=None,
-        intersect=None,
-        union=None,
-        material_tag=None,
-        name=None,
         **kwargs
     ):
 
-        default_dict = {"tet_mesh": None,
-                        "physical_groups": None,
-                        "hash_value": None}
-
-        for arg in kwargs:
-            if arg in default_dict:
-                default_dict[arg] = kwargs[arg]
-
         super().__init__(
-            points=points,
-            name=name,
-            color=color,
-            material_tag=material_tag,
             stp_filename=stp_filename,
             stl_filename=stl_filename,
-            azimuth_placement_angle=azimuth_placement_angle,
-            workplane=workplane,
-            cut=cut,
-            intersect=intersect,
-            union=union,
-            **default_dict
+            **kwargs
         )
 
         self.distance = distance

--- a/paramak/parametric_shapes/extruded_spline_shape.py
+++ b/paramak/parametric_shapes/extruded_spline_shape.py
@@ -9,25 +9,10 @@ class ExtrudeSplineShape(Shape):
     """Extrudes a 3d CadQuery solid from points connected with spline connections
 
     Args:
-        points (list of tuples each containing X (float), Z (float)): a list of
-            XZ coordinates connected by spline connections. For example
-            [(2.,1.), (2.,2.), (1.,2.), (1.,1.), (2.,1.)]
-        stp_filename (str): the filename used when saving stp files as part of a
-            reactor
-        color (RGB or RGBA - sequences of 3 or 4 floats, respectively, each in the range 0-1):
-            the color to use when exporting as html graphs or png images
-        distance (float): the extrusion distance to use (cm units if used for
-            neutronics)
-        azimuth_placement_angle (float or iterable of floats): the angle or
-            angles to use when rotating the shape on the azimuthal axis
-        cut (CadQuery object): an optional CadQuery object to perform a boolean
-            cut with this object
-        material_tag (str): the material name to use when exporting the
-            neutronics descrption
-        name (str): the legend name used when exporting a html graph of the
-            shape
-        workplane (str): the orientation of the CadQuery workplane. Options are
-            XY, YZ, XZ.
+        distance (float): the extrusion distance to use (cm units if used for neutronics)
+        extrude_both (bool): if set to True, the extrusion will occur in both
+            directions. Defaults to True.
+        Others: see paramak.Shape() arguments.
 
     Returns:
         a paramak shape object: a Shape object that has generic functionality

--- a/paramak/parametric_shapes/extruded_spline_shape.py
+++ b/paramak/parametric_shapes/extruded_spline_shape.py
@@ -35,43 +35,17 @@ class ExtrudeSplineShape(Shape):
 
     def __init__(
         self,
-        points,
         distance,
-        workplane="XZ",
         stp_filename="ExtrudeSplineShape.stp",
         stl_filename="ExtrudeSplineShape.stl",
         solid=None,
-        color=(0.5, 0.5, 0.5),
-        azimuth_placement_angle=0,
-        cut=None,
-        intersect=None,
-        union=None,
-        material_tag=None,
-        name=None,
         **kwargs
     ):
 
-        default_dict = {"tet_mesh": None,
-                        "physical_groups": None,
-                        "hash_value": None}
-
-        for arg in kwargs:
-            if arg in default_dict:
-                default_dict[arg] = kwargs[arg]
-
         super().__init__(
-            points=points,
-            name=name,
-            color=color,
-            material_tag=material_tag,
             stp_filename=stp_filename,
             stl_filename=stl_filename,
-            azimuth_placement_angle=azimuth_placement_angle,
-            workplane=workplane,
-            cut=cut,
-            intersect=intersect,
-            union=union,
-            **default_dict
+            **kwargs
         )
 
         self.distance = distance

--- a/paramak/parametric_shapes/extruded_straight_shape.py
+++ b/paramak/parametric_shapes/extruded_straight_shape.py
@@ -37,44 +37,18 @@ class ExtrudeStraightShape(Shape):
 
     def __init__(
         self,
-        points,
         distance,
         extrude_both=True,
-        workplane="XZ",
         stp_filename="ExtrudeStraightShape.stp",
         stl_filename="ExtrudeStraightShape.stl",
         solid=None,
-        color=(0.5, 0.5, 0.5),
-        azimuth_placement_angle=0,
-        cut=None,
-        intersect=None,
-        union=None,
-        material_tag=None,
-        name=None,
         **kwargs
     ):
 
-        default_dict = {"tet_mesh": None,
-                        "physical_groups": None,
-                        "hash_value": None}
-
-        for arg in kwargs:
-            if arg in default_dict:
-                default_dict[arg] = kwargs[arg]
-
         super().__init__(
-            points=points,
-            name=name,
-            color=color,
-            material_tag=material_tag,
             stp_filename=stp_filename,
             stl_filename=stl_filename,
-            azimuth_placement_angle=azimuth_placement_angle,
-            workplane=workplane,
-            cut=cut,
-            intersect=intersect,
-            union=union,
-            **default_dict
+            **kwargs
         )
 
         self.distance = distance

--- a/paramak/parametric_shapes/extruded_straight_shape.py
+++ b/paramak/parametric_shapes/extruded_straight_shape.py
@@ -10,26 +10,10 @@ class ExtrudeStraightShape(Shape):
     """Extrudes a 3d CadQuery solid from points connected with straight lines
 
     Args:
-        points (a list of tuples each containing X (float), Z (float)): a list
-            of XZ coordinates connected by straight connections. For example
-            [(2.,1.), (2.,2.), (1.,2.), (1.,1.), (2.,1.)]
-        stp_filename (str): the filename used when saving stp files as part of a
-            reactor
-        color (RGB or RGBA - sequences of 3 or 4 floats, respectively, each in the range 0-1):
-            the color to use when exporting as html graphs or png images
         distance (float): the extrusion distance to use (cm units if used for neutronics)
         extrude_both (bool): if set to True, the extrusion will occur in both
             directions. Defaults to True.
-        azimuth_placement_angle (float or iterable of floats): the angle or
-            angles to use when rotating the shape on the azimuthal axis
-        cut (CadQuery object): an optional CadQuery object to perform a boolean
-            cut with this object
-        material_tag (str): the material name to use when exporting the
-            neutronics descrption
-        name (str): the legend name used when exporting a html graph of the
-            shape
-        workplane (str): the orientation of the CadQuery workplane. Options are
-            XY, YZ, XZ.
+        Others: see paramak.Shape() arguments.
 
     Returns:
         a paramak shape object: a Shape object that has generic functionality

--- a/paramak/parametric_shapes/rotate_circle_shape.py
+++ b/paramak/parametric_shapes/rotate_circle_shape.py
@@ -34,44 +34,18 @@ class RotateCircleShape(Shape):
 
     def __init__(
         self,
-        points,
         radius,
-        workplane="XZ",
+        rotation_angle=360,
         stp_filename="RotateCircleShape.stp",
         stl_filename="RotateCircleShape.stl",
         solid=None,
-        color=(0.5, 0.5, 0.5),
-        azimuth_placement_angle=0,
-        rotation_angle=360,
-        cut=None,
-        intersect=None,
-        union=None,
-        material_tag=None,
-        name=None,
         **kwargs
     ):
 
-        default_dict = {"tet_mesh": None,
-                        "physical_groups": None,
-                        "hash_value": None}
-
-        for arg in kwargs:
-            if arg in default_dict:
-                default_dict[arg] = kwargs[arg]
-
         super().__init__(
-            points=points,
-            name=name,
-            color=color,
-            material_tag=material_tag,
             stp_filename=stp_filename,
             stl_filename=stl_filename,
-            azimuth_placement_angle=azimuth_placement_angle,
-            workplane=workplane,
-            cut=cut,
-            intersect=intersect,
-            union=union,
-            **default_dict
+            **kwargs
         )
         self.radius = radius
         self.rotation_angle = rotation_angle

--- a/paramak/parametric_shapes/rotate_circle_shape.py
+++ b/paramak/parametric_shapes/rotate_circle_shape.py
@@ -9,24 +9,9 @@ class RotateCircleShape(Shape):
     """Rotates a circular 3d CadQuery solid from a central point and a radius
 
     Args:
-        points (a list of tuples each containing X (float), Z (float)): A list
-            of a single XZ coordinate which is the central point of the circle.
-            For example, [(10, 10)].
-        radius (float): The radius of the circle.
-        name (str): The legend name used when exporting a html graph of the
-            shape.
-        color (RGB or RGBA - sequences of 3 or 4 floats, respectively, each in the range 0-1):
-            The color to use when exporting as html graphs or png images.
-        material_tag (str): The material name to use when exporting the
-            neutronics description.
-        stp_filname (str): The filename used when saving stp files as part of a
-            reactor.
-        azimuth_placement_angle (float or iterable of floats): The angle or
-            angles to use when rotating the shape on the azimuthal axis.
-        rotation_angle (float): The rotation angle to use when revolving the
+        rotation_angle (float): The rotation_angle to use when revolving the
             solid (degrees).
-        cut (CadQuery object): An optional CadQuery object to perform a boolean
-            cut with this object.
+        Others: see paramak.Shape() arguments.
 
     Returns:
         a paramak shape object: a Shape object that has generic functionality

--- a/paramak/parametric_shapes/rotate_mixed_shape.py
+++ b/paramak/parametric_shapes/rotate_mixed_shape.py
@@ -35,43 +35,17 @@ class RotateMixedShape(Shape):
 
     def __init__(
         self,
-        points,
-        workplane="XZ",
-        name=None,
-        color=(0.5, 0.5, 0.5),
-        material_tag=None,
         stp_filename="RotateMixedShape.stp",
         stl_filename="RotateMixedShape.stl",
-        azimuth_placement_angle=0,
-        solid=None,
         rotation_angle=360,
-        cut=None,
-        intersect=None,
-        union=None,
+        solid=None,
         **kwargs
     ):
 
-        default_dict = {"tet_mesh": None,
-                        "physical_groups": None,
-                        "hash_value": None}
-
-        for arg in kwargs:
-            if arg in default_dict:
-                default_dict[arg] = kwargs[arg]
-
         super().__init__(
-            points=points,
-            name=name,
-            color=color,
-            material_tag=material_tag,
             stp_filename=stp_filename,
             stl_filename=stl_filename,
-            azimuth_placement_angle=azimuth_placement_angle,
-            workplane=workplane,
-            cut=cut,
-            intersect=intersect,
-            union=union,
-            **default_dict
+            **kwargs
         )
         self.rotation_angle = rotation_angle
         self.solid = solid

--- a/paramak/parametric_shapes/rotate_mixed_shape.py
+++ b/paramak/parametric_shapes/rotate_mixed_shape.py
@@ -10,24 +10,9 @@ class RotateMixedShape(Shape):
     lines and splines
 
     Args:
-        points (list of tuples each containing X (float), Z (float), connection):
-            A list of XZ coordinates and connection types. The connection types
-            are either 'straight', 'spline' or 'circle'. For example [(2., 1.,
-            'straight'), (2., 2., 'straight'), (1., 2., 'spline'), (1., 1.,
-            'spline')].
-        name (str): The legend name used when exporting a html graph of the
-            shape.
-        color (RGB or RGBA - sequences of 3 or 4 floats, respectively, each in the range 0-1):
-            The color to use when exporting as html graphs or png images.
-        material_tag (str): The material name to use when exporting the
-            neutronics description.
-        stp_filename (str): The filename used when saving stp files as part of a
-            reactor
-        azimuth_placement_angle (float or iterable of floats): the angle or
-            angles to use when rotating the shape on the azimuthal axis.
-        rotation_angle (float): The rotation_angle to use when revoling the
+        rotation_angle (float): The rotation_angle to use when revolving the
             solid (degrees).
-        cut (CadQuery object): An optional cadquery object to perform a boolean cut with this object.
+        Others: see paramak.Shape() arguments.
 
     Returns:
         a paramak shape object: a Shape object that has generic functionality

--- a/paramak/parametric_shapes/rotate_spline_shape.py
+++ b/paramak/parametric_shapes/rotate_spline_shape.py
@@ -34,43 +34,18 @@ class RotateSplineShape(Shape):
 
     def __init__(
         self,
-        points,
         workplane="XZ",
-        name=None,
-        color=(0.5, 0.5, 0.5),
-        material_tag=None,
         stp_filename="RotateSplineShape.stp",
         stl_filename="RotateSplineShape.stl",
-        azimuth_placement_angle=0,
         solid=None,
         rotation_angle=360,
-        cut=None,
-        intersect=None,
-        union=None,
         **kwargs
     ):
 
-        default_dict = {"tet_mesh": None,
-                        "physical_groups": None,
-                        "hash_value": None}
-
-        for arg in kwargs:
-            if arg in default_dict:
-                default_dict[arg] = kwargs[arg]
-
         super().__init__(
-            points=points,
-            name=name,
-            color=color,
-            material_tag=material_tag,
             stp_filename=stp_filename,
             stl_filename=stl_filename,
-            azimuth_placement_angle=azimuth_placement_angle,
-            workplane=workplane,
-            cut=cut,
-            intersect=intersect,
-            union=union,
-            **default_dict
+            **kwargs
         )
 
         self.rotation_angle = rotation_angle

--- a/paramak/parametric_shapes/rotate_spline_shape.py
+++ b/paramak/parametric_shapes/rotate_spline_shape.py
@@ -10,23 +10,9 @@ class RotateSplineShape(Shape):
     """Rotates a 3d CadQuery solid from points connected with splines
 
     Args:
-        points (list of tuples each containing X (float), Z (float)): A list of
-            XZ coordinates connected by spline connections. For example [(2.,
-            1.), (2., 2.), (1., 2.), (1., 1.)].
-        name (str): The legend name used when exporting a html graph of the
-            shape.
-        color (RGB or RGBA - sequences of 3 or 4 floats, respectively, each in the range 0-1):
-            The color to use when exporting as html graphs or png images.
-        material_tag (str): The material name to use when exporting the
-            neutronics description.
-        stp_filename (str): The filename used when saving stp files as part of a
-            reactor.
-        azimuth_placement_angle (float or iterable of floats): the angle or
-            angles to use when rotating the shape on the azimuthal axis.
-        rotation_angle (float): The rotation_angle to use when revoling the
+        rotation_angle (float): The rotation_angle to use when revolving the
             solid (degrees).
-        cut (CadQuery object): An optional cadquery object to perform a boolean
-            cut with this object.
+        Others: see paramak.Shape() arguments.
 
     Returns:
         a paramak shape object: a Shape object that has generic functionality

--- a/paramak/parametric_shapes/rotate_straight_shape.py
+++ b/paramak/parametric_shapes/rotate_straight_shape.py
@@ -34,43 +34,17 @@ class RotateStraightShape(Shape):
 
     def __init__(
         self,
-        points,
-        workplane="XZ",
-        name=None,
-        color=(0.5, 0.5, 0.5),
-        material_tag=None,
         stp_filename="RotateStraightShape.stp",
         stl_filename="RotateStraightShape.stl",
-        azimuth_placement_angle=0,
         solid=None,
         rotation_angle=360,
-        cut=None,
-        intersect=None,
-        union=None,
         **kwargs
     ):
 
-        default_dict = {"tet_mesh": None,
-                        "physical_groups": None,
-                        "hash_value": None}
-
-        for arg in kwargs:
-            if arg in default_dict:
-                default_dict[arg] = kwargs[arg]
-
         super().__init__(
-            points=points,
-            name=name,
-            color=color,
-            material_tag=material_tag,
             stp_filename=stp_filename,
             stl_filename=stl_filename,
-            azimuth_placement_angle=azimuth_placement_angle,
-            workplane=workplane,
-            cut=cut,
-            intersect=intersect,
-            union=union,
-            **default_dict
+            **kwargs
         )
 
         self.rotation_angle = rotation_angle

--- a/paramak/parametric_shapes/rotate_straight_shape.py
+++ b/paramak/parametric_shapes/rotate_straight_shape.py
@@ -10,23 +10,9 @@ class RotateStraightShape(Shape):
     connections
 
     Args:
-        points (list of tuples each containing X (float), Z (float)): A list of
-            XZ coordinates connected by straight connections. For example
-            [(2., 1.), (2., 2.), (1., 2.), (1., 1.)].
-        name (str): The legend name used when exporting a html graph of the
-            shape.
-        color (RGB or RGBA - sequences of 3 or 4 floats, respectively, each in the range 0-1):
-            The color to use when exporting as html graphs or png images.
-        material_tag (str): The material name to use when exporting the
-            neutronics description.
-        stp_filename (str): The filename used when saving stp files as part of a
-            reactor.
-        azimuth_placement_angle (float or iterable of floats): The angle or
-            angles to use when rotating the shape on the azimuthal axis.
         rotation_angle (float): The rotation angle to use when revolving the
             solid (degrees).
-        cut (CadQuery object): An optional cadquery object to perform a boolean
-            cut with this object.
+        Others: see paramak.Shape() arguments.
 
     Returns:
         a paramak shape object: a Shape object that has generic functionality


### PR DESCRIPTION
## Proposed changes

@billingsley-john proposed in #115 a way of simplifying classes initialisation with a default dict. 
However, since most of these parameters are already defaulted at the Shape level (which is inherited by all classes in paramak), this `default_dict` can be replaced by the `kwargs`.

This PR shows how to perform this refactoring and includes it for all the parametric shapes (eg, `RotateStraightShape`, `ExtrudeSplineShape`, etc.) and for the shapes inherited from `Plasma` (`PlasmaFromPoints`, `PlasmaBoundaries`).

In the future, this should be done for all components which would:
- strongly reduce code repetition
- increase readibility
- simplify the docstrings



## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

@billingsley-john @Shimwell what are your thoughts ?
this could be a nice "Good first issue".
