### PR TITLE
Fix inboard firstwall fccs

### DIFF
--- a/paramak/parametric_components/inboard_firstwall_fccs.py
+++ b/paramak/parametric_components/inboard_firstwall_fccs.py
@@ -151,7 +151,7 @@ class InboardFirstwallFCCS(RotateMixedShape):
             )
 
         firstwall.rotation_angle = self.rotation_angle
-        points = firstwall.points[:-1]
+        points = firstwall.points[:-1]  # remove last point
         # if no connection type is given, add the connection types to points
         if connection_type is not None:
             points = [[*p, connection_type] for p in points]

--- a/paramak/parametric_components/inboard_firstwall_fccs.py
+++ b/paramak/parametric_components/inboard_firstwall_fccs.py
@@ -39,6 +39,7 @@ class InboardFirstwallFCCS(RotateMixedShape):
 
         self.central_column_shield = central_column_shield
         self.thickness = thickness
+        self.cut = self.central_column_shield
 
     @property
     def thickness(self):
@@ -56,30 +57,15 @@ class InboardFirstwallFCCS(RotateMixedShape):
     def central_column_shield(self, value):
         self._central_column_shield = value
 
-    @property
-    def solid(self):
-        if self.get_hash() != self.hash_value:
-            self.create_solid()
-        return self._solid
-
-    @solid.setter
-    def solid(self, value):
-        self._solid = value
-
-    def create_solid(self):
-        """Creates a CadQuery 3D solid
-
-           Returns:
-              A CadQuery solid: A 3D solid volume
-        """
-
+    def find_points(self):
+        connection_type = "mixed"
         if isinstance(self.central_column_shield, CenterColumnShieldCylinder):
             firstwall = CenterColumnShieldCylinder(
                 height=self.central_column_shield.height,
                 inner_radius=self.central_column_shield.inner_radius,
                 outer_radius=self.central_column_shield.outer_radius + self.thickness,
-                cut=self.central_column_shield,
                 rotation_angle=self.rotation_angle)
+            connection_type = "straight"
 
         elif isinstance(self.central_column_shield, CenterColumnShieldHyperbola):
             firstwall = CenterColumnShieldHyperbola(
@@ -87,7 +73,6 @@ class InboardFirstwallFCCS(RotateMixedShape):
                 inner_radius=self.central_column_shield.inner_radius,
                 mid_radius=self.central_column_shield.mid_radius + self.thickness,
                 outer_radius=self.central_column_shield.outer_radius + self.thickness,
-                cut=self.central_column_shield,
                 rotation_angle=self.rotation_angle)
 
         elif isinstance(self.central_column_shield, CenterColumnShieldFlatTopHyperbola):
@@ -97,7 +82,6 @@ class InboardFirstwallFCCS(RotateMixedShape):
                 inner_radius=self.central_column_shield.inner_radius,
                 mid_radius=self.central_column_shield.mid_radius + self.thickness,
                 outer_radius=self.central_column_shield.outer_radius + self.thickness,
-                cut=self.central_column_shield,
                 rotation_angle=self.rotation_angle)
 
         elif isinstance(self.central_column_shield, CenterColumnShieldPlasmaHyperbola):
@@ -106,7 +90,6 @@ class InboardFirstwallFCCS(RotateMixedShape):
                 inner_radius=self.central_column_shield.inner_radius,
                 mid_offset=self.central_column_shield.mid_offset - self.thickness,
                 edge_offset=self.central_column_shield.edge_offset - self.thickness,
-                cut=self.central_column_shield,
                 rotation_angle=self.rotation_angle)
 
         elif isinstance(self.central_column_shield, CenterColumnShieldCircular):
@@ -115,7 +98,6 @@ class InboardFirstwallFCCS(RotateMixedShape):
                 inner_radius=self.central_column_shield.inner_radius,
                 mid_radius=self.central_column_shield.mid_radius + self.thickness,
                 outer_radius=self.central_column_shield.outer_radius + self.thickness,
-                cut=self.central_column_shield,
                 rotation_angle=self.rotation_angle)
 
         elif isinstance(self.central_column_shield, CenterColumnShieldFlatTopCircular):
@@ -125,7 +107,6 @@ class InboardFirstwallFCCS(RotateMixedShape):
                 inner_radius=self.central_column_shield.inner_radius,
                 mid_radius=self.central_column_shield.mid_radius + self.thickness,
                 outer_radius=self.central_column_shield.outer_radius + self.thickness,
-                cut=self.central_column_shield,
                 rotation_angle=self.rotation_angle)
 
         else:
@@ -136,8 +117,10 @@ class InboardFirstwallFCCS(RotateMixedShape):
                 CenterColumnShieldFlatTopHyperbola, CenterColumnShieldPlasmaHyperbola, \
                 CenterColumnShieldCircular, CenterColumnShieldFlatTopCircular")
 
-        self.solid = firstwall.solid
-
-        self.hash_value = self.get_hash()
-
-        return firstwall.solid
+        points = firstwall.points[:-1]
+        if connection_type != "mixed":
+            points_with_connection = []
+            for p in points:
+                points_with_connection.append([*p, connection_type])
+            points = points_with_connection
+        self.points = points

--- a/paramak/parametric_components/inboard_firstwall_fccs.py
+++ b/paramak/parametric_components/inboard_firstwall_fccs.py
@@ -39,7 +39,10 @@ class InboardFirstwallFCCS(RotateMixedShape):
 
         self.central_column_shield = central_column_shield
         self.thickness = thickness
-        self.cut = self.central_column_shield
+        if self.cut is None:
+            self.cut = self.central_column_shield
+        else:
+            self.cut = [*[self.cut], self.central_column_shield]
 
     @property
     def thickness(self):

--- a/paramak/parametric_components/inboard_firstwall_fccs.py
+++ b/paramak/parametric_components/inboard_firstwall_fccs.py
@@ -58,65 +58,96 @@ class InboardFirstwallFCCS(RotateMixedShape):
         self._central_column_shield = value
 
     def find_points(self):
-        connection_type = "mixed"
-        if isinstance(self.central_column_shield, CenterColumnShieldCylinder):
-            firstwall = CenterColumnShieldCylinder(
-                height=self.central_column_shield.height,
-                inner_radius=self.central_column_shield.inner_radius,
-                outer_radius=self.central_column_shield.outer_radius + self.thickness,
-                rotation_angle=self.rotation_angle)
-            connection_type = "straight"
 
-        elif isinstance(self.central_column_shield, CenterColumnShieldHyperbola):
-            firstwall = CenterColumnShieldHyperbola(
-                height=self.central_column_shield.height,
-                inner_radius=self.central_column_shield.inner_radius,
-                mid_radius=self.central_column_shield.mid_radius + self.thickness,
-                outer_radius=self.central_column_shield.outer_radius + self.thickness,
-                rotation_angle=self.rotation_angle)
-
-        elif isinstance(self.central_column_shield, CenterColumnShieldFlatTopHyperbola):
-            firstwall = CenterColumnShieldFlatTopHyperbola(
-                height=self.central_column_shield.height,
-                arc_height=self.central_column_shield.arc_height,
-                inner_radius=self.central_column_shield.inner_radius,
-                mid_radius=self.central_column_shield.mid_radius + self.thickness,
-                outer_radius=self.central_column_shield.outer_radius + self.thickness,
-                rotation_angle=self.rotation_angle)
-
-        elif isinstance(self.central_column_shield, CenterColumnShieldPlasmaHyperbola):
-            firstwall = CenterColumnShieldPlasmaHyperbola(
-                height=self.central_column_shield.height,
-                inner_radius=self.central_column_shield.inner_radius,
-                mid_offset=self.central_column_shield.mid_offset - self.thickness,
-                edge_offset=self.central_column_shield.edge_offset - self.thickness,
-                rotation_angle=self.rotation_angle)
-
-        elif isinstance(self.central_column_shield, CenterColumnShieldCircular):
-            firstwall = CenterColumnShieldCircular(
-                height=self.central_column_shield.height,
-                inner_radius=self.central_column_shield.inner_radius,
-                mid_radius=self.central_column_shield.mid_radius + self.thickness,
-                outer_radius=self.central_column_shield.outer_radius + self.thickness,
-                rotation_angle=self.rotation_angle)
-
-        elif isinstance(self.central_column_shield, CenterColumnShieldFlatTopCircular):
-            firstwall = CenterColumnShieldFlatTopCircular(
-                height=self.central_column_shield.height,
-                arc_height=self.central_column_shield.arc_height,
-                inner_radius=self.central_column_shield.inner_radius,
-                mid_radius=self.central_column_shield.mid_radius + self.thickness,
-                outer_radius=self.central_column_shield.outer_radius + self.thickness,
-                rotation_angle=self.rotation_angle)
-
-        else:
-
+        acceptable_classes = (
+            CenterColumnShieldCylinder,
+            CenterColumnShieldHyperbola,
+            CenterColumnShieldFlatTopHyperbola,
+            CenterColumnShieldPlasmaHyperbola,
+            CenterColumnShieldCircular,
+            CenterColumnShieldFlatTopCircular
+        )
+        if not isinstance(self.central_column_shield, acceptable_classes):
             raise ValueError(
                 "InboardFirstwallFCCS.central_column_shield must be an \
-                instance of CenterColumnShieldCylinder, CenterColumnShieldHyperbola, \
-                CenterColumnShieldFlatTopHyperbola, CenterColumnShieldPlasmaHyperbola, \
+                instance of CenterColumnShieldCylinder, \
+                CenterColumnShieldHyperbola, \
+                CenterColumnShieldFlatTopHyperbola, \
+                CenterColumnShieldPlasmaHyperbola, \
                 CenterColumnShieldCircular, CenterColumnShieldFlatTopCircular")
 
+        connection_type = "mixed"
+
+        inner_radius = self.central_column_shield.inner_radius
+        height = self.central_column_shield.height
+
+        if isinstance(self.central_column_shield, CenterColumnShieldCylinder):
+            firstwall = CenterColumnShieldCylinder(
+                height=height,
+                inner_radius=inner_radius,
+                outer_radius=self.central_column_shield.outer_radius +
+                self.thickness
+            )
+            connection_type = "straight"
+
+        elif isinstance(self.central_column_shield,
+                        CenterColumnShieldHyperbola):
+            firstwall = CenterColumnShieldHyperbola(
+                height=height,
+                inner_radius=inner_radius,
+                mid_radius=self.central_column_shield.mid_radius +
+                self.thickness,
+                outer_radius=self.central_column_shield.outer_radius +
+                self.thickness,
+            )
+
+        elif isinstance(self.central_column_shield,
+                        CenterColumnShieldFlatTopHyperbola):
+            firstwall = CenterColumnShieldFlatTopHyperbola(
+                height=height,
+                arc_height=self.central_column_shield.arc_height,
+                inner_radius=inner_radius,
+                mid_radius=self.central_column_shield.mid_radius +
+                self.thickness,
+                outer_radius=self.central_column_shield.outer_radius +
+                self.thickness,
+            )
+
+        elif isinstance(self.central_column_shield,
+                        CenterColumnShieldPlasmaHyperbola):
+            firstwall = CenterColumnShieldPlasmaHyperbola(
+                height=height,
+                inner_radius=inner_radius,
+                mid_offset=self.central_column_shield.mid_offset -
+                self.thickness,
+                edge_offset=self.central_column_shield.edge_offset -
+                self.thickness,
+            )
+
+        elif isinstance(self.central_column_shield,
+                        CenterColumnShieldCircular):
+            firstwall = CenterColumnShieldCircular(
+                height=height,
+                inner_radius=inner_radius,
+                mid_radius=self.central_column_shield.mid_radius +
+                self.thickness,
+                outer_radius=self.central_column_shield.outer_radius +
+                self.thickness,
+            )
+
+        elif isinstance(self.central_column_shield,
+                        CenterColumnShieldFlatTopCircular):
+            firstwall = CenterColumnShieldFlatTopCircular(
+                height=height,
+                arc_height=self.central_column_shield.arc_height,
+                inner_radius=inner_radius,
+                mid_radius=self.central_column_shield.mid_radius +
+                self.thickness,
+                outer_radius=self.central_column_shield.outer_radius +
+                self.thickness,
+            )
+
+        firstwall.rotation_angle = self.rotation_angle
         points = firstwall.points[:-1]
         if connection_type != "mixed":
             points_with_connection = []

--- a/paramak/parametric_components/inboard_firstwall_fccs.py
+++ b/paramak/parametric_components/inboard_firstwall_fccs.py
@@ -40,6 +40,12 @@ class InboardFirstwallFCCS(RotateMixedShape):
 
         self.central_column_shield = central_column_shield
         self.thickness = thickness
+        if self.cut is None:
+            self.cut = self.central_column_shield
+        elif isinstance(self.cut, Iterable):
+            self.cut = [*self.cut, self.central_column_shield]
+        else:
+            self.cut = [*[self.cut], self.central_column_shield]
 
     @property
     def thickness(self):
@@ -55,11 +61,6 @@ class InboardFirstwallFCCS(RotateMixedShape):
 
     @central_column_shield.setter
     def central_column_shield(self, value):
-        if self.cut is None:
-            self.cut = self.central_column_shield
-        elif isinstance(self.cut, Iterable):
-            if self.central_column_shield not in self.cut:
-                self.cut.append(self.central_column_shield)
         self._central_column_shield = value
 
     def find_points(self):

--- a/paramak/parametric_components/inboard_firstwall_fccs.py
+++ b/paramak/parametric_components/inboard_firstwall_fccs.py
@@ -40,12 +40,6 @@ class InboardFirstwallFCCS(RotateMixedShape):
 
         self.central_column_shield = central_column_shield
         self.thickness = thickness
-        if self.cut is None:
-            self.cut = self.central_column_shield
-        elif isinstance(self.cut, Iterable):
-            self.cut = [*self.cut, self.central_column_shield]
-        else:
-            self.cut = [*[self.cut], self.central_column_shield]
 
     @property
     def thickness(self):
@@ -162,3 +156,11 @@ class InboardFirstwallFCCS(RotateMixedShape):
         if connection_type is not None:
             points = [[*p, connection_type] for p in points]
         self.points = points
+
+        # add to cut attribute
+        if self.cut is None:
+            self.cut = self.central_column_shield
+        elif isinstance(self.cut, Iterable):
+            self.cut = [*self.cut, self.central_column_shield]
+        else:
+            self.cut = [*[self.cut], self.central_column_shield]

--- a/paramak/parametric_components/inboard_firstwall_fccs.py
+++ b/paramak/parametric_components/inboard_firstwall_fccs.py
@@ -2,6 +2,7 @@ from paramak import RotateMixedShape, CenterColumnShieldCylinder, \
     CenterColumnShieldHyperbola, CenterColumnShieldFlatTopHyperbola, \
     CenterColumnShieldPlasmaHyperbola, CenterColumnShieldCircular, \
     CenterColumnShieldFlatTopCircular
+from collections import Iterable
 
 
 class InboardFirstwallFCCS(RotateMixedShape):
@@ -39,10 +40,6 @@ class InboardFirstwallFCCS(RotateMixedShape):
 
         self.central_column_shield = central_column_shield
         self.thickness = thickness
-        if self.cut is None:
-            self.cut = self.central_column_shield
-        else:
-            self.cut = [*[self.cut], self.central_column_shield]
 
     @property
     def thickness(self):
@@ -58,6 +55,11 @@ class InboardFirstwallFCCS(RotateMixedShape):
 
     @central_column_shield.setter
     def central_column_shield(self, value):
+        if self.cut is None:
+            self.cut = self.central_column_shield
+        elif isinstance(self.cut, Iterable):
+            if self.central_column_shield not in self.cut:
+                self.cut.append(self.central_column_shield)
         self._central_column_shield = value
 
     def find_points(self):

--- a/paramak/parametric_components/inboard_firstwall_fccs.py
+++ b/paramak/parametric_components/inboard_firstwall_fccs.py
@@ -59,6 +59,7 @@ class InboardFirstwallFCCS(RotateMixedShape):
 
     def find_points(self):
 
+        # check that is an acceptable class
         acceptable_classes = (
             CenterColumnShieldCylinder,
             CenterColumnShieldHyperbola,
@@ -76,7 +77,8 @@ class InboardFirstwallFCCS(RotateMixedShape):
                 CenterColumnShieldPlasmaHyperbola, \
                 CenterColumnShieldCircular, CenterColumnShieldFlatTopCircular")
 
-        connection_type = "mixed"
+        # initialise connection type
+        connection_type = None
 
         inner_radius = self.central_column_shield.inner_radius
         height = self.central_column_shield.height
@@ -88,6 +90,7 @@ class InboardFirstwallFCCS(RotateMixedShape):
                 outer_radius=self.central_column_shield.outer_radius +
                 self.thickness
             )
+            # since no connection type in firstwall.points
             connection_type = "straight"
 
         elif isinstance(self.central_column_shield,
@@ -149,9 +152,7 @@ class InboardFirstwallFCCS(RotateMixedShape):
 
         firstwall.rotation_angle = self.rotation_angle
         points = firstwall.points[:-1]
-        if connection_type != "mixed":
-            points_with_connection = []
-            for p in points:
-                points_with_connection.append([*p, connection_type])
-            points = points_with_connection
+        # if no connection type is given, add the connection types to points
+        if connection_type is not None:
+            points = [[*p, connection_type] for p in points]
         self.points = points

--- a/tests/test_parametric_components/test_InboardFirstwallFCCS.py
+++ b/tests/test_parametric_components/test_InboardFirstwallFCCS.py
@@ -162,3 +162,20 @@ class test_InboardFirstwallFCCS(unittest.TestCase):
             azimuth_placement_angle=90,
             cut=b)
         assert np.isclose(c.volume, 0.5*b.volume)
+
+    def test_cut_attribute(self):
+        """Creates a firstwall then reset its cut attribute and check that
+        the shape isn't affected"""
+        a = paramak.CenterColumnShieldCylinder(
+            height=100,
+            inner_radius=20,
+            outer_radius=80)
+        b = paramak.InboardFirstwallFCCS(
+            central_column_shield=a,
+            thickness=20,
+            rotation_angle=180)
+
+        volume_1 = b.volume
+        b.cut = None
+        volume_2 = b.volume
+        assert np.isclose(volume_1, volume_2)

--- a/tests/test_parametric_components/test_InboardFirstwallFCCS.py
+++ b/tests/test_parametric_components/test_InboardFirstwallFCCS.py
@@ -140,8 +140,9 @@ class test_InboardFirstwallFCCS(unittest.TestCase):
         assert np.isclose(c.volume, 2*b.volume)
 
     def test_azimuth_placement_angle(self):
-        """Makes two halfs of a 360 firstwall and perform a union and checks
-        that the volume corresponds to 2 times the volume of 1 half"""
+        """Makes two 180deg firstwalls (one is rotated 90deg), performs a cut
+        and checks that the volume corresponds to 0.5 times the volume of 1
+        half"""
         a = paramak.CenterColumnShieldFlatTopCircular(
             height=500,
             arc_height=300,

--- a/tests/test_parametric_components/test_InboardFirstwallFCCS.py
+++ b/tests/test_parametric_components/test_InboardFirstwallFCCS.py
@@ -1,6 +1,7 @@
 
 import paramak
 import unittest
+import numpy as np
 
 
 class test_InboardFirstwallFCCS(unittest.TestCase):
@@ -114,3 +115,49 @@ class test_InboardFirstwallFCCS(unittest.TestCase):
         self.assertRaises(
             ValueError,
             test_construction_with_string)
+
+    def test_boolean_union(self):
+        """Makes two halfs of a 360 firstwall and perform a union and checks
+        that the volume corresponds to 2 times the volume of 1 half"""
+        a = paramak.CenterColumnShieldFlatTopCircular(
+            height=500,
+            arc_height=300,
+            inner_radius=30,
+            mid_radius=70,
+            outer_radius=120)
+        b = paramak.InboardFirstwallFCCS(
+            central_column_shield=a,
+            thickness=20,
+            rotation_angle=180,
+            azimuth_placement_angle=0)
+
+        c = paramak.InboardFirstwallFCCS(
+            central_column_shield=a,
+            thickness=20,
+            rotation_angle=180,
+            azimuth_placement_angle=180,
+            union=b)
+        assert np.isclose(c.volume, 2*b.volume)
+
+    def test_azimuth_placement_angle(self):
+        """Makes two halfs of a 360 firstwall and perform a union and checks
+        that the volume corresponds to 2 times the volume of 1 half"""
+        a = paramak.CenterColumnShieldFlatTopCircular(
+            height=500,
+            arc_height=300,
+            inner_radius=30,
+            mid_radius=70,
+            outer_radius=120)
+        b = paramak.InboardFirstwallFCCS(
+            central_column_shield=a,
+            thickness=20,
+            rotation_angle=180,
+            azimuth_placement_angle=0)
+
+        c = paramak.InboardFirstwallFCCS(
+            central_column_shield=a,
+            thickness=20,
+            rotation_angle=180,
+            azimuth_placement_angle=90,
+            cut=b)
+        assert np.isclose(c.volume, 0.5*b.volume)


### PR DESCRIPTION
## Proposed changes

This fixed #374.

In InboardFirstwallFCCS, instead of overwritting the create_solid method, the find_points method is overwritten.
Therefore, the boolean operations and the azimuth placement angle can be set.

2 unit tests have been added to catch the bugs.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
