### PR TITLE
No more error if first and last points are the same

### DIFF
--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -299,11 +299,7 @@ class Shape:
                             3 but not a mixture of 2 and 3")
 
             if len(values) > 1:
-                if values[-1][0] == values[0][0] and values[-1][1] == values[0][1]:
-                    raise ValueError(
-                        "The coordinates of the last and first points are the same."
-                    )
-                else:
+                if values[-1][:2] != values[0][:2]:
                     values.append(values[0])
 
             self._points = values

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -36,12 +36,12 @@ class test_object_properties(unittest.TestCase):
         def incorrect_points_end_point_is_start_point():
             """checks ValueError is raised when the start and end points are
             the same"""
-
-            test_shape.points = [(0, 200), (200, 100), (0, 0), (0, 200)]
-
-        self.assertRaises(
-            ValueError,
-            incorrect_points_end_point_is_start_point)
+            points = [(0, 200), (200, 100), (0, 0), (0, 200)]
+            test_shape.points = points
+            assert test_shape.points == points
+            points2 = [(0, 200), (200, 100), (0, 0)]
+            test_shape.points = points
+            assert test_shape.points == points
 
         def incorrect_points_missing_z_value():
             """checks ValueError is raised when a point is missing a z value"""


### PR DESCRIPTION
## Proposed changes

In the following lines of `Shape()` it is clear that having the first and last point identical is required by the code. This PR therefore proposes to get rid of the error raise.

https://github.com/ukaea/paramak/blob/77bdc10a2744fb50062f42342f863bad94a2ba98/paramak/shape.py#L302-L307

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
