### PR TITLE
added cutting wedge to extrude shapes and tf coils

### DIFF
--- a/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
+++ b/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
@@ -3,6 +3,7 @@ from collections import Iterable
 import cadquery as cq
 import numpy as np
 from paramak import ExtrudeStraightShape
+from paramak.utils import calculate_wedge_cut
 
 
 class ToroidalFieldCoilCoatHanger(ExtrudeStraightShape):
@@ -40,6 +41,7 @@ class ToroidalFieldCoilCoatHanger(ExtrudeStraightShape):
         thickness,
         distance,
         number_of_coils,
+        rotation_angle=360,
         with_inner_leg=True,
         stp_filename="ToroidalFieldCoilCoatHangar.stp",
         stl_filename="ToroidalFieldCoilCoatHangar.stl",
@@ -52,6 +54,7 @@ class ToroidalFieldCoilCoatHanger(ExtrudeStraightShape):
             stp_filename=stp_filename,
             stl_filename=stl_filename,
             material_tag=material_tag,
+            rotation_angle=rotation_angle,
             **kwargs
         )
 
@@ -198,6 +201,7 @@ class ToroidalFieldCoilCoatHanger(ExtrudeStraightShape):
             solid = solid.rotate(
                 (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
 
+        calculate_wedge_cut(self)
         self.perform_boolean_operations(solid)
 
         return solid

--- a/paramak/parametric_components/toroidal_field_coil_princeton_d.py
+++ b/paramak/parametric_components/toroidal_field_coil_princeton_d.py
@@ -6,6 +6,7 @@ from scipy import integrate
 from scipy.optimize import minimize
 
 from paramak import ExtrudeMixedShape
+from paramak.utils import calculate_wedge_cut
 
 
 class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
@@ -37,6 +38,7 @@ class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
         thickness,
         distance,
         number_of_coils,
+        rotation_angle=360,
         vertical_displacement=0.0,
         with_inner_leg=True,
         stp_filename="ToroidalFieldCoilPrincetonD.stp",
@@ -60,6 +62,7 @@ class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
         self.number_of_coils = number_of_coils
         self.vertical_displacement = vertical_displacement
         self.with_inner_leg = with_inner_leg
+        self.rotation_angle = rotation_angle
 
     @property
     def azimuth_placement_angle(self):
@@ -69,6 +72,14 @@ class ToroidalFieldCoilPrincetonD(ExtrudeMixedShape):
     @azimuth_placement_angle.setter
     def azimuth_placement_angle(self, value):
         self._azimuth_placement_angle = value
+
+    @property
+    def rotation_angle(self):
+        return self._rotation_angle
+
+    @rotation_angle.setter
+    def rotation_angle(self, value):
+        self._rotation_angle = value
 
     def _compute_inner_points(self, R1, R2):
         """Computes the inner curve points

--- a/paramak/parametric_components/toroidal_field_coil_rectangle.py
+++ b/paramak/parametric_components/toroidal_field_coil_rectangle.py
@@ -49,6 +49,7 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
             stp_filename=stp_filename,
             stl_filename=stl_filename,
             material_tag=material_tag,
+            rotation_angle=rotation_angle,
             **kwargs
         )
 
@@ -58,7 +59,6 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
         self.distance = distance
         self.number_of_coils = number_of_coils
         self.with_inner_leg = with_inner_leg
-        self.rotation_angle = rotation_angle
 
     @property
     def azimuth_placement_angle(self):
@@ -68,14 +68,6 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
     @azimuth_placement_angle.setter
     def azimuth_placement_angle(self, value):
         self._azimuth_placement_angle = value
-
-    @property
-    def rotation_angle(self):
-        return self._rotation_angle
-
-    @rotation_angle.setter
-    def rotation_angle(self, value):
-        self._rotation_angle = value
 
     def find_points(self):
         """Finds the XZ points joined by straight connections that describe

--- a/paramak/parametric_components/toroidal_field_coil_triple_arc.py
+++ b/paramak/parametric_components/toroidal_field_coil_triple_arc.py
@@ -39,6 +39,7 @@ class ToroidalFieldCoilTripleArc(ExtrudeMixedShape):
         thickness,
         distance,
         number_of_coils,
+        rotation_angle=360,
         vertical_displacement=0.0,
         with_inner_leg=True,
         stp_filename="ToroidalFieldCoilPrincetonD.stp",
@@ -64,6 +65,7 @@ class ToroidalFieldCoilTripleArc(ExtrudeMixedShape):
         self.number_of_coils = number_of_coils
         self.vertical_displacement = vertical_displacement
         self.with_inner_leg = with_inner_leg
+        self.rotation_angle = rotation_angle
 
     @property
     def azimuth_placement_angle(self):
@@ -73,6 +75,14 @@ class ToroidalFieldCoilTripleArc(ExtrudeMixedShape):
     @azimuth_placement_angle.setter
     def azimuth_placement_angle(self, value):
         self._azimuth_placement_angle = value
+
+    @property
+    def rotation_angle(self):
+        return self._rotation_angle
+
+    @rotation_angle.setter
+    def rotation_angle(self, value):
+        self._rotation_angle = value
 
     def _compute_curve(self, R1, h, radii, coverages):
         npoints = 500

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -3,6 +3,7 @@ from collections import Iterable
 import cadquery as cq
 
 from paramak import Shape
+from paramak.utils import calculate_wedge_cut
 
 
 class ExtrudeMixedShape(Shape):
@@ -20,6 +21,7 @@ class ExtrudeMixedShape(Shape):
     def __init__(
         self,
         distance,
+        rotation_angle=360,
         stp_filename="ExtrudeMixedShape.stp",
         stl_filename="ExtrudeMixedShape.stl",
         **kwargs
@@ -32,6 +34,7 @@ class ExtrudeMixedShape(Shape):
         )
 
         self.distance = distance
+        self.rotation_angle = rotation_angle
 
     @property
     def distance(self):
@@ -40,6 +43,14 @@ class ExtrudeMixedShape(Shape):
     @distance.setter
     def distance(self, value):
         self._distance = value
+
+    @property
+    def rotation_angle(self):
+        return self._rotation_angle
+
+    @rotation_angle.setter
+    def rotation_angle(self, value):
+        self._rotation_angle = value
 
     def create_solid(self):
         """Creates an extruded 3d solid using points connected with straight
@@ -108,6 +119,7 @@ class ExtrudeMixedShape(Shape):
             solid = solid.rotate(
                 (0, 0, -1), (0, 0, 1), self.azimuth_placement_angle)
 
+        calculate_wedge_cut(self)
         self.perform_boolean_operations(solid)
 
         return solid

--- a/paramak/parametric_shapes/extruded_spline_shape.py
+++ b/paramak/parametric_shapes/extruded_spline_shape.py
@@ -3,6 +3,7 @@ from collections import Iterable
 import cadquery as cq
 
 from paramak import Shape
+from paramak.utils import calculate_wedge_cut
 
 
 class ExtrudeSplineShape(Shape):
@@ -19,6 +20,7 @@ class ExtrudeSplineShape(Shape):
     def __init__(
         self,
         distance,
+        rotation_angle=360,
         stp_filename="ExtrudeSplineShape.stp",
         stl_filename="ExtrudeSplineShape.stl",
         **kwargs
@@ -31,6 +33,7 @@ class ExtrudeSplineShape(Shape):
         )
 
         self.distance = distance
+        self.rotation_angle = rotation_angle
 
     @property
     def distance(self):
@@ -39,6 +42,14 @@ class ExtrudeSplineShape(Shape):
     @distance.setter
     def distance(self, value):
         self._distance = value
+
+    @property
+    def rotation_angle(self):
+        return self._rotation_angle
+
+    @rotation_angle.setter
+    def rotation_angle(self, value):
+        self._rotation_angle = value
 
     def create_solid(self):
         """Creates an extruded 3d solid using points connected with spline
@@ -74,6 +85,7 @@ class ExtrudeSplineShape(Shape):
             solid = solid.rotate(
                 (0, 0, -1), (0, 0, 1), self.azimuth_placement_angle)
 
+        calculate_wedge_cut(self)
         self.perform_boolean_operations(solid)
 
         return solid

--- a/paramak/parametric_shapes/extruded_straight_shape.py
+++ b/paramak/parametric_shapes/extruded_straight_shape.py
@@ -4,6 +4,7 @@ from collections import Iterable
 import cadquery as cq
 
 from paramak import Shape
+from paramak.utils import calculate_wedge_cut
 
 
 class ExtrudeStraightShape(Shape):
@@ -21,6 +22,7 @@ class ExtrudeStraightShape(Shape):
     def __init__(
         self,
         distance,
+        rotation_angle=360,
         extrude_both=True,
         stp_filename="ExtrudeStraightShape.stp",
         stl_filename="ExtrudeStraightShape.stl",
@@ -34,6 +36,7 @@ class ExtrudeStraightShape(Shape):
         )
 
         self.distance = distance
+        self.rotation_angle = rotation_angle
         self.extrude_both = extrude_both
 
     @property
@@ -43,6 +46,14 @@ class ExtrudeStraightShape(Shape):
     @distance.setter
     def distance(self, value):
         self._distance = value
+
+    @property
+    def rotation_angle(self):
+        return self._rotation_angle
+
+    @rotation_angle.setter
+    def rotation_angle(self, value):
+        self._rotation_angle = value
 
     def create_solid(self):
         """Creates an extruded 3d solid using points connected with straight
@@ -78,6 +89,7 @@ class ExtrudeStraightShape(Shape):
             solid = solid.rotate(
                 (0, 0, -1), (0, 0, 1), self.azimuth_placement_angle)
 
+        calculate_wedge_cut(self)
         self.perform_boolean_operations(solid)
 
         return solid


### PR DESCRIPTION
## Proposed changes

PR which adds the cutting wedge to some extrude classes, allowing rotation_angle for these classes to be specified. This allows the cutting wedge to be used in the tf coil parametric components which do not have their own create_solid() method.
I.e. calculate_wedge_cut has been added to all create_solid() methods for the extruded shapes and components.
This allows rotation_angle to be inherited from the extrude shapes, rather than specified in the extrude components, such as tf coils.
(Note. Has not yet been added to ExtrudeCircleShape as the workplane causes issues)

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
