### PR TITLE
added extrude_both to shapes and components

### DIFF
--- a/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
+++ b/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
@@ -167,7 +167,7 @@ class ToroidalFieldCoilCoatHanger(ExtrudeStraightShape):
             cq.Workplane(self.workplane)
             .polyline(self.points)
             .close()
-            .extrude(distance=-self.distance / 2.0, both=True)
+            .extrude(distance=-self.distance / 2.0, both=self.extrude_both)
         )
 
         if self.with_inner_leg is True:
@@ -175,7 +175,7 @@ class ToroidalFieldCoilCoatHanger(ExtrudeStraightShape):
             inner_leg_solid = inner_leg_solid.polyline(
                 self.inner_leg_connection_points)
             inner_leg_solid = inner_leg_solid.close().extrude(
-                distance=-self.distance / 2.0, both=True)
+                distance=-self.distance / 2.0, both=self.extrude_both)
 
         solid = cq.Compound.makeCompound(
             [a.val() for a in [inner_leg_solid, solid]]

--- a/paramak/parametric_components/toroidal_field_coil_rectangle.py
+++ b/paramak/parametric_components/toroidal_field_coil_rectangle.py
@@ -136,7 +136,7 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
             cq.Workplane(self.workplane)
             .polyline(self.points)
             .close()
-            .extrude(distance=-self.distance / 2.0, both=True)
+            .extrude(distance=-self.distance / 2.0, both=self.extrude_both)
         )
 
         if self.with_inner_leg is True:
@@ -144,7 +144,7 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
             inner_leg_solid = inner_leg_solid.polyline(
                 self.inner_leg_connection_points)
             inner_leg_solid = inner_leg_solid.close().extrude(
-                distance=-self.distance / 2.0, both=True)
+                distance=-self.distance / 2.0, both=self.extrude_both)
 
             solid = cq.Compound.makeCompound(
                 [a.val() for a in [inner_leg_solid, solid]]

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -13,7 +13,7 @@ class ExtrudeMixedShape(Shape):
     Args:
         distance (float): the extrusion distance to use (cm units if used for
             neutronics).
-        rotation_angle (float, optional): rotation angle of solid created. a cut 
+        rotation_angle (float, optional): rotation angle of solid created. a cut
             is performed from rotation_angle to 360 degrees. Defaults to 360.
         extrude_both (bool, optional): if set to True, the extrusion will occur
             in both directions. Defaults to True.
@@ -105,7 +105,9 @@ class ExtrudeMixedShape(Shape):
                 solid = solid.moveTo(p0[0], p0[1]).threePointArc(p1, p2)
 
         # performs extrude in both directions, hence distance / 2
-        solid = solid.close().extrude(distance=-self.distance / 2.0, both=self.extrude_both)
+        solid = solid.close().extrude(
+            distance=-self.distance / 2.0,
+            both=self.extrude_both)
 
         # Checks if the azimuth_placement_angle is a list of angles
         if isinstance(self.azimuth_placement_angle, Iterable):

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -13,8 +13,10 @@ class ExtrudeMixedShape(Shape):
     Args:
         distance (float): the extrusion distance to use (cm units if used for
             neutronics).
-        rotation_angle (float): rotation angle of solid created. a cut is performed
-            from rotation_angle to 360 degrees. Defaults to 360.
+        rotation_angle (float, optional): rotation angle of solid created. a cut 
+            is performed from rotation_angle to 360 degrees. Defaults to 360.
+        extrude_both (bool, optional): if set to True, the extrusion will occur
+            in both directions. Defaults to True.
         stp_filename (str, optional): Defaults to "ExtrudeMixedShape.stp".
         stl_filename (str, optional): Defaults to "ExtrudeMixedShape.stl".
 
@@ -24,6 +26,7 @@ class ExtrudeMixedShape(Shape):
         self,
         distance,
         rotation_angle=360,
+        extrude_both=True,
         stp_filename="ExtrudeMixedShape.stp",
         stl_filename="ExtrudeMixedShape.stl",
         **kwargs
@@ -37,6 +40,7 @@ class ExtrudeMixedShape(Shape):
 
         self.distance = distance
         self.rotation_angle = rotation_angle
+        self.extrude_both = extrude_both
 
     @property
     def distance(self):
@@ -101,7 +105,7 @@ class ExtrudeMixedShape(Shape):
                 solid = solid.moveTo(p0[0], p0[1]).threePointArc(p1, p2)
 
         # performs extrude in both directions, hence distance / 2
-        solid = solid.close().extrude(distance=-self.distance / 2.0, both=True)
+        solid = solid.close().extrude(distance=-self.distance / 2.0, both=self.extrude_both)
 
         # Checks if the azimuth_placement_angle is a list of angles
         if isinstance(self.azimuth_placement_angle, Iterable):

--- a/paramak/parametric_shapes/extruded_spline_shape.py
+++ b/paramak/parametric_shapes/extruded_spline_shape.py
@@ -13,7 +13,7 @@ class ExtrudeSplineShape(Shape):
     Args:
         distance (float): the extrusion distance to use (cm units if used for
             neutronics).
-        rotation_angle (float, optional): rotation angle of solid created. a 
+        rotation_angle (float, optional): rotation angle of solid created. a
             cut is performed from rotation_angle to 360 degrees. Defaults to 360.
         extrude_both (bool, optional): if set to True, the extrusion will
             occur in both directions. Defaults to True.

--- a/paramak/parametric_shapes/extruded_spline_shape.py
+++ b/paramak/parametric_shapes/extruded_spline_shape.py
@@ -13,8 +13,10 @@ class ExtrudeSplineShape(Shape):
     Args:
         distance (float): the extrusion distance to use (cm units if used for
             neutronics).
-        rotation_angle (float): rotation angle of solid created. a cut is performed
-            from rotation_angle to 360 degrees. Defaults to 360.
+        rotation_angle (float, optional): rotation angle of solid created. a 
+            cut is performed from rotation_angle to 360 degrees. Defaults to 360.
+        extrude_both (bool, optional): if set to True, the extrusion will
+            occur in both directions. Defaults to True.
         stp_filename (str, optional): Defaults to "ExtrudeSplineShape.stp".
         stl_filename (str, optional): Defaults to "ExtrudeSplineShape.stl".
     """
@@ -23,6 +25,7 @@ class ExtrudeSplineShape(Shape):
         self,
         distance,
         rotation_angle=360,
+        extrude_both=True,
         stp_filename="ExtrudeSplineShape.stp",
         stl_filename="ExtrudeSplineShape.stl",
         **kwargs
@@ -36,6 +39,7 @@ class ExtrudeSplineShape(Shape):
 
         self.distance = distance
         self.rotation_angle = rotation_angle
+        self.extrude_both = extrude_both
 
     @property
     def distance(self):
@@ -66,7 +70,7 @@ class ExtrudeSplineShape(Shape):
             cq.Workplane(self.workplane)
             .spline(self.points)
             .close()
-            .extrude(distance=-1 * self.distance / 2.0, both=True)
+            .extrude(distance=-1 * self.distance / 2.0, both=self.extrude_both)
         )
 
         # Checks if the azimuth_placement_angle is a list of angles


### PR DESCRIPTION
## Proposed changes

Small PR which adds the extrude_both option to shapes and components that were missing this option.
Also adds rotation_angle to extrude shapes docstrings.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Tests will be added in a future PR
