### PR TITLE
New blanket cutters parametric shape

### DIFF
--- a/docs/source/paramak.parametric_components.rst
+++ b/docs/source/paramak.parametric_components.rst
@@ -47,6 +47,20 @@ BlanketFP()
    :members:
    :show-inheritance:
 
+BlanketCutterStar()
+^^^^^^^^^^^^^^^^^^^
+
+|BlanketCutterStarstp| |BlanketCutterStarsvg|
+
+.. |BlanketCutterStarstp| image:: https://user-images.githubusercontent.com/8583900/97103699-0178ac80-16a6-11eb-8e5a-ec3575d265fe.png
+   :width: 300
+.. |BlanketCutterStarsvg| image:: https://user-images.githubusercontent.com/8583900/97103794-b0b58380-16a6-11eb-86f0-fb5530d630af.png
+   :width: 450
+
+.. automodule:: paramak.parametric_components.blanket_cutters_star
+   :members:
+   :show-inheritance:
+
 CenterColumnShieldCylinder()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/examples/example_parametric_components/make_all_parametric_components.py
+++ b/examples/example_parametric_components/make_all_parametric_components.py
@@ -29,6 +29,12 @@ def main():
     )
     all_components.append(component)
 
+    component = paramak.BlanketCutterStar(
+        height=2000,
+        width=2000,
+        distance=100)
+    all_components.append(component)
+
     component = paramak.BlanketFP(
         plasma=plasma,
         thickness=100,

--- a/examples/example_parametric_components/make_demo_style_blankets.py
+++ b/examples/example_parametric_components/make_demo_style_blankets.py
@@ -66,15 +66,9 @@ def make_demo_blanket(
     )
 
     # this makes the regular gaps (non parallel) gaps on the outboard blanket
-    outboard_gaps = paramak.ExtrudeStraightShape(
-        points=[(large_dimention, large_dimention),
-                (large_dimention, -large_dimention),
-                (0, -large_dimention),
-                (0, large_dimention),
-                ],
+    outboard_gaps = paramak.BlanketCutterStar(
         distance=gap_size,
-        azimuth_placement_angle=np.linspace(0 + offset, 360 + offset, number_of_segments, endpoint=False)
-    )
+        azimuth_placement_angle=np.linspace(0 + offset, 360 + offset, number_of_segments, endpoint=False))
 
     # makes the outboard blanket with cuts for all the segmentation
     outboard_blanket = paramak.BlanketFP(
@@ -90,12 +84,7 @@ def make_demo_blanket(
             inboard_to_outboard_gaps])
 
     # this makes the regular gaps on the outboard blanket
-    inboard_gaps = paramak.ExtrudeStraightShape(
-        points=[(large_dimention, large_dimention),
-                (large_dimention, -large_dimention),
-                (0, -large_dimention),
-                (0, large_dimention),
-                ],
+    inboard_gaps = paramak.BlanketCutterStar(
         distance=gap_size,
         azimuth_placement_angle=np.linspace(0, 360, number_of_segments * 2, endpoint=False)
     )

--- a/examples/example_parametric_components/make_demo_style_blankets.py
+++ b/examples/example_parametric_components/make_demo_style_blankets.py
@@ -67,8 +67,8 @@ def make_demo_blanket(
 
     # this makes the regular gaps (non parallel) gaps on the outboard blanket
     outboard_gaps = paramak.BlanketCutterStar(
-        distance=gap_size,
-        azimuth_placement_angle=np.linspace(0 + offset, 360 + offset, number_of_segments, endpoint=False))
+        distance=gap_size, azimuth_placement_angle=np.linspace(
+            0 + offset, 360 + offset, number_of_segments, endpoint=False))
 
     # makes the outboard blanket with cuts for all the segmentation
     outboard_blanket = paramak.BlanketFP(
@@ -85,9 +85,8 @@ def make_demo_blanket(
 
     # this makes the regular gaps on the outboard blanket
     inboard_gaps = paramak.BlanketCutterStar(
-        distance=gap_size,
-        azimuth_placement_angle=np.linspace(0, 360, number_of_segments * 2, endpoint=False)
-    )
+        distance=gap_size, azimuth_placement_angle=np.linspace(
+            0, 360, number_of_segments * 2, endpoint=False))
 
     # makes the inboard blanket with cuts for all the segmentation
     inboard_blanket = paramak.BlanketFP(

--- a/paramak/__init__.py
+++ b/paramak/__init__.py
@@ -46,6 +46,7 @@ from .parametric_components.port_cutters_rectangular import PortCutterRectangula
 from .parametric_components.port_cutters_circular import PortCutterCircular
 from .parametric_components.cutting_wedge import CuttingWedge
 from .parametric_components.cutting_wedge_fs import CuttingWedgeFS
+from .parametric_components.blanket_cutters_star import BlanketCutterStar
 
 from .parametric_components.inner_tf_coils_circular import InnerTfCoilsCircular
 from .parametric_components.inner_tf_coils_flat import InnerTfCoilsFlat

--- a/paramak/parametric_components/blanket_cutters_star.py
+++ b/paramak/parametric_components/blanket_cutters_star.py
@@ -29,7 +29,7 @@ class BlanketCutterStar(ExtrudeStraightShape):
         self,
         distance,
         azimuth_placement_angle=[0., 36., 72., 108., 144., 180., 216., 252.,
-            288., 324.],
+                                 288., 324.],
         height=2000,
         width=2000,
         stp_filename="BlanketCutterStar.stp",

--- a/paramak/parametric_components/blanket_cutters_star.py
+++ b/paramak/parametric_components/blanket_cutters_star.py
@@ -1,0 +1,66 @@
+
+from paramak import ExtrudeStraightShape
+
+
+class BlanketCutterStar(ExtrudeStraightShape):
+    """Creates an extruded shape with a rectangular section that is used to cut
+    other components (eg. blankets and firstwalls) in order to create banana
+    stlye blanket segments. Typically used to divide a blanket into vertical
+    sections with a fixed gap between each section.
+
+    Args:
+        distance (float): extruded distance (cm) of the cutter which translates
+            to being the gap size between blankets when the cutter is used to
+            segment blankets.
+        azimuth_placement_angle (float, optional): the azimuth angle(s) used
+            when positioning the shape. If an iterable of angles is provided,
+            the shape is duplicated at all angles. Defaults to [0., 36.,
+            72., 108., 144., 180., 216., 252., 288., 324.]
+        height (float, optional): height (cm) of the port. Defaults to 2000
+        width (float, optional): width (cm) of the port. Defaults to 2000
+        stp_filename (str, optional): defaults to "BlanketCutterStar.stp".
+        stl_filename (str, optional): defaults to "BlanketCutterStar.stl".
+        name (str, optional): defaults to "blanket_cutter_star".
+        material_tag (str, optional): defaults to
+            "blanket_cutter_star_mat".
+    """
+
+    def __init__(
+        self,
+        distance,
+        azimuth_placement_angle=[0., 36., 72., 108., 144., 180., 216., 252.,
+            288., 324.],
+        height=2000,
+        width=2000,
+        stp_filename="BlanketCutterStar.stp",
+        stl_filename="BlanketCutterStar.stl",
+        name="blanket_cutter_star",
+        material_tag="blanket_cutter_star_mat",
+        **kwargs
+    ):
+
+        super().__init__(
+            extrude_both=True,
+            name=name,
+            material_tag=material_tag,
+            stp_filename=stp_filename,
+            stl_filename=stl_filename,
+            azimuth_placement_angle=azimuth_placement_angle,
+            distance=distance,
+            **kwargs
+        )
+
+        self.azimuth_placement_angle = azimuth_placement_angle
+        self.height = height
+        self.width = width
+        self.distance = distance
+
+    def find_points(self):
+
+        points = [
+            (0, -self.height / 2),
+            (self.width, -self.height / 2),
+            (self.width, self.height / 2),
+            (0, self.height / 2),
+        ]
+        self.points = points

--- a/tests/test_parametric_components/test_BlanketCutterStar.py
+++ b/tests/test_parametric_components/test_BlanketCutterStar.py
@@ -1,0 +1,15 @@
+
+import paramak
+import unittest
+
+
+class test_BlanketCutterStar(unittest.TestCase):
+    def test_BlanketCutterStar_creation(self):
+        """creates a pf coil using the BlanketCutterStar parametric component
+        and checks that a cadquery solid is created"""
+
+        test_shape = paramak.BlanketCutterStar(
+            distance=100)
+
+        assert test_shape.solid is not None
+        assert test_shape.volume > 1000


### PR DESCRIPTION
## Proposed changes

This adds a new parametric component to the available options. This includes:

- a simple parametric component called BlanketCutterStar
- simple tests that show it can be created
- additional documentation with images. Images were added to github issue #32 along with the other documentation images
- added this component to the examples
- as a bonus was also able to refactor a small amount of code that efficiently did the same thing with a parametric shape.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [x] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
