### PR TITLE
Parralel blanket cutters refac

### DIFF
--- a/examples/example_parametric_components/make_demo_style_blankets.py
+++ b/examples/example_parametric_components/make_demo_style_blankets.py
@@ -32,8 +32,9 @@ def make_demo_blanket(
     # this makes a cutter shape that is used to make the blanket bananna
     # segment that has parallel sides
     parallel_outboard_gaps_outer = paramak.BlanketCutterParallels(
-        distance=gap_size, azimuth_placement_angle=np.linspace(
-            0, 360, number_of_segments, endpoint=False), gap_size=central_block_width)
+        thickness=gap_size, azimuth_placement_angle=np.linspace(
+            0, 360, number_of_segments, endpoint=False),
+        gap_size=central_block_width)
 
     # this makes a gap that seperates the inboard and outboard blanket
     inboard_to_outboard_gaps = paramak.ExtrudeStraightShape(

--- a/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
+++ b/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
@@ -182,25 +182,9 @@ class ToroidalFieldCoilCoatHanger(ExtrudeStraightShape):
             [a.val() for a in [inner_leg_solid, solid]]
         )
 
-        # Checks if the azimuth_placement_angle is a list of angles
-        if isinstance(self.azimuth_placement_angle, Iterable):
-            rotated_solids = []
-            # Perform seperate rotations for each angle
-            for angle in self.azimuth_placement_angle:
-                rotated_solids.append(
-                    solid.rotate(
-                        (0, 0, -1), (0, 0, 1), angle))
-            solid = cq.Workplane(self.workplane)
-
-            # Joins the seperate solids together
-            for i in rotated_solids:
-                solid = solid.union(i)
-        else:
-            # Peform rotations for a single azimuth_placement_angle angle
-            solid = solid.rotate(
-                (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
+        solid = self.rotate_solid(solid)
 
         calculate_wedge_cut(self)
-        self.perform_boolean_operations(solid)
-
+        solid = self.perform_boolean_operations(solid)
+        self.solid = solid
         return solid

--- a/paramak/parametric_components/toroidal_field_coil_rectangle.py
+++ b/paramak/parametric_components/toroidal_field_coil_rectangle.py
@@ -151,25 +151,8 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
                 [a.val() for a in [inner_leg_solid, solid]]
             )
 
-        # Checks if the azimuth_placement_angle is a list of angles
-        if isinstance(self.azimuth_placement_angle, Iterable):
-            rotated_solids = []
-            # Perform seperate rotations for each angle
-            for angle in self.azimuth_placement_angle:
-                rotated_solids.append(
-                    solid.rotate(
-                        (0, 0, -1), (0, 0, 1), angle))
-            solid = cq.Workplane(self.workplane)
-
-            # Joins the seperate solids together
-            for i in rotated_solids:
-                solid = solid.union(i)
-        else:
-            # Peform rotations for a single azimuth_placement_angle angle
-            solid = solid.rotate(
-                (0, 0, 1), (0, 0, -1), self.azimuth_placement_angle)
-
+        solid = self.rotate_solid(solid)
         calculate_wedge_cut(self)
-        self.perform_boolean_operations(solid)
-
+        solid = self.perform_boolean_operations(solid)
+        self.solid = solid
         return solid

--- a/paramak/parametric_shapes/extruded_circle_shape.py
+++ b/paramak/parametric_shapes/extruded_circle_shape.py
@@ -86,6 +86,6 @@ class ExtrudeCircleShape(Shape):
 
         solid = self.rotate_solid(solid)
         calculate_wedge_cut(self)
-        self.perform_boolean_operations(solid)
-
+        solid = self.perform_boolean_operations(solid)
+        self.solid = solid
         return solid

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -111,6 +111,7 @@ class ExtrudeMixedShape(Shape):
 
         solid = self.rotate_solid(solid)
         calculate_wedge_cut(self)
-        self.perform_boolean_operations(solid)
+        solid = self.perform_boolean_operations(solid)
+        self.solid = solid
 
         return solid

--- a/paramak/parametric_shapes/rotate_circle_shape.py
+++ b/paramak/parametric_shapes/rotate_circle_shape.py
@@ -65,7 +65,6 @@ class RotateCircleShape(Shape):
         )
 
         solid = self.rotate_solid(solid)
-
-        self.perform_boolean_operations(solid)
-
+        solid = self.perform_boolean_operations(solid)
+        self.solid = solid
         return solid

--- a/paramak/parametric_shapes/rotate_mixed_shape.py
+++ b/paramak/parametric_shapes/rotate_mixed_shape.py
@@ -86,6 +86,6 @@ class RotateMixedShape(Shape):
         solid = solid.close().revolve(self.rotation_angle)
 
         solid = self.rotate_solid(solid)
-        self.perform_boolean_operations(solid)
+        solid = self.perform_boolean_operations(solid)
 
         return solid

--- a/paramak/parametric_shapes/rotate_mixed_shape.py
+++ b/paramak/parametric_shapes/rotate_mixed_shape.py
@@ -40,7 +40,8 @@ class RotateMixedShape(Shape):
         self._rotation_angle = value
 
     def create_solid(self):
-        """Creates a rotated 3d solid using points with straight and spline edges.
+        """Creates a rotated 3d solid using points with straight and spline
+        edges.
 
            Returns:
               A CadQuery solid: A 3D solid volume
@@ -71,6 +72,7 @@ class RotateMixedShape(Shape):
             instructions[-1][keyname].append(XZ_points[0])
 
         solid = cq.Workplane(self.workplane)
+        solid.moveTo(XZ_points[0][0], XZ_points[0][1])
 
         for entry in instructions:
             if list(entry.keys())[0] == "spline":
@@ -87,5 +89,5 @@ class RotateMixedShape(Shape):
 
         solid = self.rotate_solid(solid)
         solid = self.perform_boolean_operations(solid)
-
+        self.solid = solid
         return solid

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -766,8 +766,6 @@ class Shape:
         if self.union is not None:
             solid = union_solid(solid, self.union)
 
-        self.solid = solid
-
         self.hash_value = self.get_hash()
 
         return solid

--- a/tests/test_parametric_components/test_BlanketCutterParallels.py
+++ b/tests/test_parametric_components/test_BlanketCutterParallels.py
@@ -9,7 +9,7 @@ class test_BlanketCutterParallels(unittest.TestCase):
         and checks that a cadquery solid is created"""
 
         test_shape = paramak.BlanketCutterParallels(
-            distance=50,
+            thickness=50,
             gap_size=200)
 
         assert test_shape.solid is not None
@@ -21,11 +21,11 @@ class test_BlanketCutterParallels(unittest.TestCase):
         """
 
         small_shape = paramak.BlanketCutterParallels(
-            distance=50,
+            thickness=50,
             gap_size=200)
 
         large_shape = paramak.BlanketCutterParallels(
-            distance=100,
+            thickness=100,
             gap_size=200,
         )
 


### PR DESCRIPTION
## Proposed changes

This PR makes some small changes to the new parralel blanket cutters.

- `distance` attribute is replaced by `thickness` to avoid confusion
- instead of having the create_solid method overwritten, the `.cut` attribute is used to cut the central pieces
- ToroidalFieldCoilCoatHanger, ToroidalFieldCoilRectangle refactored
- self.solid = solid is now done in `create_solid` and not in `perform_boolean_operations`
- minor pep8-ing

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

@Shimwell there is one test failing, maybe this is due to the merge of the neutronics branch ?
