### PR TITLE
Variable rotation axis for azimuth_placement_angle

### DIFF
--- a/paramak/parametric_components/inner_tf_coils_circular.py
+++ b/paramak/parametric_components/inner_tf_coils_circular.py
@@ -32,6 +32,7 @@ class InnerTfCoilsCircular(ExtrudeMixedShape):
         stl_filename="InnerTfCoilsCircular.stl",
         material_tag="inner_tf_coil_mat",
         workplane="XY",
+        rotation_axis="Z",
         **kwargs
     ):
 
@@ -41,6 +42,7 @@ class InnerTfCoilsCircular(ExtrudeMixedShape):
             stl_filename=stl_filename,
             material_tag=material_tag,
             workplane=workplane,
+            rotation_axis=rotation_axis,
             **kwargs
         )
 

--- a/paramak/parametric_components/inner_tf_coils_circular.py
+++ b/paramak/parametric_components/inner_tf_coils_circular.py
@@ -18,6 +18,7 @@ class InnerTfCoilsCircular(ExtrudeMixedShape):
         stl_filename (str, optional): defaults to "InnerTfCoilsCircular.stl".
         material_tag (str, optional): defaults to "inner_tf_coil_mat".
         workplane (str, optional): defaults to "XY".
+        rotation_axis (str, optional): Defaults to "Z".
     """
 
     def __init__(

--- a/paramak/parametric_components/inner_tf_coils_flat.py
+++ b/paramak/parametric_components/inner_tf_coils_flat.py
@@ -18,6 +18,7 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
         stl_filename (str, optional): defaults to "InnerTfCoilsFlat.stl".
         material_tag (str, optional): defaults to "inner_tf_coil_mat".
         workplane (str, optional):defaults to "XY".
+        rotation_axis (str, optional): Defaults to "Z".
     """
 
     def __init__(
@@ -32,6 +33,7 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
         stl_filename="InnerTfCoilsFlat.stl",
         material_tag="inner_tf_coil_mat",
         workplane="XY",
+        rotation_axis="Z",
         **kwargs
     ):
 
@@ -41,6 +43,7 @@ class InnerTfCoilsFlat(ExtrudeStraightShape):
             stl_filename=stl_filename,
             material_tag=material_tag,
             workplane=workplane,
+            rotation_axis=rotation_axis,
             **kwargs
         )
 

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -164,6 +164,41 @@ class Shape:
                 value)
 
     @property
+    def rotation_axis(self):
+        return self._rotation_axis
+
+    @rotation_axis.setter
+    def rotation_axis(self, value):
+        if isinstance(value, str):
+            acceptable_values = \
+                ["X", "Y", "Z", "-X", "-Y", "-Z", "+X", "+Y", "+Z"]
+            if value not in acceptable_values:
+                msg = "Shape.rotation_axis must be one of " + \
+                    " ".join(acceptable_values) + \
+                    " not " + value
+                raise ValueError(msg)
+        elif isinstance(value, Iterable):
+            msg = "Shape.rotation_axis must be a list of two (X, Y, Z) floats"
+            if len(value) != 2:
+                raise ValueError(msg)
+            for point in value:
+                if not isinstance(point, tuple):
+                    raise ValueError(msg)
+                if len(point) != 3:
+                    raise ValueError(msg)
+                for val in point:
+                    if not isinstance(val, (int, float)):
+                        raise ValueError(msg)
+
+            if value[0] == value[1]:
+                msg = "The two points must be different"
+                raise ValueError(msg)
+        elif value is not None:
+            msg = "Shape.rotation_axis must be a list or a string or None"
+            raise ValueError(msg)
+        self._rotation_axis = value
+
+    @property
     def volume(self):
         """Get the total volume of the Shape. Returns a float"""
         if isinstance(self.solid, cq.Compound):
@@ -533,7 +568,7 @@ class Shape:
         """Returns the rotation axis for a given shape. If self.rotation_axis
         is None, the rotation axis will be computed from self.workplane (or
         from self.path_workplane if applicable). If self.rotation_axis is an
-        acceptable string (eg. "X", "Y", "-Z"...) then this axis will be used.
+        acceptable string (eg. "X", "+Y", "-Z"...) then this axis will be used.
         If self.rotation_axis is a list of two points, then these two points
         will be used to form an axis.
 
@@ -550,7 +585,7 @@ class Shape:
         }
         if isinstance(self.rotation_axis, str):
             # X, Y or Z axis
-            return rotation_axis[self.rotation_axis]
+            return rotation_axis[self.rotation_axis.replace("+", "")]
         elif isinstance(self.rotation_axis, Iterable):
             # Custom axis
             return self.rotation_axis

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -45,6 +45,11 @@ class Shape:
             Defaults to 0.0.
         workplane (str, optional): the orientation of the Cadquery workplane.
             (XY, YZ or XZ). Defaults to "XZ".
+        rotation_axis (str or list, optional): rotation axis around which the
+            solid is rotated. If None, the rotation axis will depend on the
+            workplane or path_workplane if applicable. Can be set to "X", "-Y",
+            "Z", etc. A custom axis can be set by setting a list of two XYZ
+            floats. Defaults to None.
         tet_mesh (str, optional): If not None, a tet mesh flag will be added to
             the neutronics description output. Defaults to None.
         physical_groups (dict, optional): contains information on physical

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -499,6 +499,33 @@ class test_object_properties(unittest.TestCase):
             shape.path_workplane = wp
             assert shape.get_rotation_axis() == expected_dict[axis]
 
+    def test_rotation_axis_error(self):
+        """Checks errors are raised when incorrect values of rotation_axis are
+        set
+        """
+        incorrect_values = [
+            "coucou",
+            2,
+            2.2,
+            [(1, 1, 1), 'coucou'],
+            [(1, 1, 1), 1],
+            [(1, 1, 1), 1.0],
+            [(1, 1, 1), (1, 1, 1)],
+            [(1, 1, 1), (1, 0, 1, 2)],
+            [(1, 1, 1, 2), (1, 0, 2)],
+            [(1, 1, 2), [1, 0, 2]],
+            [(1, 1, 1)],
+            [(1, 1, 1), (1, 'coucou', 1)],
+            [(1, 1, 1), (1, 0, 1), (1, 2, 3)],
+        ]
+        shape = paramak.Shape()
+
+        def set_value():
+            shape.rotation_axis = incorrect_values[i]
+
+        for i in range(len(incorrect_values)):
+            self.assertRaises(ValueError, set_value)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -462,6 +462,43 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, tet_mesh_int)
         self.assertRaises(ValueError, tet_mesh_list)
 
+    def test_get_rotation_axis(self):
+        """Creates a shape and test the expected rotation_axis is the correct
+        values for several cases
+        """
+        shape = paramak.Shape()
+        expected_dict = {
+            "X": [(-1, 0, 0), (1, 0, 0)],
+            "-X": [(1, 0, 0), (-1, 0, 0)],
+            "Y": [(0, -1, 0), (0, 1, 0)],
+            "-Y": [(0, 1, 0), (0, -1, 0)],
+            "Z": [(0, 0, -1), (0, 0, 1)],
+            "-Z": [(0, 0, 1), (0, 0, -1)],
+        }
+        # test with axis from string
+        for axis in expected_dict:
+            shape.rotation_axis = axis
+            assert shape.get_rotation_axis() == expected_dict[axis]
+
+        # test with axis from list of two points
+        expected_axis = [(-1, -2, -3), (1, 4, 5)]
+        shape.rotation_axis = expected_axis
+        assert shape.get_rotation_axis() == expected_axis
+
+        # test with axis from workplane
+        shape.rotation_axis = None
+
+        workplanes = ["XY", "XZ", "YZ"]
+        expected_axis = ["Y", "Z", "Z"]
+        for wp, axis in zip(workplanes, expected_axis):
+            shape.workplane = wp
+            assert shape.get_rotation_axis() == expected_dict[axis]
+
+        # test with axis from path_workplane
+        for wp, axis in zip(workplanes, expected_axis):
+            shape.path_workplane = wp
+            assert shape.get_rotation_axis() == expected_dict[axis]
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Proposed changes

This PR fixes #312 by making the rotation axis used in `shape.rotate_solid()` variable.
To this end, a new argument/attribute has been added as rotation_axis.
rotation_axis accepts a string in `["X", "Y", "Z", "-X", "-Y", "-Z", "+X", "+Y", "+Z"]`, a list of two points or `None`.

**Usage**
Default behaviour
```python
import paramak

component = paramak.ToroidalFieldCoilTripleArc(
    R1=80,
    h=200,
    radii=(70, 100),
    coverages=(60, 60),
    thickness=30,
    distance=30,
    number_of_coils=3,
    workplane="YZ"
)

component.export_svg("out.svg")
```
![image](https://user-images.githubusercontent.com/40028739/97859851-76c92a80-1d01-11eb-85ef-33e20846f6be.png)

String for rotation_axis
```python
import paramak

component = paramak.ToroidalFieldCoilTripleArc(
    R1=80,
    h=200,
    radii=(70, 100),
    coverages=(60, 60),
    thickness=30,
    distance=30,
    number_of_coils=3,
    workplane="YZ"
)
component.rotation_axis = "X"
component.export_svg("out.svg")
```
![image](https://user-images.githubusercontent.com/40028739/97860005-b4c64e80-1d01-11eb-8dbd-f45780096895.png)

List of two points for rotation_axis
```python
import paramak

component = paramak.ToroidalFieldCoilTripleArc(
    R1=80,
    h=200,
    radii=(70, 100),
    coverages=(60, 60),
    thickness=30,
    distance=30,
    number_of_coils=3,
    workplane="YZ"
)
component.rotation_axis = [(0, 0, 0), (1, 1, 1)]
component.export_svg("out.svg")
```

![image](https://user-images.githubusercontent.com/40028739/97860117-dfb0a280-1d01-11eb-82c5-45f40126dd9d.png)

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
