### PR TITLE
Del summary

### DIFF
--- a/paramak/parametric_neutronics/neutronics_model_from_reactor.py
+++ b/paramak/parametric_neutronics/neutronics_model_from_reactor.py
@@ -394,7 +394,8 @@ class NeutronicsModelFromReactor():
         self.model = openmc.model.Model(geom, self.mats, settings, tallies)
 
     def simulate(self, verbose=True, method=None):
-        """Run the OpenMC simulation.
+        """Run the OpenMC simulation. Deletes exisiting simulation output
+        (summary.h5) if files exists.
 
         Arguments:
             verbose: (Boolean, optional): Print the output from OpenMC (true)
@@ -411,8 +412,10 @@ class NeutronicsModelFromReactor():
         if self.model is None:
             self.create_neutronics_model(method=method)
 
-        # deletes summary.h5m if it already exists
-        os.system('rm summary.h5m')
+        # Deletes summary.h5m if it already exists.
+        # This avoids permission problems when trying to overwrite the file
+        os.system('rm summary.h5')
+
         self.output_filename = self.model.run(output=verbose)
         self.results = self.get_results()
 

--- a/paramak/parametric_neutronics/neutronics_model_from_reactor.py
+++ b/paramak/parametric_neutronics/neutronics_model_from_reactor.py
@@ -410,6 +410,9 @@ class NeutronicsModelFromReactor():
 
         if self.model is None:
             self.create_neutronics_model(method=method)
+
+        # deletes summary.h5m if it already exists
+        os.system('rm summary.h5m')
         self.output_filename = self.model.run(output=verbose)
         self.results = self.get_results()
 


### PR DESCRIPTION
## Proposed changes

This adds a tiny change that automatically deletes the summary.h5 file. This is needed as openmc can fail when it finds an existing summary.h5 file

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

