### PR TITLE
30% speed up of the parametric reactors tests

### DIFF
--- a/paramak/parametric_reactors/single_null_ball_reactor.py
+++ b/paramak/parametric_reactors/single_null_ball_reactor.py
@@ -71,10 +71,6 @@ class SingleNullBallReactor(paramak.BallReactor):
             number_of_tf_coils=number_of_tf_coils,
             **kwargs)
 
-        self.shapes_and_components = []
-
-        self.create_solids()
-
     @property
     def divertor_position(self):
         return self._divertor_position

--- a/paramak/parametric_reactors/single_null_submersion_reactor.py
+++ b/paramak/parametric_reactors/single_null_submersion_reactor.py
@@ -104,10 +104,6 @@ class SingleNullSubmersionTokamak(paramak.SubmersionTokamak):
         self.elongation = None
         self.triangularity = None
 
-        self.shapes_and_components = []
-
-        self.create_solids()
-
     @property
     def divertor_position(self):
         return self._divertor_position

--- a/paramak/parametric_reactors/single_null_submersion_reactor.py
+++ b/paramak/parametric_reactors/single_null_submersion_reactor.py
@@ -99,10 +99,6 @@ class SingleNullSubmersionTokamak(paramak.SubmersionTokamak):
             support_radial_thickness=support_radial_thickness,
             plasma_high_point=plasma_high_point,
             **kwargs)
-        self.major_radius = None
-        self.minor_radius = None
-        self.elongation = None
-        self.triangularity = None
 
     @property
     def divertor_position(self):


### PR DESCRIPTION
## Proposed changes

This PR refactores (a bit) the single null submersion reactor and single null ball reactor by removing the initial calls of create_solids() that is already called in super initialisation.

This method is the bottleneck of the computation time and calling it twice only makes it worse.

This tiny change should decrease the total testing time for these tests by 30% ! (from 20min to 14min !!)

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
