### PR TITLE
added basic area tests

### DIFF
--- a/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
+++ b/paramak/parametric_components/toroidal_field_coil_coat_hanger.py
@@ -65,8 +65,14 @@ class ToroidalFieldCoilCoatHanger(ExtrudeStraightShape):
         self.number_of_coils = number_of_coils
         self.with_inner_leg = with_inner_leg
 
-        self.find_points()
+    @property
+    def azimuth_placement_angle(self):
         self.find_azimuth_placement_angle()
+        return self._azimuth_placement_angle
+
+    @azimuth_placement_angle.setter
+    def azimuth_placement_angle(self, value):
+        self._azimuth_placement_angle = value
 
     def find_points(self):
         """Finds the XZ points joined by straight connections that describe the 2D

--- a/tests/test_parametric_components/test_ToroidalFieldCoilCoatHanger.py
+++ b/tests/test_parametric_components/test_ToroidalFieldCoilCoatHanger.py
@@ -74,6 +74,15 @@ class test_ToroidalFieldCoilCoatHanger(unittest.TestCase):
         assert test_shape.volume == pytest.approx((400 * 50 * 30 * 2) + ((50 * 50 * 30 / 2) * 2) + (
             50 * 500 * 30) + (((150 * 250 * 30) - (((100 * 250) / 2) * 30) - (((100 * 250) / 2) * 30)) * 2))
 
+        test_shape.with_inner_leg = True
+        test_shape.number_of_coils = 8
+        assert test_shape.volume == pytest.approx(((400 * 50 * 30 * 2) + ((50 * 50 * 30 / 2) * 2) + (50 * 500 * 30) + (
+            ((150 * 250 * 30) - (((100 * 250) / 2) * 30) - (((100 * 250) / 2) * 30)) * 2) + (50 * 1000 * 30))*8)
+        
+        test_shape.with_inner_leg = False
+        assert test_shape.volume == pytest.approx(((400 * 50 * 30 * 2) + ((50 * 50 * 30 / 2) * 2) + (
+            50 * 500 * 30) + (((150 * 250 * 30) - (((100 * 250) / 2) * 30) - (((100 * 250) / 2) * 30)) * 2))*8)
+
     def test_ToroidalFieldCoilCoatHanger_absolute_area(self):
         """creates a tf coil using the ToroidalFieldCoilCoatHanger parametric
         component and checks that the areas of the faces are correct"""

--- a/tests/test_parametric_components/test_ToroidalFieldCoilCoatHanger.py
+++ b/tests/test_parametric_components/test_ToroidalFieldCoilCoatHanger.py
@@ -77,11 +77,11 @@ class test_ToroidalFieldCoilCoatHanger(unittest.TestCase):
         test_shape.with_inner_leg = True
         test_shape.number_of_coils = 8
         assert test_shape.volume == pytest.approx(((400 * 50 * 30 * 2) + ((50 * 50 * 30 / 2) * 2) + (50 * 500 * 30) + (
-            ((150 * 250 * 30) - (((100 * 250) / 2) * 30) - (((100 * 250) / 2) * 30)) * 2) + (50 * 1000 * 30))*8)
+            ((150 * 250 * 30) - (((100 * 250) / 2) * 30) - (((100 * 250) / 2) * 30)) * 2) + (50 * 1000 * 30)) * 8)
         
         test_shape.with_inner_leg = False
         assert test_shape.volume == pytest.approx(((400 * 50 * 30 * 2) + ((50 * 50 * 30 / 2) * 2) + (
-            50 * 500 * 30) + (((150 * 250 * 30) - (((100 * 250) / 2) * 30) - (((100 * 250) / 2) * 30)) * 2))*8)
+            50 * 500 * 30) + (((150 * 250 * 30) - (((100 * 250) / 2) * 30) - (((100 * 250) / 2) * 30)) * 2)) * 8 )
 
     def test_ToroidalFieldCoilCoatHanger_absolute_area(self):
         """creates a tf coil using the ToroidalFieldCoilCoatHanger parametric

--- a/tests/test_parametric_components/test_ToroidalFieldCoilPrincetonD.py
+++ b/tests/test_parametric_components/test_ToroidalFieldCoilPrincetonD.py
@@ -55,16 +55,16 @@ class test_ToroidalFieldCoilPrincetonD(unittest.TestCase):
         their relative volumes are correct"""
 
         test_shape_1 = paramak.ToroidalFieldCoilPrincetonD(
-            R1=100, R2=300, thickness=50, distance=50, number_of_coils=1,
+            R1=100, R2=300, thickness=50, distance=30, number_of_coils=4,
             with_inner_leg=True
         )
         test_volume_1 = test_shape_1.volume
 
         test_shape_2 = paramak.ToroidalFieldCoilPrincetonD(
-            R1=100, R2=300, thickness=50, distance=50, number_of_coils=8,
+            R1=100, R2=300, thickness=50, distance=30, number_of_coils=8,
             with_inner_leg=True
         )
-        assert test_shape_2.volume == pytest.approx(test_volume_1 * 8)
+        assert test_shape_2.volume == pytest.approx(test_volume_1 * 2)
 
     def test_ToroidalFieldCoilPrincetonD_rotation_angle(self):
         """Creates a tf coil with a rotation_angle < 360 degrees and checks

--- a/tests/test_parametric_components/test_ToroidalFieldCoilPrincetonD.py
+++ b/tests/test_parametric_components/test_ToroidalFieldCoilPrincetonD.py
@@ -50,6 +50,22 @@ class test_ToroidalFieldCoilPrincetonD(unittest.TestCase):
         assert test_shape_2.volume == pytest.approx(
             test_volume_1 - inner_leg_volume)
 
+    def test_ToroidalFieldCoilPrincetonD_relative_volume(self):
+        """creates tf coil shapes with different numbers of tf coils and checks that
+        their relative volumes are correct"""
+
+        test_shape_1 = paramak.ToroidalFieldCoilPrincetonD(
+            R1=100, R2=300, thickness=50, distance=50, number_of_coils=1,
+            with_inner_leg=True
+        )
+        test_volume_1 = test_shape_1.volume
+
+        test_shape_2 = paramak.ToroidalFieldCoilPrincetonD(
+            R1=100, R2=300, thickness=50, distance=50, number_of_coils=8,
+            with_inner_leg=True
+        )
+        assert test_shape_2.volume == pytest.approx(test_volume_1 * 8)
+
     def test_ToroidalFieldCoilPrincetonD_rotation_angle(self):
         """Creates a tf coil with a rotation_angle < 360 degrees and checks
         that the correct cut is performed and the volume is correct."""

--- a/tests/test_parametric_components/test_ToroidalFieldCoilRectangle.py
+++ b/tests/test_parametric_components/test_ToroidalFieldCoilRectangle.py
@@ -60,15 +60,26 @@ class test_ToroidalFieldCoilRectangle(unittest.TestCase):
             vertical_mid_point=(800, 0),
             thickness=150,
             distance=50,
-            number_of_coils=8
+            number_of_coils=1
         )
 
         assert test_shape.volume == pytest.approx(
-            ((850 * 150 * 50 * 2) + (1400 * 150 * 50 * 2)) * 8)
+            (850 * 150 * 50 * 2) + (1400 * 150 * 50 * 2))
 
         test_shape.with_inner_leg = False
         assert test_shape.volume == pytest.approx(
-            ((850 * 150 * 50 * 2) + (1400 * 150 * 50)) * 8)
+            (850 * 150 * 50 * 2) + (1400 * 150 * 50))
+
+        test_shape.with_inner_leg = True
+        test_shape.number_of_coils = 8
+        assert test_shape.volume == pytest.approx(
+            ((850 * 150 * 50 *2) + (1400 *150 * 50 * 2)) * 8
+        )
+
+        test_shape.with_inner_leg = False
+        assert test_shape.volume == pytest.approx(
+            ((850 * 150 * 50 * 2) + (1400 * 150 * 50)) * 8
+        )
 
     def test_ToroidalFieldCoilRectangle_absolute_areas(self):
         """creates tf coils using the ToroidalFieldCoilRectangle parametric

--- a/tests/test_parametric_components/test_ToroidalFieldCoilTripleArc.py
+++ b/tests/test_parametric_components/test_ToroidalFieldCoilTripleArc.py
@@ -54,6 +54,24 @@ class test_ToroidalFieldCoilTripleArc(unittest.TestCase):
         assert test_shape_2.volume == pytest.approx(
             test_volume_1 - inner_leg_volume)
 
+    def test_ToroidalFieldCoilTripleArc_relative_volume(self):
+        """creates tf coil shapes with different numbers of tf coils and checks that
+        their relative volumes are correct"""
+
+        test_shape_1 = paramak.ToroidalFieldCoilTripleArc(
+            R1=100, h=100, radii=(100, 200), coverages=(10, 60), thickness=10,
+            distance=50, number_of_coils=1, vertical_displacement=10,
+            with_inner_leg=True
+        )
+        test_volume_1 = test_shape_1.volume
+
+        test_shape_2 = paramak.ToroidalFieldCoilTripleArc(
+            R1=100, h=100, radii=(100, 200), coverages=(10, 60), thickness=10,
+            distance=50, number_of_coils=8, vertical_displacement=10,
+            with_inner_leg=True
+        )
+        assert test_shape_2.volume == pytest.approx(test_volume_1 * 8)
+
     def test_ToroidalFieldCoilTripleArc_rotation_angle(self):
         """Creates tf coils with rotation_angles < 360 in different workplanes
         and checks that the correct cuts are performed and their volumes are

--- a/tests/test_parametric_components/test_ToroidalFieldCoilTripleArc.py
+++ b/tests/test_parametric_components/test_ToroidalFieldCoilTripleArc.py
@@ -70,7 +70,7 @@ class test_ToroidalFieldCoilTripleArc(unittest.TestCase):
             distance=50, number_of_coils=8, vertical_displacement=10,
             with_inner_leg=True
         )
-        assert test_shape_2.volume == pytest.approx(test_volume_1 * 8)
+        assert test_shape_2.volume == pytest.approx(test_volume_1 * 8, rel=0.01)
 
     def test_ToroidalFieldCoilTripleArc_rotation_angle(self):
         """Creates tf coils with rotation_angles < 360 in different workplanes

--- a/tests/test_parametric_shapes/test_ExtrudeMixedShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeMixedShape.py
@@ -58,6 +58,26 @@ class test_object_properties(unittest.TestCase):
 
         assert test_shape_1.volume * 4 == pytest.approx(test_shape_2.volume)
 
+    def test_shape_areas(self):
+        """creates an extruded shape using mixed connections and checks that the
+        areas of the faces are expected"""
+
+        test_shape = ExtrudeMixedShape(
+            points=[
+                (50, 0, "straight"),
+                (50, 50, "spline"),
+                (60, 70, "spline"),
+                (70, 50, "circle"),
+                (60, 25, "circle"),
+                (70, 0, "straight")
+            ],
+            extrude_both=False,
+            distance=50
+        )
+
+        assert len(test_shape.areas) == 6
+        assert len(set(test_shape.areas)) == 5
+
     def test_cut_volume(self):
         """creates an extruded shape using straight and spline connections with
         another shape cut out and checks that the volume is correct"""

--- a/tests/test_parametric_shapes/test_ExtrudeSplineShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeSplineShape.py
@@ -19,6 +19,27 @@ class test_object_properties(unittest.TestCase):
         assert test_shape.solid is not None
         assert test_shape.volume > 20 * 20 * 30
 
+    def test_shape_areas(self):
+        """creates an extruded shape using spline connections and checks that the
+        areas of faces are expected"""
+
+        test_shape = ExtrudeSplineShape(
+            points=[
+                (50, 0),
+                (50, 20),
+                (70, 80),
+                (90, 50),
+                (70, 0),
+                (90, -50),
+                (70, -80),
+                (50, -20)
+            ],
+            distance=50
+        )
+
+        assert len(test_shape.areas) == 3
+        assert len(set(test_shape.areas)) == 2
+
     def test_extruded_shape_relative_volume(self):
         """Creates two extruded shapes at different placement angles using
         spline connections and checks that their relative volumes are

--- a/tests/test_parametric_shapes/test_ExtrudeSplineShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeSplineShape.py
@@ -34,7 +34,8 @@ class test_object_properties(unittest.TestCase):
                 (70, -80),
                 (50, -20)
             ],
-            distance=50
+            distance=50,
+            extrude_both=False
         )
 
         assert len(test_shape.areas) == 3

--- a/tests/test_parametric_shapes/test_RotateCircleShape.py
+++ b/tests/test_parametric_shapes/test_RotateCircleShape.py
@@ -36,7 +36,8 @@ class test_object_properties(unittest.TestCase):
         are correct"""
 
         test_shape = RotateCircleShape(
-            points=[(60, 0)], radius=10
+            points=[(60, 0)], 
+            radius=10
         )
 
         test_shape.rotation_angle = 180
@@ -44,15 +45,16 @@ class test_object_properties(unittest.TestCase):
             ((math.pi * (10**2)) * 2) + (math.pi * (10 * 2) * math.pi * (60 * 2) / 2), rel=0.01)
         assert len(test_shape.areas) == 3
         assert test_shape.areas.count(pytest.approx(math.pi * (10**2))) == 2
-        # assert test_shape.areas.count(pytest.approx(
-        #     math.pi * (10 * 2) * math.pi * (60 * 2) * 0.5)) == 1
+        assert test_shape.areas.count(pytest.approx(
+            math.pi * (10*2) * math.pi * (60*2) * 0.5)) == 1
 
-        # test_shape.rotation_angle = 270
-        # assert test_shape.area == pytest.approx(
-        #     math.pi * (10 * 2) * math.pi * (60 * 2) * 0.75, rel=0.01)
-        # assert len(test_shape.areas) == 1
-        # assert test_shape.areas.count(pytest.approx(
-        #     math.pi * (10 * 2) * math.pi * (60 * 2) * 0.75)) == 1
+        test_shape.rotation_angle = 270
+        assert test_shape.area == pytest.approx(
+            (math.pi * (10**2) * 2) + (math.pi * (10 * 2) * math.pi * (60 * 2) * 0.75), rel=0.01)
+        assert len(test_shape.areas) == 3
+        assert test_shape.areas.count(pytest.approx(math.pi * (10**2))) == 2
+        assert test_shape.areas.count(pytest.approx(
+            math.pi * (10 * 2) * math.pi * (60 * 2) * 0.75)) == 1
 
     def test_shape_volume_with_multiple_azimuth_placement_angles(self):
         """creates two rotated shapes at different placement angles using circles and

--- a/tests/test_parametric_shapes/test_RotateMixedShape.py
+++ b/tests/test_parametric_shapes/test_RotateMixedShape.py
@@ -81,6 +81,29 @@ class test_object_properties(unittest.TestCase):
         assert test_shape2.solid is not None
         assert 2 * test_shape2.volume == test_shape.volume
 
+    def test_shape_areas(self):
+        """Creates rotated shapes using mixed connections and checks the
+        areas are expected"""
+
+        test_shape = RotateMixedShape(
+            points=[
+                (50, 0, "straight"),
+                (50, 50, "spline"),
+                (60, 70, "spline"),
+                (70, 50, "circle"),
+                (60, 25, "circle"),
+                (70, 0, "straight")
+            ]
+        )
+        
+        assert len(test_shape.areas) == 4
+        assert len(set(test_shape.areas)) == 4
+
+        test_shape.rotation_angle = 180
+
+        assert len(test_shape.areas) == 6
+        assert len(set(test_shape.areas)) == 5
+
     def test_shape_volume_with_multiple_azimuth_placement_angles(self):
         """Creates rotated shapes at multiple placement angles using mixed
         connections and checks the volumes are correct."""

--- a/tests/test_parametric_shapes/test_RotateSplineShape.py
+++ b/tests/test_parametric_shapes/test_RotateSplineShape.py
@@ -3,7 +3,7 @@ import unittest
 import pytest
 import numpy as np
 
-import paramak
+from paramak import RotateSplineShape
 
 
 class test_object_properties(unittest.TestCase):
@@ -11,11 +11,19 @@ class test_object_properties(unittest.TestCase):
         """creates a rotated shape using spline connections and checks the volume
         is correct"""
 
-        test_shape = paramak.RotateSplineShape(
-            points=[(0, 0), (0, 20), (20, 20), (20, 0)])
-
+        test_shape = RotateSplineShape(
+            points=[
+                (50, 0),
+                (50, 20),
+                (70, 80),
+                (90, 50),
+                (70, 0),
+                (90, -50),
+                (70, -80),
+                (50, -20)
+            ]
+        )
         test_shape.rotation_angle = 360
-        test_shape.create_solid()
 
         assert test_shape.solid is not None
         assert test_shape.volume > 100
@@ -24,15 +32,15 @@ class test_object_properties(unittest.TestCase):
         """creates a rotated shape using spline connections with another shape cut
         out and checks that the volume is correct"""
 
-        inner_shape = paramak.RotateSplineShape(
+        inner_shape = RotateSplineShape(
             points=[(5, 5), (5, 10), (10, 10), (10, 5)], rotation_angle=180
         )
 
-        outer_shape = paramak.RotateSplineShape(
+        outer_shape = RotateSplineShape(
             points=[(3, 3), (3, 12), (12, 12), (12, 3)], rotation_angle=180
         )
 
-        outer_shape_with_cut = paramak.RotateSplineShape(
+        outer_shape_with_cut = RotateSplineShape(
             points=[(3, 3), (3, 12), (12, 12), (12, 3)],
             cut=inner_shape,
             rotation_angle=180,
@@ -43,10 +51,35 @@ class test_object_properties(unittest.TestCase):
         assert outer_shape_with_cut.volume == pytest.approx(
             2881.76 - 900.88, abs=0.2)
 
+    def test_shape_areas(self):
+        """creates rotated shapes using spline connections and checks the
+        areas are expected"""
+
+        test_shape = RotateSplineShape(
+            points=[
+                (50, 0),
+                (50, 20),
+                (70, 80),
+                (90, 50),
+                (70, 0),
+                (90, -50),
+                (70, -80),
+                (50, -20)
+            ]
+        )
+
+        assert len(test_shape.areas) == 1
+        assert len(set(test_shape.areas)) == 1
+
+        test_shape.rotation_angle = 180
+
+        assert len(test_shape.areas) == 3
+        assert len(set(test_shape.areas)) == 2
+
     def test_shape_azimuth_placement_angles_iterabel(self):
         """checks that azimuth_placement_angle can take an Iterable
         """
-        test_shape = paramak.RotateSplineShape(
+        test_shape = RotateSplineShape(
             points=[(200, 100), (200, 200), (500, 200), (500, 100)],
             rotation_angle=20,
             azimuth_placement_angle=[0, 180])
@@ -54,10 +87,10 @@ class test_object_properties(unittest.TestCase):
         assert test_shape.solid is not None
 
     def test_incorrect_color_values(self):
-        """Checks incorrect argument values for paramak.RotateSplineShape"""
+        """Checks incorrect argument values for RotateSplineShape"""
         def test_string_color_value():
-            """Tries to make a paramak.RotateSplineShape is string values for color"""
-            paramak.RotateSplineShape(
+            """Tries to make a RotateSplineShape is string values for color"""
+            RotateSplineShape(
                 points=[(200, 100), (200, 200), (500, 200), (500, 100)],
                 azimuth_placement_angle=np.linspace(0, 90, 2),
                 color=('1', '0', '1')

--- a/tests/test_parametric_shapes/test_RotateSplineShape.py
+++ b/tests/test_parametric_shapes/test_RotateSplineShape.py
@@ -28,6 +28,12 @@ class test_object_properties(unittest.TestCase):
         assert test_shape.solid is not None
         assert test_shape.volume > 100
 
+        test_volume = test_shape.volume
+        test_shape.rotation_angle = 180
+
+        assert test_shape.solid is not None
+        assert test_shape.volume == pytest.approx(test_volume * 0.5)
+
     def test_cut_volume(self):
         """creates a rotated shape using spline connections with another shape cut
         out and checks that the volume is correct"""


### PR DESCRIPTION
## Proposed changes

PR which adds some basic face area tests for some extrude and rotate parametric shapes. Equivalent tests for swept shapes will be added as part of a different PR once sweep construction has been fixed. 
Also fixes ToroidalFieldCoilCoatHanger which did not allow azimuth_placement_angles to be recalculated after initial construction.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
