### PR TITLE
attempt at hash value for reactors

### DIFF
--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -122,8 +122,6 @@ class BallReactor(paramak.Reactor):
 
         self.shapes_and_components = []
 
-        self.create_solids()
-
     @property
     def pf_coil_radial_thicknesses(self):
         return self._pf_coil_radial_thicknesses
@@ -161,7 +159,16 @@ class BallReactor(paramak.Reactor):
         self._make_divertor()
         self._make_component_cuts()
 
-        return self.shapes_and_components
+        print('recalculating all solids in ball reactor')
+
+        return [self._plasma, self._inboard_tf_coils,
+                self._center_column_shield,
+                self._divertor,
+                self._blanket,
+                self._firstwall,
+                self._blanket_rear_wall
+                ]
+        # return self.shapes_and_components
 
     def _rotation_angle_check(self):
 
@@ -182,7 +189,7 @@ class BallReactor(paramak.Reactor):
         )
         plasma.create_solid()
 
-        self.shapes_and_components.append(plasma)
+        # self.shapes_and_components.append(plasma)
 
         self._plasma = plasma
 
@@ -315,7 +322,7 @@ class BallReactor(paramak.Reactor):
             name="inboard_tf_coils",
             material_tag="inboard_tf_coils_mat",
         )
-        self.shapes_and_components.append(self._inboard_tf_coils)
+        # self.shapes_and_components.append(self._inboard_tf_coils)
 
     def _make_center_column_shield(self):
 
@@ -330,7 +337,7 @@ class BallReactor(paramak.Reactor):
             name="center_column_shield",
             material_tag="center_column_shield_mat",
         )
-        self.shapes_and_components.append(self._center_column_shield)
+        # self.shapes_and_components.append(self._center_column_shield)
 
     def _make_blankets_layers(self):
 
@@ -436,7 +443,7 @@ class BallReactor(paramak.Reactor):
             material_tag="divertor_mat",
             rotation_angle=self.rotation_angle
         )
-        self.shapes_and_components.append(self._divertor)
+        # self.shapes_and_components.append(self._divertor)
 
         blanket_cutter = paramak.CenterColumnShieldCylinder(
             height=self._center_column_shield_height * 1.5,  # extra 0.5 to ensure overlap,
@@ -449,9 +456,9 @@ class BallReactor(paramak.Reactor):
         self._blanket.solid = self._blanket.solid.cut(blanket_cutter.solid)
         self._blanket_rear_wall.solid = self._blanket_rear_wall.solid.cut(
             blanket_cutter.solid)
-        self.shapes_and_components.append(self._firstwall)
-        self.shapes_and_components.append(self._blanket)
-        self.shapes_and_components.append(self._blanket_rear_wall)
+        # self.shapes_and_components.append(self._firstwall)
+        # self.shapes_and_components.append(self._blanket)
+        # self.shapes_and_components.append(self._blanket_rear_wall)
 
     def _make_component_cuts(self):
 
@@ -472,7 +479,7 @@ class BallReactor(paramak.Reactor):
                 material_tag="pf_coil_mat",
             )
 
-            self.shapes_and_components.append(self._pf_coil)
+            # self.shapes_and_components.append(self._pf_coil)
 
             if (
                 self.pf_coil_to_tf_coil_radial_gap is not None
@@ -496,4 +503,4 @@ class BallReactor(paramak.Reactor):
                     rotation_angle=self.rotation_angle
                 )
 
-                self.shapes_and_components.append(self._tf_coil)
+                # self.shapes_and_components.append(self._tf_coil)

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -13,6 +13,7 @@ from paramak.shape import Shape
 
 from hashlib import blake2b
 
+
 class Reactor:
     """The Reactor object allows shapes and components to be added and then
     collective operations to be performed on them. Combining all the shapes is
@@ -273,7 +274,7 @@ class Reactor:
         # reactor_s_or_c =[]
         # for s_or_c in self.shapes_and_components:
         #     reactor_s_or_c.append(s_or_c.get_hash)
-        
+
         # shape_or_compound_attributes = str(reactor_s_or_c)
         reactor_attributes = str(list(reactor_dict.values()))
         # all_atributes= (shape_or_compound_attributes + reactor_attributes)


### PR DESCRIPTION
## Proposed changes

I can't quite get the hash value for the reactors to work but making a PR just to show progress. The idea is to remove the call to create_solid() from the parametric reactor init section. The create_solids will then be called when attributes change to avoid unnecessarily recalculating the reactor. At the moment the get_hash is reporting a different value each time even when nothing has changed so the PR is not quite working . I've started with the ball reactor but if this can be made to work then it can be rolled out over all the reactors.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
