### PR TITLE
added new vertical gap parameter to ball reactor

### DIFF
--- a/docs/source/paramak.parametric_reactors.rst
+++ b/docs/source/paramak.parametric_reactors.rst
@@ -6,7 +6,7 @@ These are the current reactor designs that can be created using the Paramak.
 BallReactor()
 ^^^^^^^^^^^^^
 
-.. image:: https://user-images.githubusercontent.com/8583900/89423931-070dc880-d72f-11ea-8cb3-1ce3ce840b7e.png
+.. image:: https://user-images.githubusercontent.com/8583900/98723423-3feeb680-238a-11eb-94b3-a424982f991c.png
    :width: 400
    :align: center
 

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -33,6 +33,9 @@ class BallReactor(paramak.Reactor):
             rear wall of the blanket (cm)
         elongation (float): the elongation of the plasma
         triangularity (float): the triangularity of the plasma
+        plasma_gap_vertical_thickness (float): the vertical thickness of the
+            gap between the plasma and firstwall (cm). If left as None then the
+            outer_plasma_gap_radial_thickness is used. Defaults to None.
         number_of_tf_coils (int, optional): the number of tf coils
         pf_coil_to_rear_blanket_radial_gap (float, optional): the radial
             distance between the rear blanket and the closest poloidal field
@@ -66,6 +69,7 @@ class BallReactor(paramak.Reactor):
         blanket_rear_wall_radial_thickness,
         elongation,
         triangularity,
+        plasma_gap_vertical_thickness=None,
         number_of_tf_coils=12,
         pf_coil_to_rear_blanket_radial_gap=None,
         pf_coil_radial_thicknesses=None,
@@ -96,6 +100,7 @@ class BallReactor(paramak.Reactor):
         self.pf_coil_to_tf_coil_radial_gap = pf_coil_to_tf_coil_radial_gap
         self.outboard_tf_coil_radial_thickness = outboard_tf_coil_radial_thickness
         self.outboard_tf_coil_poloidal_thickness = outboard_tf_coil_poloidal_thickness
+        self.plasma_gap_vertical_thickness = plasma_gap_vertical_thickness
 
         # sets major radius and minor radius from equatorial_points to allow a radial build
         # this helps avoid the plasma overlapping the center column and other
@@ -234,7 +239,8 @@ class BallReactor(paramak.Reactor):
         # this is the vertical build sequence, components build on each other in
         # a similar manner to the radial build
 
-        self.plasma_gap_vertical_thickness = self.outer_plasma_gap_radial_thickness
+        if self.plasma_gap_vertical_thickness == None:
+            self.plasma_gap_vertical_thickness = self.outer_plasma_gap_radial_thickness
 
         self._firstwall_start_height = (
             self._plasma.high_point[1] + self.plasma_gap_vertical_thickness
@@ -260,10 +266,8 @@ class BallReactor(paramak.Reactor):
         ):
             self._number_of_pf_coils = len(self.pf_coil_vertical_thicknesses)
 
-            y_position_step = (
-                2
-                * (
-                    self._blanket_rear_wall_end_height
+            y_position_step = (2 * (
+                self._blanket_rear_wall_end_height
                     + self.pf_coil_to_rear_blanket_radial_gap
                 )
             ) / (self._number_of_pf_coils + 1)


### PR DESCRIPTION
## Proposed changes

While writing the paper I noticed that the vertical aspect of the BallReactor was a little lacking. Therefore I added another parameter called plasma_gap_vertical_thickness which allows the gap to be different to the outer_plasma_gap_radial_thickness.

If left as None then the plasma_gap_vertical_thickness will default to the same as outer_plasma_gap_radial_thickness

As the reactor tests are currently being rearranged on another PR I shall add tests later.

![ball](https://user-images.githubusercontent.com/8583900/98723423-3feeb680-238a-11eb-94b3-a424982f991c.png)


## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
