### PR TITLE
switch magnets from rectangle to coat hanger

### DIFF
--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -238,7 +238,6 @@ class SubmersionTokamak(paramak.Reactor):
                 self._outboard_tf_coil_start_radius +
                 self.outboard_tf_coil_radial_thickness)
 
-
             self._outboard_tf_coils_horizontal_length = self._blanket_rear_wall_end_radius * 0.75
 
         self._pf_info_provided = False


### PR DESCRIPTION
## Proposed changes

The BallReactor and Submersion reactor have the same rectangular magnets and from a distance look very similar. To highlight the different magnet sets available this PR makes use of the recently fixed #474 coat hanger TF coils.

![Screenshot from 2020-11-12 19-54-27](https://user-images.githubusercontent.com/8583900/98989927-b1ad3880-2521-11eb-9603-c6b242bb43f6.png)

ToDo

Update all the images in the docs

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
