### PR TITLE
Allowing floats for casing thicknesses

### DIFF
--- a/paramak/parametric_components/poloidal_field_coil_case_set.py
+++ b/paramak/parametric_components/poloidal_field_coil_case_set.py
@@ -121,48 +121,50 @@ class PoloidalFieldCoilCaseSet(RotateStraightShape):
                 self.heights, self.widths,
                 self.center_points, casing_thicknesses_list):
 
-            all_points = all_points + [
-                (
-                    center_point[0] + width / 2.0,
-                    center_point[1] + height / 2.0,
-                ),  # upper right
-                (
-                    center_point[0] + width / 2.0,
-                    center_point[1] - height / 2.0,
-                ),  # lower right
-                (
-                    center_point[0] - width / 2.0,
-                    center_point[1] - height / 2.0,
-                ),  # lower left
-                (
-                    center_point[0] - width / 2.0,
-                    center_point[1] + height / 2.0,
-                ),  # upper left
-                (
-                    center_point[0] + width / 2.0,
-                    center_point[1] + height / 2.0,
-                ),  # upper right
-                (
-                    center_point[0] + (casing_thickness + width / 2.0),
-                    center_point[1] + (casing_thickness + height / 2.0),
-                ),
-                (
-                    center_point[0] + (casing_thickness + width / 2.0),
-                    center_point[1] - (casing_thickness + height / 2.0),
-                ),
-                (
-                    center_point[0] - (casing_thickness + width / 2.0),
-                    center_point[1] - (casing_thickness + height / 2.0),
-                ),
-                (
-                    center_point[0] - (casing_thickness + width / 2.0),
-                    center_point[1] + (casing_thickness + height / 2.0),
-                ),
-                (
-                    center_point[0] + (casing_thickness + width / 2.0),
-                    center_point[1] + (casing_thickness + height / 2.0),
-                )
-            ]
+            if casing_thickness != 0:
+
+                all_points = all_points + [
+                    (
+                        center_point[0] + width / 2.0,
+                        center_point[1] + height / 2.0,
+                    ),  # upper right
+                    (
+                        center_point[0] + width / 2.0,
+                        center_point[1] - height / 2.0,
+                    ),  # lower right
+                    (
+                        center_point[0] - width / 2.0,
+                        center_point[1] - height / 2.0,
+                    ),  # lower left
+                    (
+                        center_point[0] - width / 2.0,
+                        center_point[1] + height / 2.0,
+                    ),  # upper left
+                    (
+                        center_point[0] + width / 2.0,
+                        center_point[1] + height / 2.0,
+                    ),  # upper right
+                    (
+                        center_point[0] + (casing_thickness + width / 2.0),
+                        center_point[1] + (casing_thickness + height / 2.0),
+                    ),
+                    (
+                        center_point[0] + (casing_thickness + width / 2.0),
+                        center_point[1] - (casing_thickness + height / 2.0),
+                    ),
+                    (
+                        center_point[0] - (casing_thickness + width / 2.0),
+                        center_point[1] - (casing_thickness + height / 2.0),
+                    ),
+                    (
+                        center_point[0] - (casing_thickness + width / 2.0),
+                        center_point[1] + (casing_thickness + height / 2.0),
+                    ),
+                    (
+                        center_point[0] + (casing_thickness + width / 2.0),
+                        center_point[1] + (casing_thickness + height / 2.0),
+                    )
+                ]
 
         self.points = all_points
 

--- a/paramak/parametric_components/poloidal_field_coil_case_set.py
+++ b/paramak/parametric_components/poloidal_field_coil_case_set.py
@@ -110,11 +110,15 @@ class PoloidalFieldCoilCaseSet(RotateStraightShape):
         if isinstance(self.casing_thicknesses, list):
             casing_thicknesses_list = self.casing_thicknesses
         else:
-            casing_thicknesses_list = [self.casing_thicknesses] * len(self.widths)
+            casing_thicknesses_list = [
+                self.casing_thicknesses] * len(self.widths)
 
-        if not len(self.heights) == len(self.widths) == len(self.center_points) == len(casing_thicknesses_list):
+        if not len(
+            self.heights) == len(
+            self.widths) == len(
+                self.center_points) == len(casing_thicknesses_list):
             raise ValueError(
-                "The number of heights, widths, center_points and " \
+                "The number of heights, widths, center_points and "
                 "casing_thicknesses must be equal")
 
         for height, width, center_point, casing_thickness in zip(

--- a/paramak/parametric_components/poloidal_field_coil_case_set.py
+++ b/paramak/parametric_components/poloidal_field_coil_case_set.py
@@ -13,7 +13,10 @@ class PoloidalFieldCoilCaseSet(RotateStraightShape):
             (cm).
         widths (list of floats): the horizontal (x axis) widths of the coil
             (cm).
-        casing_thicknesses (list of floats): the thickness of the casing (cm).
+        casing_thicknesses (float or list of floats): the thicknesses of the
+            coil casing (cm). If float then the same thickness is applied to
+            all coils. If list of floats then each entry is applied to a
+            seperate pf_coil, one entry for each pf_coil.
         center_points (tuple of floats): the center of the coil (x,z) values
             (cm).
         stp_filename (str, optional): defaults to "PoloidalFieldCoil.stp".
@@ -82,15 +85,41 @@ class PoloidalFieldCoilCaseSet(RotateStraightShape):
     def widths(self, widths):
         self._widths = widths
 
+    @property
+    def casing_thicknesses(self):
+        return self._casing_thicknesses
+
+    @casing_thicknesses.setter
+    def casing_thicknesses(self, value):
+        if isinstance(value, list):
+            if not all(isinstance(x, (int, float)) for x in value):
+                raise ValueError(
+                    "Every entry in Casing_thicknesses must be a float or int")
+        else:
+            if not isinstance(value, (float, int)):
+                raise ValueError(
+                    "Casing_thicknesses must be a list of numbers or a number")
+        self._casing_thicknesses = value
+
     def find_points(self):
         """Finds the XZ points joined by straight connections that describe
         the 2D profile of the poloidal field coil shape."""
 
         all_points = []
 
+        if isinstance(self.casing_thicknesses, list):
+            casing_thicknesses_list = self.casing_thicknesses
+        else:
+            casing_thicknesses_list = [self.casing_thicknesses] * len(self.widths)
+
+        if not len(self.heights) == len(self.widths) == len(self.center_points) == len(casing_thicknesses_list):
+            raise ValueError(
+                "The number of heights, widths, center_points and " \
+                "casing_thicknesses must be equal")
+
         for height, width, center_point, casing_thickness in zip(
                 self.heights, self.widths,
-                self.center_points, self.casing_thicknesses):
+                self.center_points, casing_thicknesses_list):
 
             all_points = all_points + [
                 (

--- a/paramak/parametric_components/poloidal_field_coil_case_set_fc.py
+++ b/paramak/parametric_components/poloidal_field_coil_case_set_fc.py
@@ -114,48 +114,50 @@ class PoloidalFieldCoilCaseSetFC(RotateStraightShape):
                 self.heights, self.widths,
                 self.center_points, casing_thicknesses_list):
 
-            all_points = all_points + [
-                (
-                    center_point[0] + width / 2.0,
-                    center_point[1] + height / 2.0,
-                ),  # upper right
-                (
-                    center_point[0] + width / 2.0,
-                    center_point[1] - height / 2.0,
-                ),  # lower right
-                (
-                    center_point[0] - width / 2.0,
-                    center_point[1] - height / 2.0,
-                ),  # lower left
-                (
-                    center_point[0] - width / 2.0,
-                    center_point[1] + height / 2.0,
-                ),  # upper left
-                (
-                    center_point[0] + width / 2.0,
-                    center_point[1] + height / 2.0,
-                ),  # upper right
-                (
-                    center_point[0] + (casing_thickness + width / 2.0),
-                    center_point[1] + (casing_thickness + height / 2.0),
-                ),
-                (
-                    center_point[0] + (casing_thickness + width / 2.0),
-                    center_point[1] - (casing_thickness + height / 2.0),
-                ),
-                (
-                    center_point[0] - (casing_thickness + width / 2.0),
-                    center_point[1] - (casing_thickness + height / 2.0),
-                ),
-                (
-                    center_point[0] - (casing_thickness + width / 2.0),
-                    center_point[1] + (casing_thickness + height / 2.0),
-                ),
-                (
-                    center_point[0] + (casing_thickness + width / 2.0),
-                    center_point[1] + (casing_thickness + height / 2.0),
-                )
-            ]
+            if casing_thickness != 0:
+
+                all_points = all_points + [
+                    (
+                        center_point[0] + width / 2.0,
+                        center_point[1] + height / 2.0,
+                    ),  # upper right
+                    (
+                        center_point[0] + width / 2.0,
+                        center_point[1] - height / 2.0,
+                    ),  # lower right
+                    (
+                        center_point[0] - width / 2.0,
+                        center_point[1] - height / 2.0,
+                    ),  # lower left
+                    (
+                        center_point[0] - width / 2.0,
+                        center_point[1] + height / 2.0,
+                    ),  # upper left
+                    (
+                        center_point[0] + width / 2.0,
+                        center_point[1] + height / 2.0,
+                    ),  # upper right
+                    (
+                        center_point[0] + (casing_thickness + width / 2.0),
+                        center_point[1] + (casing_thickness + height / 2.0),
+                    ),
+                    (
+                        center_point[0] + (casing_thickness + width / 2.0),
+                        center_point[1] - (casing_thickness + height / 2.0),
+                    ),
+                    (
+                        center_point[0] - (casing_thickness + width / 2.0),
+                        center_point[1] - (casing_thickness + height / 2.0),
+                    ),
+                    (
+                        center_point[0] - (casing_thickness + width / 2.0),
+                        center_point[1] + (casing_thickness + height / 2.0),
+                    ),
+                    (
+                        center_point[0] + (casing_thickness + width / 2.0),
+                        center_point[1] + (casing_thickness + height / 2.0),
+                    )
+                ]
 
         self.points = all_points
 

--- a/paramak/parametric_components/poloidal_field_coil_case_set_fc.py
+++ b/paramak/parametric_components/poloidal_field_coil_case_set_fc.py
@@ -89,7 +89,8 @@ class PoloidalFieldCoilCaseSetFC(RotateStraightShape):
         if isinstance(self.pf_coils, list):
             self.heights = [entry.height for entry in self.pf_coils]
             self.widths = [entry.width for entry in self.pf_coils]
-            self.center_points = [entry.center_point for entry in self.pf_coils]
+            self.center_points = [
+                entry.center_point for entry in self.pf_coils]
 
             num_of_coils = len(self.pf_coils)
 
@@ -97,13 +98,13 @@ class PoloidalFieldCoilCaseSetFC(RotateStraightShape):
             self.heights = self.pf_coils.heights
             self.widths = self.pf_coils.widths
             self.center_points = self.pf_coils.center_points
-            
+
             num_of_coils = len(self.pf_coils.solid.Solids())
 
         if isinstance(self.casing_thicknesses, list):
             if len(self.casing_thicknesses) != num_of_coils:
-                raise ValueError("The number pf_coils is not equal to the" \
-                    "number of thichnesses provided")
+                raise ValueError("The number pf_coils is not equal to the"
+                                 "number of thichnesses provided")
             casing_thicknesses_list = self.casing_thicknesses
         else:
             casing_thicknesses_list = [self.casing_thicknesses] * num_of_coils

--- a/tests/test_parametric_components/test_PoloidalFieldCoilCaseSet.py
+++ b/tests/test_parametric_components/test_PoloidalFieldCoilCaseSet.py
@@ -27,6 +27,28 @@ class test_PoloidalFieldCoilCaseSet(unittest.TestCase):
         assert test_shape.solid is not None
         assert len(test_shape.solid.Solids()) == 4
 
+    def test_PoloidalFieldCoilCaseSet_creation_with_zero_thickness(self):
+        """Creates a set of pf coils using the PoloidalFieldCoilCaseSet
+        parametric component and passing a 0 entry into the casing_thicknesses
+        list, and checks that a solid with the correct number of solids is
+        created"""
+
+        test_shape = paramak.PoloidalFieldCoilCaseSet(
+            heights=[10, 10, 20, 20],
+            widths=[10, 10, 20, 40],
+            casing_thicknesses=[5, 0, 10, 10],
+            center_points=[
+                (100, 100),
+                (100, 150),
+                (50, 200),
+                (50, 50)
+            ],
+            rotation_angle=180
+        )
+
+        assert test_shape.solid is not None
+        assert len(test_shape.solid.Solids()) == 3
+
     def test_PoloidalFieldCoilCaseSet_absolute_volume(self):
         """Creates a set of pf coils using the PoloidalFieldCoilCaseSet
         parametric component and checks that the volume is correct"""

--- a/tests/test_parametric_components/test_PoloidalFieldCoilCaseSet.py
+++ b/tests/test_parametric_components/test_PoloidalFieldCoilCaseSet.py
@@ -43,8 +43,11 @@ class test_PoloidalFieldCoilCaseSet(unittest.TestCase):
             ],
         )
 
-        assert test_shape.volume == pytest.approx((((20 * 5 * 2) + (10 * 5 * 2)) * math.pi * 2 * 100) + (((30 * 10 * 2) + (
-            10 * 10 * 2)) * math.pi * 2 * 100) + (((30 * 5 * 2) + (20 * 5 * 2)) * math.pi * 2 * 50) + (((60 * 10 * 2) + (20 * 10 * 2)) * math.pi * 2 * 50))
+        assert test_shape.volume == pytest.approx((((20 * 5 * 2) +
+            (10 * 5 * 2)) * math.pi * 2 * 100) + (((30 * 10 * 2) +
+            (10 * 10 * 2)) * math.pi * 2 * 100) + (((30 * 5 * 2) +
+            (20 * 5 * 2)) * math.pi * 2 * 50) + (((60 * 10 * 2) +
+            (20 * 10 * 2)) * math.pi * 2 * 50))
 
     def test_PoloidalFieldCoilCaseSet_absolute_areas(self):
         """Creates a set of pf coils using the PoloidalFieldCoilCaseSet
@@ -96,3 +99,47 @@ class test_PoloidalFieldCoilCaseSet(unittest.TestCase):
             pytest.approx(20 * math.pi * 2 * 30)) == 1
         assert test_shape.areas.count(
             pytest.approx(40 * math.pi * 2 * 80)) == 1
+
+    def test_PoloidalFieldCoilCaseSet_creation(self):
+        """Creates a set of pf coils using the PoloidalFieldCoilCaseSet
+        parametric component and passing all required args, and checks
+        that a solid with the correct number of solids is created"""
+
+        test_shape = paramak.PoloidalFieldCoilCaseSet(
+            heights=[10, 10, 20, 20],
+            widths=[10, 10, 20, 40],
+            casing_thicknesses=42,
+            center_points=[
+                (100, 100),
+                (100, 150),
+                (50, 200),
+                (50, 50)
+            ],
+            rotation_angle=180
+        )
+
+        assert test_shape.casing_thicknesses == 42
+        assert test_shape.solid is not None
+        assert len(test_shape.solid.Solids()) == 4
+
+    def test_PoloidalFieldCoilCaseSet_incorrect_args(self):
+        """Creates a solid using the PoloidalFieldCoilCaseSet with incorrect
+        args"""
+
+        def test_PoloidalFieldCoilSet_incorrect_lengths_():
+            """Checks PoloidalFieldCoilSet with the wrong number of casing
+            thicknesses (3) using a coil set object with 4 pf_coils."""
+
+            paramak.PoloidalFieldCoilCaseSet(
+                heights=[10, 10, 20, 20],
+                widths=[10, 10, 20, 40],
+                center_points=[(100, 100),
+                               (100, 150),
+                               (50, 200),
+                               (50, 50)],
+                casing_thicknesses=[5, 5, 10],
+                rotation_angle=180).solid
+
+        self.assertRaises(
+            ValueError,
+            test_PoloidalFieldCoilSet_incorrect_lengths_)

--- a/tests/test_parametric_components/test_PoloidalFieldCoilCaseSet.py
+++ b/tests/test_parametric_components/test_PoloidalFieldCoilCaseSet.py
@@ -66,10 +66,10 @@ class test_PoloidalFieldCoilCaseSet(unittest.TestCase):
         )
 
         assert test_shape.volume == pytest.approx((((20 * 5 * 2) +
-            (10 * 5 * 2)) * math.pi * 2 * 100) + (((30 * 10 * 2) +
-            (10 * 10 * 2)) * math.pi * 2 * 100) + (((30 * 5 * 2) +
-            (20 * 5 * 2)) * math.pi * 2 * 50) + (((60 * 10 * 2) +
-            (20 * 10 * 2)) * math.pi * 2 * 50))
+                                                    (10 * 5 * 2)) * math.pi * 2 * 100) + (((30 * 10 * 2) +
+                                                                                           (10 * 10 * 2)) * math.pi * 2 * 100) + (((30 * 5 * 2) +
+                                                                                                                                   (20 * 5 * 2)) * math.pi * 2 * 50) + (((60 * 10 * 2) +
+                                                                                                                                                                         (20 * 10 * 2)) * math.pi * 2 * 50))
 
     def test_PoloidalFieldCoilCaseSet_absolute_areas(self):
         """Creates a set of pf coils using the PoloidalFieldCoilCaseSet

--- a/tests/test_parametric_components/test_PoloidalFieldCoilCaseSetFC.py
+++ b/tests/test_parametric_components/test_PoloidalFieldCoilCaseSetFC.py
@@ -31,6 +31,32 @@ class test_PoloidalFieldCoilCaseSetFC(unittest.TestCase):
         assert len(test_shape.solid.Solids()) == 4
         assert len(pf_coils_set.solid.Solids()) == 4
 
+    def test_PoloidalFieldCoilCaseSetFC_with_zero_thickness(self):
+        """Creates a set of PF coil cases from a PF coils object and sets one
+        of the casing thicknesses to 0"""
+
+        pf_coils_set = paramak.PoloidalFieldCoilSet(
+            heights=[10, 10, 20, 20],
+            widths=[10, 10, 20, 40],
+            center_points=[
+                (100, 100),
+                (100, 150),
+                (50, 200),
+                (50, 50)
+            ],
+            rotation_angle=180
+        )
+
+        test_shape = paramak.PoloidalFieldCoilCaseSetFC(
+            pf_coils=pf_coils_set,
+            casing_thicknesses=[5, 5, 0, 10],
+            rotation_angle=180
+        )
+
+        assert test_shape.solid is not None
+        assert len(test_shape.solid.Solids()) == 3
+        assert len(pf_coils_set.solid.Solids()) == 4
+
     def test_PoloidalFieldCoilCaseSetFC_from_pf_coil_set_absolute_volume(self):
         """Creates a set of pf coil cases from a pf coil set object and checks
         that the volume is correct"""

--- a/tests/test_parametric_components/test_PoloidalFieldCoilCaseSetFC.py
+++ b/tests/test_parametric_components/test_PoloidalFieldCoilCaseSetFC.py
@@ -110,12 +110,12 @@ class test_PoloidalFieldCoilCaseSetFC(unittest.TestCase):
             pytest.approx(40 * math.pi * 2 * 80)) == 1
 
     def test_PoloidalFieldCoilCaseSetFC_incorrect_args(self):
-        """Creates a solid using the PoloidalFieldCoilCaseSetFC with the wrong
-        number of casing_thicknesses."""
+        """Creates a solid using the PoloidalFieldCoilCaseSet with incorrect
+        args"""
 
         def test_PoloidalFieldCoilSet_incorrect_lengths_FC():
             """Checks PoloidalFieldCoilSet with the wrong number of casing
-            thicknesses using a coil set object."""
+            thicknesses (3) using a coil set object with 4 pf_coils."""
 
             pf_coils_set = paramak.PoloidalFieldCoilSet(
                 heights=[10, 10, 20, 20],
@@ -167,7 +167,8 @@ class test_PoloidalFieldCoilCaseSetFC(unittest.TestCase):
             test_PoloidalFieldCoilSet_incorrect_pf_coil)
 
     def test_PoloidalFieldCoilCaseSetFC_from_list(self):
-        """Creates a set of PF coil cases from a list of PF coils."""
+        """Creates a set of PF coil cases from a list of PF coils with a list
+        of thicknesses"""
 
         pf_coils_1 = paramak.PoloidalFieldCoil(height=10,
                                                width=10,
@@ -190,9 +191,44 @@ class test_PoloidalFieldCoilCaseSetFC(unittest.TestCase):
                                                rotation_angle=180)
 
         test_shape = paramak.PoloidalFieldCoilCaseSetFC(
-            pf_coils=[
-                pf_coils_1, pf_coils_2, pf_coils_3, pf_coils_4], casing_thicknesses=[
-                5, 5, 10, 10], rotation_angle=180)
+            pf_coils=[pf_coils_1, pf_coils_2, pf_coils_3, pf_coils_4],
+            casing_thicknesses=[5, 5, 10, 10],
+            rotation_angle=180
+        )
 
+        assert test_shape.solid is not None
+        assert len(test_shape.solid.Solids()) == 4
+
+    def test_PoloidalFieldCoilCaseFC_with_number_thickness(self):
+        """Creates a set of PF coil cases from a list of PF coils with a
+        single numerical thicknesses"""
+
+        pf_coils_1 = paramak.PoloidalFieldCoil(height=10,
+                                               width=10,
+                                               center_point=(100, 100),
+                                               rotation_angle=180)
+
+        pf_coils_2 = paramak.PoloidalFieldCoil(height=10,
+                                               width=10,
+                                               center_point=(100, 150),
+                                               rotation_angle=180)
+
+        pf_coils_3 = paramak.PoloidalFieldCoil(height=20,
+                                               width=20,
+                                               center_point=(50, 200),
+                                               rotation_angle=180)
+
+        pf_coils_4 = paramak.PoloidalFieldCoil(height=20,
+                                               width=40,
+                                               center_point=(50, 50),
+                                               rotation_angle=180)
+
+        test_shape = paramak.PoloidalFieldCoilCaseSetFC(
+            pf_coils=[pf_coils_1, pf_coils_2, pf_coils_3, pf_coils_4],
+            casing_thicknesses=10,
+            rotation_angle=180
+        )
+
+        assert test_shape.casing_thicknesses == 10
         assert test_shape.solid is not None
         assert len(test_shape.solid.Solids()) == 4


### PR DESCRIPTION
## Proposed changes

This small addition allows pf coil case sets to be made with all the same thicknesses. Normally a list was needed for the casing_thickness but now a float is accepted and used as a constant thickness for all cases. 

This was needed so that the reactors can have a default setting of 10 for the case thickness. It  was not possible to use a list for the default setting as the number of coils would not be known.

Hence there will be another PR that adds coil casing to the submersion and the ball reactor

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [x] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
