### PR TITLE
added reactor export_stl error raise test

### DIFF
--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -137,7 +137,7 @@ class test_object_properties(unittest.TestCase):
             my_reactor.export_stp()
 
         self.assertRaises(ValueError, test_stp_filename_duplication)
-    
+
     def test_adding_shape_with_duplicate_stl_filename_to_reactor(self):
         """Adds shapes to a Reactor object to checks errors are raised
         correctly"""
@@ -150,7 +150,7 @@ class test_object_properties(unittest.TestCase):
                 points=[(0, 0), (0, 20), (20, 20)], stl_filename="filename.stl"
             )
             test_shape_2 = paramak.RotateStraightShape(
-                points=[(0, 0), (0, 20), (20, 20)],  stl_filename="filename.stl"
+                points=[(0, 0), (0, 20), (20, 20)], stl_filename="filename.stl"
             )
             test_shape_1.rotation_angle = 90
             my_reactor = paramak.Reactor([test_shape_1, test_shape_2])

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -123,21 +123,40 @@ class test_object_properties(unittest.TestCase):
         correctly."""
 
         def test_stp_filename_duplication():
-            """Checks ValueError is raised when RotateStraightShapes with
-            duplicate stp filenames are added."""
+            """Checks ValueError is raised when shapes with the same stp
+            filenames are added to a reactor object"""
 
-            test_shape = paramak.RotateStraightShape(
+            test_shape_1 = paramak.RotateStraightShape(
                 points=[(0, 0), (0, 20), (20, 20)], stp_filename="filename.stp"
             )
-            test_shape2 = paramak.RotateSplineShape(
+            test_shape_2 = paramak.RotateSplineShape(
                 points=[(0, 0), (0, 20), (20, 20)], stp_filename="filename.stp"
             )
-            test_shape.rotation_angle = 360
-            test_shape.create_solid()
-            my_reactor = paramak.Reactor([test_shape, test_shape2])
+            test_shape_1.rotation_angle = 90
+            my_reactor = paramak.Reactor([test_shape_1, test_shape_2])
             my_reactor.export_stp()
 
         self.assertRaises(ValueError, test_stp_filename_duplication)
+    
+    def test_adding_shape_with_duplicate_stl_filename_to_reactor(self):
+        """Adds shapes to a Reactor object to checks errors are raised
+        correctly"""
+
+        def test_stl_filename_duplication():
+            """Checks ValueError is raised when shapes with the same stl
+            filenames are added to a reactor object"""
+
+            test_shape_1 = paramak.RotateStraightShape(
+                points=[(0, 0), (0, 20), (20, 20)], stl_filename="filename.stl"
+            )
+            test_shape_2 = paramak.RotateStraightShape(
+                points=[(0, 0), (0, 20), (20, 20)],  stl_filename="filename.stl"
+            )
+            test_shape_1.rotation_angle = 90
+            my_reactor = paramak.Reactor([test_shape_1, test_shape_2])
+            my_reactor.export_stl()
+
+        sefl.assertRaises(ValueError, test_stl_filename_duplication)
 
     def test_adding_shape_with_None_stp_filename_to_reactor(self):
         """adds shapes to a Reactor object to check errors are raised correctly"""


### PR DESCRIPTION
## Proposed changes

PR which adds a reactor test to check that an error is raised when shapes with the same stl filename are added to a reactor object, and an stl file of the reactor tries to be exported.
Thanks @Shimwell for the suggestion.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
