### PR TITLE
added build args to dockerfile

### DIFF
--- a/.github/workflows/dockerhub-publish-dev-cd-master.yml
+++ b/.github/workflows/dockerhub-publish-dev-cd-master.yml
@@ -1,0 +1,39 @@
+# This yml file will trigger a Github Action on pushes to the develop branch.
+# This Action will build and upload a Docker image to Dockerhub
+# https://github.com/marketplace/actions/publish-docker
+
+name: dockerhub-publish-dev-cq-master
+
+on:
+  push:
+    branches: migration_to_cq_master
+    branches: develop
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ukaea/paramak:dev-cq-master
+          build-args: |
+            cq_version=master
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,29 @@
-# This docker image is available on dockerhub and can be downloaded using
-# docker pull ukaea/paramak
-# However the docker image can also be build locally with these commands
+# This dockerfile can be built in a few different ways.
 
-# Build with the following command from within the base repository directory
-# sudo docker build -t ukaea/paramak .
+# Building using the latest release version of CadQuery (default).
+# Run command from within the base repository directory
+# docker build -t ukaea/paramak
 
+# Building using master branch version of CadQuery.
 # Run with the following command for terminal access
-# sudo docker run -it ukaea/paramak
+# docker build -t ukaea/paramak --build-arg cq_version=master .
 
-# Run with the following command for jupyter notebook interface
-# sudo docker run -p 8888:8888 ukaea/paramak /bin/bash -c "jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser --allow-root"
+
+# This dockerfile can be run in a few different ways.
+
+# Run with the following command for a jupyter notebook interface
+# docker run -it ukaea/paramak .
+
+# Run with the following command for a jupyter notebook interface
+# docker run -p 8888:8888 ukaea/paramak /bin/bash -c "jupyter notebook --notebook-dir=/examples --ip='*' --port=8888 --no-browser --allow-root"
 
 # test with the folowing command
-# sudo docker run --rm ukaea/paramak pytest /tests
+# docker run --rm ukaea/paramak pytest /tests
 
 FROM continuumio/miniconda3
+
+# By default this Dockerfile builds with the latest release of CadQuery 2
+ARG cq_version=release
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
@@ -25,9 +34,18 @@ RUN apt-get install -y libgl1-mesa-glx libgl1-mesa-dev libglu1-mesa-dev \
                        libgles2-mesa-dev && \
                        apt-get clean
 
-# Set cadquery version to master to fix issue 445
-RUN conda install -c conda-forge -c cadquery cadquery=master && \
-    conda install jupyter -y --quiet && \
+# Installing CadQuery release
+RUN if [ "$cq_version" = "release" ] ; \
+    conda install -c conda-forge -c cadquery cadquery=2 ; \
+    conda install jupyter -y --quiet ; \
+    conda clean -afy
+
+# Installing CadQuery master
+# jupyter is installed before cadquery master version to avoid a conflict
+RUN if [ "$cq_version" = "master" ] ; \
+    conda install jupyter -y --quiet ; \
+    conda clean -afy ; \
+    conda install -c cadquery -c conda-forge cadquery=master ; \
     conda clean -afy
 
 # Copy over the source code


### PR DESCRIPTION
## Proposed changes

This PR adds some build arguments to the dockerfile so that it can be build with cq master or cq latest release

A new github actions file is also added that will automatically build and publish a tag ```ukaea/paramak:dev-cq-master```

Lastest release of cadquery stays as default 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
