### PR TITLE
Fix blanketFP

### DIFF
--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -99,14 +99,14 @@ class BlanketFP(RotateMixedShape):
 
     @start_angle.setter
     def start_angle(self, value):
-        if value is not None:
-            if self.stop_angle is not None:
-                if diff_between_angles(value,
-                                       self.stop_angle) == 0:
-                    if self.rotation_angle == 360:
-                        msg = "Full coverage and 360 rotation will" + \
-                            " result in a standard construction error."
-                        raise ValueError(msg)
+        # if value is not None:
+        #     if self.stop_angle is not None:
+        #         if diff_between_angles(value,
+        #                                self.stop_angle) == 0:
+        #             if self.rotation_angle == 360:
+        #                 msg = "Full coverage and 360 rotation will" + \
+        #                     " result in a standard construction error."
+        #                 raise ValueError(msg)
         self._start_angle = value
 
     @property
@@ -115,14 +115,14 @@ class BlanketFP(RotateMixedShape):
 
     @stop_angle.setter
     def stop_angle(self, value):
-        if value is not None:
-            if self.start_angle is not None:
-                if diff_between_angles(self.start_angle,
-                                       value) == 0:
-                    if self.rotation_angle == 360:
-                        msg = "Full coverage and 360 rotation will" + \
-                            " result in a standard construction error."
-                        raise ValueError(msg)
+        # if value is not None:
+        #     if self.start_angle is not None:
+        #         if diff_between_angles(self.start_angle,
+        #                                value) == 0:
+        #             if self.rotation_angle == 360:
+        #                 msg = "Full coverage and 360 rotation will" + \
+        #                     " result in a standard construction error."
+        #                 raise ValueError(msg)
         self._stop_angle = value
 
     @property

--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -99,14 +99,6 @@ class BlanketFP(RotateMixedShape):
 
     @start_angle.setter
     def start_angle(self, value):
-        # if value is not None:
-        #     if self.stop_angle is not None:
-        #         if diff_between_angles(value,
-        #                                self.stop_angle) == 0:
-        #             if self.rotation_angle == 360:
-        #                 msg = "Full coverage and 360 rotation will" + \
-        #                     " result in a standard construction error."
-        #                 raise ValueError(msg)
         self._start_angle = value
 
     @property
@@ -115,14 +107,6 @@ class BlanketFP(RotateMixedShape):
 
     @stop_angle.setter
     def stop_angle(self, value):
-        # if value is not None:
-        #     if self.start_angle is not None:
-        #         if diff_between_angles(self.start_angle,
-        #                                value) == 0:
-        #             if self.rotation_angle == 360:
-        #                 msg = "Full coverage and 360 rotation will" + \
-        #                     " result in a standard construction error."
-        #                 raise ValueError(msg)
         self._stop_angle = value
 
     @property

--- a/tests/test_parametric_components/test_BlanketFP.py
+++ b/tests/test_parametric_components/test_BlanketFP.py
@@ -68,43 +68,6 @@ class test_BlanketFP(unittest.TestCase):
         assert test_shape.solid is not None
         assert test_shape.volume > 1000
 
-    def test_BlanketFP_full_cov_full_rotation(self):
-        """Checks BlanketFP cannot have full coverage and a rotation_angle of
-        360 degrees at the same time."""
-
-        def create_shape_incorrect_stop_angle():
-            test_shape = paramak.BlanketFP(
-                major_radius=450,
-                minor_radius=150,
-                triangularity=0.55,
-                elongation=2,
-                thickness=150,
-                stop_angle=90,
-                start_angle=45,
-                rotation_angle=360
-            )
-
-            test_shape.start_angle = 0
-            test_shape.stop_angle = 360
-        self.assertRaises(
-            ValueError, create_shape_incorrect_stop_angle)
-
-        def create_shape_incorrect_start_angle():
-            test_shape = paramak.BlanketFP(
-                major_radius=450,
-                minor_radius=150,
-                triangularity=0.55,
-                elongation=2,
-                thickness=150,
-                stop_angle=90,
-                start_angle=45,
-                rotation_angle=360
-            )
-            test_shape.stop_angle = 360
-            test_shape.start_angle = 0
-        self.assertRaises(
-            ValueError, create_shape_incorrect_start_angle)
-
     def test_BlanketFP_creation_variable_thickness_from_tuple(self):
         """Checks that a cadquery solid can be created using the BlanketFP
         parametric component when a tuple of thicknesses is passed as an
@@ -279,3 +242,19 @@ class test_BlanketFP(unittest.TestCase):
         )
 
         test_shape.export_stp("tests/test_blanket_full_cov")
+
+    def test_full_cov_full_rotation(self):
+        """Creates a blanket with full rotation and full coverage
+        """
+        test_shape = paramak.BlanketFP(
+            major_radius=300,
+            minor_radius=50,
+            triangularity=0.5,
+            elongation=2,
+            thickness=200,
+            stop_angle=360,
+            start_angle=0,
+            rotation_angle=360,
+        )
+
+        assert test_shape.solid is not None

--- a/tests/test_parametric_components/test_BlanketFP.py
+++ b/tests/test_parametric_components/test_BlanketFP.py
@@ -146,15 +146,15 @@ class test_BlanketFP(unittest.TestCase):
         argument."""
 
         def thickness(theta):
-            return 100 + 3 * theta
+            return 10 + 0.1 * theta
 
         test_shape = paramak.BlanketFP(
-            major_radius=300,
+            major_radius=200,
             minor_radius=50,
             triangularity=0.5,
             elongation=2,
             thickness=thickness,
-            stop_angle=90,
+            stop_angle=10,
             start_angle=270,
         )
 
@@ -222,7 +222,7 @@ class test_BlanketFP(unittest.TestCase):
         parametric component when an offset function is passed."""
 
         def offset(theta):
-            return 100 + 3 * theta
+            return 10 + 0.1 * theta
 
         test_shape = paramak.BlanketFP(
             major_radius=300,


### PR DESCRIPTION
## Proposed changes

This PR fixes the tests in BlanketFP and is a sub PR of #507 
The tests resulted in a rubbish geometry which didn't failed in the previous version of Cadquery but do in master.

Thanks to the new version of Cadquery, BlanketFP can now have a 360degree rotation and full coverage.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
