### PR TITLE
Fix overlapping BlanketFP

### DIFF
--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -302,7 +302,7 @@ class BlanketFP(RotateMixedShape):
             stop_equals_start = True
 
         # rearrange order
-        # TODO: fix issue #86 (full coverage)
+        new_order = [i for i in range(len(surface_names))]
         if full_rot:
             if not stop_equals_start:
                 # from ["inner", "outer", "inner_section", "outer_section"]

--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 from scipy.interpolate import interp1d
 import sympy as sp
@@ -188,7 +189,7 @@ class BlanketFP(RotateMixedShape):
         return fun
 
     def find_points(self, angles=None):
-
+        self._overlapping_shape = False
         # create array of angles theta
         if angles is None:
             thetas = np.linspace(
@@ -218,6 +219,11 @@ class BlanketFP(RotateMixedShape):
 
         # assemble
         points = inner_points + outer_points
+        if self._overlapping_shape:
+            msg = "BlanketFP: Some points with negative R" + \
+                " coordinate have been ignored."
+            warnings.warn(msg)
+
         self.points = points
         return points
 
@@ -259,8 +265,10 @@ class BlanketFP(RotateMixedShape):
             # calculate outer points
             val_R_outer = self.distribution(theta)[0] + offset(theta) * nx
             val_Z_outer = self.distribution(theta)[1] + offset(theta) * ny
-
-            points.append([float(val_R_outer), float(val_Z_outer), "spline"])
+            if float(val_R_outer) > 0:
+                points.append([float(val_R_outer), float(val_Z_outer), "spline"])
+            else:
+                self._overlapping_shape = True
         return points
 
     def create_physical_groups(self):

--- a/paramak/parametric_components/blanket_fp.py
+++ b/paramak/parametric_components/blanket_fp.py
@@ -266,7 +266,8 @@ class BlanketFP(RotateMixedShape):
             val_R_outer = self.distribution(theta)[0] + offset(theta) * nx
             val_Z_outer = self.distribution(theta)[1] + offset(theta) * ny
             if float(val_R_outer) > 0:
-                points.append([float(val_R_outer), float(val_Z_outer), "spline"])
+                points.append(
+                    [float(val_R_outer), float(val_Z_outer), "spline"])
             else:
                 self._overlapping_shape = True
         return points

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -365,8 +365,8 @@ class BallReactor(paramak.Reactor):
                 self.outer_plasma_gap_radial_thickness,
                 self.plasma_gap_vertical_thickness,
                 self.inner_plasma_gap_radial_thickness],
-            start_angle=-179,
-            stop_angle=179,
+            start_angle=-180,
+            stop_angle=180,
             rotation_angle=self.rotation_angle,
             material_tag="firstwall_mat",
             stp_filename="firstwall.stp",
@@ -388,8 +388,8 @@ class BallReactor(paramak.Reactor):
                 self.firstwall_radial_thickness,
                 self.inner_plasma_gap_radial_thickness +
                 self.firstwall_radial_thickness],
-            start_angle=-179,
-            stop_angle=179,
+            start_angle=-180,
+            stop_angle=180,
             rotation_angle=self.rotation_angle,
             material_tag="blanket_mat",
             stp_filename="blanket.stp",
@@ -415,13 +415,14 @@ class BallReactor(paramak.Reactor):
                 self.inner_plasma_gap_radial_thickness +
                 self.firstwall_radial_thickness +
                 self.blanket_radial_thickness],
-            start_angle=-90,
-            stop_angle=90,
+            start_angle=-180,
+            stop_angle=180,
             rotation_angle=self.rotation_angle,
             material_tag="blanket_rear_wall_mat",
             stp_filename="blanket_rear_wall.stp",
             stl_filename="blanket_rear_wall.stl",
-            cut=center_column_cutter)
+            cut=center_column_cutter,
+            )
 
     def _make_divertor(self):
         list_of_components = []
@@ -441,10 +442,6 @@ class BallReactor(paramak.Reactor):
             stop_angle=180,
             rotation_angle=self.rotation_angle,
         )
-
-        # remove negative points for _blanket_fw_rear_wall_envelope
-        for p in self._blanket_fw_rear_wall_envelope.points:
-            p[0] = max(p[0], 0)
 
         self._divertor = paramak.CenterColumnShieldCylinder(
             height=self._blanket_rear_wall_end_height * 2,

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -388,8 +388,7 @@ class BallReactor(paramak.Reactor):
                 self.firstwall_radial_thickness,
                 self.inner_plasma_gap_radial_thickness +
                 self.firstwall_radial_thickness],
-            start_angle=-
-            179,
+            start_angle=-179,
             stop_angle=179,
             rotation_angle=self.rotation_angle,
             material_tag="blanket_mat",
@@ -416,9 +415,8 @@ class BallReactor(paramak.Reactor):
                 self.inner_plasma_gap_radial_thickness +
                 self.firstwall_radial_thickness +
                 self.blanket_radial_thickness],
-            start_angle=-
-            179,
-            stop_angle=179,
+            start_angle=-90,
+            stop_angle=90,
             rotation_angle=self.rotation_angle,
             material_tag="blanket_rear_wall_mat",
             stp_filename="blanket_rear_wall.stp",
@@ -439,10 +437,14 @@ class BallReactor(paramak.Reactor):
                 self.plasma_gap_vertical_thickness,
                 # self.inner_plasma_gap_radial_thickness],
                 self.major_radius - self.minor_radius],
-            start_angle=-179,
-            stop_angle=179,
+            start_angle=-180,
+            stop_angle=180,
             rotation_angle=self.rotation_angle,
         )
+
+        # remove negative points for _blanket_fw_rear_wall_envelope
+        for p in self._blanket_fw_rear_wall_envelope.points:
+            p[0] = max(p[0], 0)
 
         self._divertor = paramak.CenterColumnShieldCylinder(
             height=self._blanket_rear_wall_end_height * 2,
@@ -450,11 +452,11 @@ class BallReactor(paramak.Reactor):
             outer_radius=self._divertor_end_radius,
             intersect=self._blanket_fw_rear_wall_envelope,
             stp_filename="divertor.stp",
+            stl_filename="divertor.stl",
             name="divertor",
             material_tag="divertor_mat",
             rotation_angle=self.rotation_angle
         )
-        list_of_components.append(self._divertor)
 
         blanket_cutter = paramak.CenterColumnShieldCylinder(
             height=self._center_column_shield_height * 1.5,  # extra 0.5 to ensure overlap,
@@ -467,6 +469,8 @@ class BallReactor(paramak.Reactor):
         self._blanket.solid = self._blanket.solid.cut(blanket_cutter.solid)
         self._blanket_rear_wall.solid = self._blanket_rear_wall.solid.cut(
             blanket_cutter.solid)
+
+        list_of_components.append(self._divertor)
         list_of_components.append(self._firstwall)
         list_of_components.append(self._blanket)
         list_of_components.append(self._blanket_rear_wall)

--- a/paramak/parametric_reactors/single_null_ball_reactor.py
+++ b/paramak/parametric_reactors/single_null_ball_reactor.py
@@ -103,8 +103,8 @@ class SingleNullBallReactor(paramak.BallReactor):
                 self.plasma_gap_vertical_thickness,
                 # self.inner_plasma_gap_radial_thickness],
                 self.major_radius - self.minor_radius],
-            start_angle=-179,
-            stop_angle=179,
+            start_angle=-180,
+            stop_angle=180,
             rotation_angle=self.rotation_angle,
         )
 

--- a/tests/test_parametric_components/test_BlanketFP.py
+++ b/tests/test_parametric_components/test_BlanketFP.py
@@ -276,4 +276,3 @@ class test_BlanketFP(unittest.TestCase):
             warnings.simplefilter("always")
             assert test_shape.solid is not None
             assert len(w) == 1
-

--- a/tests/test_parametric_components/test_BlanketFP.py
+++ b/tests/test_parametric_components/test_BlanketFP.py
@@ -1,6 +1,7 @@
 import os
 import paramak
 import unittest
+import warnings
 
 
 class test_BlanketFP(unittest.TestCase):
@@ -258,3 +259,21 @@ class test_BlanketFP(unittest.TestCase):
         )
 
         assert test_shape.solid is not None
+
+    def test_overlapping(self):
+        """Creates an overlapping geometry and checks that a warning is raised
+        """
+        test_shape = paramak.BlanketFP(
+            major_radius=100,
+            minor_radius=100,
+            triangularity=0.5,
+            elongation=2,
+            thickness=200,
+            stop_angle=360,
+            start_angle=0,
+        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            assert test_shape.solid is not None
+            assert len(w) == 1
+


### PR DESCRIPTION
## Proposed changes

This PR make the BlanketFP component ignore points if the R coordinate is negative. Thus avoiding potential construction errors from occuring.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
