### PR TITLE
offset from plasma consistent accross components

### DIFF
--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -360,11 +360,11 @@ class BallReactor(paramak.Reactor):
             plasma=self._plasma,
             thickness=self.firstwall_radial_thickness,
             offset_from_plasma=[
-                self.inner_plasma_gap_radial_thickness,
+                self.major_radius - self.minor_radius,
                 self.plasma_gap_vertical_thickness,
                 self.outer_plasma_gap_radial_thickness,
                 self.plasma_gap_vertical_thickness,
-                self.inner_plasma_gap_radial_thickness],
+                self.major_radius - self.minor_radius],
             start_angle=-179,
             stop_angle=179,
             rotation_angle=self.rotation_angle,
@@ -378,7 +378,7 @@ class BallReactor(paramak.Reactor):
             plasma=self._plasma,
             thickness=self.blanket_radial_thickness,
             offset_from_plasma=[
-                self.inner_plasma_gap_radial_thickness +
+                self.major_radius - self.minor_radius +
                 self.firstwall_radial_thickness,
                 self.plasma_gap_vertical_thickness +
                 self.firstwall_radial_thickness,
@@ -386,7 +386,7 @@ class BallReactor(paramak.Reactor):
                 self.firstwall_radial_thickness,
                 self.plasma_gap_vertical_thickness +
                 self.firstwall_radial_thickness,
-                self.inner_plasma_gap_radial_thickness +
+                self.major_radius - self.minor_radius +
                 self.firstwall_radial_thickness],
             start_angle=-
             179,
@@ -401,7 +401,7 @@ class BallReactor(paramak.Reactor):
             plasma=self._plasma,
             thickness=self.blanket_rear_wall_radial_thickness,
             offset_from_plasma=[
-                self.inner_plasma_gap_radial_thickness +
+                self.major_radius - self.minor_radius +
                 self.firstwall_radial_thickness +
                 self.blanket_radial_thickness,
                 self.plasma_gap_vertical_thickness +
@@ -413,7 +413,7 @@ class BallReactor(paramak.Reactor):
                 self.plasma_gap_vertical_thickness +
                 self.firstwall_radial_thickness +
                 self.blanket_radial_thickness,
-                self.inner_plasma_gap_radial_thickness +
+                self.major_radius - self.minor_radius +
                 self.firstwall_radial_thickness +
                 self.blanket_radial_thickness],
             start_angle=-


### PR DESCRIPTION
## Proposed changes

This small PR fixes #515 by making the offset from plasma of blanket, first wall and rear wall in BallReactor consistent with that of the divertor.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
