### PR TITLE
Fix extrude shapes

### DIFF
--- a/paramak/parametric_shapes/extruded_circle_shape.py
+++ b/paramak/parametric_shapes/extruded_circle_shape.py
@@ -76,17 +76,21 @@ class ExtrudeCircleShape(Shape):
         :rtype: a cadquery solid
         """
 
-        # Creates a cadquery solid from points and revolves
+        if self.extrude_both == False:
+            extrusion_distance = -self.distance
+        else:
+            extrusion_distance = -self.distance / 2
+
         solid = (
             cq.Workplane(self.workplane)
             .moveTo(self.points[0][0], self.points[0][1])
             .circle(self.radius)
-            .extrude(distance=-self.distance / 2.0, both=self.extrude_both)
+            .extrude(distance=extrusion_distance, both=self.extrude_both)
         )
 
         solid = self.rotate_solid(solid)
         cutting_wedge = calculate_wedge_cut(self)
         solid = self.perform_boolean_operations(solid, wedge_cut=cutting_wedge)
-        self.solid = solid   # not necessarily required as set in boolean_operations
+        self.solid = solid
 
         return solid

--- a/paramak/parametric_shapes/extruded_circle_shape.py
+++ b/paramak/parametric_shapes/extruded_circle_shape.py
@@ -76,7 +76,7 @@ class ExtrudeCircleShape(Shape):
         :rtype: a cadquery solid
         """
 
-        if self.extrude_both == False:
+        if not self.extrude_both:
             extrusion_distance = -self.distance
         else:
             extrusion_distance = -self.distance / 2

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -68,7 +68,7 @@ class ExtrudeMixedShape(Shape):
 
         solid = super().create_solid()
 
-        if self.extrude_both == False:
+        if not self.extrude_both:
             extrusion_distance = -self.distance
         else:
             extrusion_distance = -self.distance / 2

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -68,9 +68,13 @@ class ExtrudeMixedShape(Shape):
 
         solid = super().create_solid()
 
-        # performs extrude in both directions, hence distance / 2
+        if self.extrude_both == False:
+            extrusion_distance = -self.distance
+        else:
+            extrusion_distance = -self.distance / 2
+
         solid = solid.close().extrude(
-            distance=-self.distance / 2.0,
+            distance=extrusion_distance,
             both=self.extrude_both)
 
         solid = self.rotate_solid(solid)

--- a/tests/test_parametric_shapes/test_ExtrudeCircleShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeCircleShape.py
@@ -87,7 +87,8 @@ class test_object_properties(unittest.TestCase):
 
         test_volume_extrude_both = self.test_shape.volume
         self.test_shape.extrude_both = False
-        assert self.test_shape.volume == pytest.approx(test_volume_extrude_both)
+        assert self.test_shape.volume == pytest.approx(
+            test_volume_extrude_both)
 
 
 if __name__ == "__main__":

--- a/tests/test_parametric_shapes/test_ExtrudeCircleShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeCircleShape.py
@@ -85,10 +85,9 @@ class test_object_properties(unittest.TestCase):
         """Creates an ExtrudeCircleShape with extrude_both = True and False and checks
         that the volumes are correct."""
 
-        test_volume_double_extrude = self.test_shape.volume
+        test_volume_extrude_both = self.test_shape.volume
         self.test_shape.extrude_both = False
-        assert self.test_shape.volume == pytest.approx(
-            test_volume_double_extrude * 0.5)
+        assert self.test_shape.volume == pytest.approx(test_volume_extrude_both)
 
 
 if __name__ == "__main__":

--- a/tests/test_parametric_shapes/test_ExtrudeMixedShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeMixedShape.py
@@ -121,25 +121,13 @@ class test_object_properties(unittest.TestCase):
         assert self.test_shape.volume == pytest.approx(
             test_volume * 0.5, rel=0.01)
 
-    # def test_extrude_both(self):
-    #     """test that the volume with extrude_both=True is twice as when
-    #     extrude_both=False
-    #     """
-    #     test_shape = ExtrudeMixedShape(
-    #         points=[
-    #             (10, 20, "straight"),
-    #             (10, 10, "spline"),
-    #             (20, 10, "circle"),
-    #             (22, 15, "circle"),
-    #             (20, 20, "straight"),
-    #         ],
-    #         distance=10,
-    #     )
-    #     test_volume_double_extrude = test_shape.volume
-    #     test_shape.extrude_both = False
+    def test_extrude_both(self):
+        """Creates an ExtrudeMixedShape with extrude_both = True and False and checks
+        that the volumes are correct."""
 
-    #     assert test_shape.volume == \
-    #         pytest.approx(test_volume_double_extrude * 0.5)
+        test_volume_extrude_both = self.test_shape.volume
+        self.test_shape.extrude_both = False
+        assert self.test_shape.volume == pytest.approx(test_volume_extrude_both)
 
 
 if __name__ == "__main__":

--- a/tests/test_parametric_shapes/test_ExtrudeMixedShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeMixedShape.py
@@ -127,7 +127,8 @@ class test_object_properties(unittest.TestCase):
 
         test_volume_extrude_both = self.test_shape.volume
         self.test_shape.extrude_both = False
-        assert self.test_shape.volume == pytest.approx(test_volume_extrude_both)
+        assert self.test_shape.volume == pytest.approx(
+            test_volume_extrude_both)
 
 
 if __name__ == "__main__":

--- a/tests/test_parametric_shapes/test_ExtrudeSplineShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeSplineShape.py
@@ -75,6 +75,14 @@ class test_object_properties(unittest.TestCase):
         assert self.test_shape.volume == pytest.approx(
             test_volume * 0.5, rel=0.01)
 
+    def test_extrude_both(self):
+        """Creates an ExtrudeSplineShape with extrude_both = True and False and checks
+        that the volumes are correct."""
+
+        test_volume_extrude_both = self.test_shape.volume
+        self.test_shape.extrude_both = False
+        assert self.test_shape.volume == pytest.approx(test_volume_extrude_both)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parametric_shapes/test_ExtrudeSplineShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeSplineShape.py
@@ -81,7 +81,8 @@ class test_object_properties(unittest.TestCase):
 
         test_volume_extrude_both = self.test_shape.volume
         self.test_shape.extrude_both = False
-        assert self.test_shape.volume == pytest.approx(test_volume_extrude_both)
+        assert self.test_shape.volume == pytest.approx(
+            test_volume_extrude_both)
 
 
 if __name__ == "__main__":

--- a/tests/test_parametric_shapes/test_ExtrudeStraightShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeStraightShape.py
@@ -89,6 +89,14 @@ class test_object_properties(unittest.TestCase):
         assert self.test_shape.volume == pytest.approx(
             test_volume * 0.5, rel=0.01)
 
+    def test_extrude_both(self):
+        """Creates an ExtrudeStraightShape with extrude_both = True and False and checks
+        that the volumes are correct."""
+
+        test_volume_extrude_both = self.test_shape.volume
+        self.test_shape.extrude_both = False
+        assert self.test_shape.volume == pytest.approx(test_volume_extrude_both)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parametric_shapes/test_ExtrudeStraightShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeStraightShape.py
@@ -95,7 +95,8 @@ class test_object_properties(unittest.TestCase):
 
         test_volume_extrude_both = self.test_shape.volume
         self.test_shape.extrude_both = False
-        assert self.test_shape.volume == pytest.approx(test_volume_extrude_both)
+        assert self.test_shape.volume == pytest.approx(
+            test_volume_extrude_both)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Proposed changes

PR which fixes the extrusion distance for extruded shapes. Previously, distance was divided by 2 for both extrude_both=True and extrude_both=False. For extrude_both = True, this was fine because the shape was extruded by distance/2 in both directions so the total distance was still equal to distance. However, for extrude_both = False, this resulted in a shape with a total distance of distance / 2. This PR fixes this problem. Also adds tests for each extruded shape to test this feature.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

No further comments
