### PR TITLE
Tiny corrections to allow neutronics testing without openmc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@
 # Run command from within the base repository directory
 # docker build -t ukaea/paramak --build-arg include_neutronics=true .
 
+# Building using the master version of CadQuery and MOAB.
+# Run command from within the base repository directory
+# docker build -t ukaea/paramak --build-arg include_neutronics=true --build-arg cq_version=master .
+
 # This dockerfile can be run in a few different ways.
 
 # Run with the following command for a jupyter notebook interface
@@ -103,16 +107,16 @@ RUN if [ "$include_neutronics" = "true" ] ; \
     python setup.py install ; \
     fi
 
-# Copy over the source code
+COPY requirements.txt requirements.txt
+# includes optional dependancies like neutronics_material_maker
+RUN pip install -r requirements.txt
+
+# Copy over the source code, examples and tests
 COPY paramak paramak/
 COPY examples examples/
 COPY setup.py setup.py
-COPY requirements.txt requirements.txt
-COPY README.md README.md
 COPY tests tests/
-
-# includes optional dependancies like neutronics_material_maker
-RUN pip install -r requirements.txt
+COPY README.md README.md
 
 # using setup.py instead of pip due to https://github.com/pypa/pip/issues/5816
 RUN python setup.py install

--- a/examples/example_neutronics_simulations/ball_reactor_minimal.py
+++ b/examples/example_neutronics_simulations/ball_reactor_minimal.py
@@ -35,7 +35,7 @@ def make_model_and_simulate():
             'firstwall_mat': 'eurofer',
             'blanket_rear_wall_mat': 'eurofer',
             'blanket_mat': 'Li4SiO4'},
-        cell_tallies=['TBR', 'heat'],
+        cell_tallies=['TBR', 'heating'],
         simulation_batches=5,
         simulation_particles_per_batch=1e4,
     )

--- a/examples/example_neutronics_simulations/center_column_study_reactor.py
+++ b/examples/example_neutronics_simulations/center_column_study_reactor.py
@@ -45,7 +45,7 @@ def make_model_and_simulate():
                 'divertor_mat': 'eurofer',
                 'firstwall_mat': 'eurofer',
                 'blanket_mat': 'Li4SiO4'},
-            cell_tallies=['heat'],
+            cell_tallies=['heating'],
             simulation_batches=5,
             simulation_particles_per_batch=1e4,
         )
@@ -54,7 +54,7 @@ def make_model_and_simulate():
         neutronics_model.simulate(method='trelis')
 
         # converts the results to mega watts
-        total_heat_in_MW = neutronics_model.results['firstwall_mat_heat']['Watts']['result'] / 1e6
+        total_heat_in_MW = neutronics_model.results['firstwall_mat_heating']['Watts']['result'] / 1e6
 
         # adds the results and inputs to a list
         total_heats_in_MW.append(total_heat_in_MW)

--- a/examples/example_neutronics_simulations/center_column_study_reactor_minimal.py
+++ b/examples/example_neutronics_simulations/center_column_study_reactor_minimal.py
@@ -33,7 +33,7 @@ def make_model_and_simulate():
             'divertor_mat': 'eurofer',
             'firstwall_mat': 'eurofer',
             'blanket_mat': 'Li4SiO4'},
-        cell_tallies=['heat'],
+        cell_tallies=['heating'],
         simulation_batches=5,
         simulation_particles_per_batch=1e4,
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 scipy
 sympy
-cadquery
+# cadquery not installed via pip to avoid installing cadquery version 1
 plotly
 pytest
 numpy
 plasmaboundaries
 matplotlib
-Pillow
+pillow
 neutronics_material_maker

--- a/tests/test_parametric_neutronics/test_NeutronicModelFromReactor.py
+++ b/tests/test_parametric_neutronics/test_NeutronicModelFromReactor.py
@@ -31,7 +31,9 @@ class test_neutronics_BallReactor(unittest.TestCase):
         materials=[
             nmm.Material(
                 'Pb842Li158',
-                enrichment=90,
+                # can't be enriched without openmc installed see issue
+                # https://github.com/ukaea/neutronics_material_maker/issues/105
+                # enrichment=90,
                 temperature_in_K=500),
             nmm.Material('eurofer')
         ])


### PR DESCRIPTION
## Proposed changes

This allows the tests to be run from outside docker, including the one neutronics test we have. The neutronics tests been changed a tiny amount (no more material enrichment) so it does not need openmc as described in https://github.com/ukaea/neutronics_material_maker/issues/105

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
