### PR TITLE
added simple creation tests for port cutter circle and rectangle

### DIFF
--- a/tests/test_parametric_components/test_PortCutterCircular.py
+++ b/tests/test_parametric_components/test_PortCutterCircular.py
@@ -4,8 +4,8 @@ import unittest
 import paramak
 
 
-class test_PortCutterCircular(unittest.TestCase):
-    def test_PortCutterCircular_creation(self):
+class test_component(unittest.TestCase):
+    def test_creation(self):
         """Checks a PortCutterCircular creation."""
 
         test_component = paramak.PortCutterCircular(

--- a/tests/test_parametric_components/test_PortCutterCircular.py
+++ b/tests/test_parametric_components/test_PortCutterCircular.py
@@ -1,0 +1,18 @@
+
+import unittest
+
+import paramak
+
+
+class test_PortCutterCircular(unittest.TestCase):
+    def test_PortCutterCircular_creation(self):
+        """Checks a PortCutterCircular creation."""
+
+        test_component = paramak.PortCutterCircular(
+            distance=3,
+            z_pos=0.25,
+            radius=0.1,
+            azimuth_placement_angle=[0, 45, 90, 180]
+        )
+
+        assert test_component.solid is not None

--- a/tests/test_parametric_components/test_PortCutterRectangular.py
+++ b/tests/test_parametric_components/test_PortCutterRectangular.py
@@ -1,0 +1,20 @@
+
+import unittest
+
+import paramak
+
+
+class test_PortCutterRectangular(unittest.TestCase):
+    def test_PortCutterRectangular_creation(self):
+        """Checks a PortCutterRectangular creation."""
+
+        test_component = paramak.PortCutterRectangular(
+            distance=3,
+            z_pos=0,
+            height=0.2,
+            width=0.4,
+            fillet_radius=0.02,
+            azimuth_placement_angle=[0, 45, 90, 180]
+        )
+
+        assert test_component.solid is not None

--- a/tests/test_parametric_components/test_PortCutterRectangular.py
+++ b/tests/test_parametric_components/test_PortCutterRectangular.py
@@ -4,8 +4,8 @@ import unittest
 import paramak
 
 
-class test_PortCutterRectangular(unittest.TestCase):
-    def test_PortCutterRectangular_creation(self):
+class test_component(unittest.TestCase):
+    def test_creation(self):
         """Checks a PortCutterRectangular creation."""
 
         test_component = paramak.PortCutterRectangular(


### PR DESCRIPTION
## Proposed changes

Some really simple creation tests for a couple of components that didn't have any tests.

Interestingly the port cuttr circle works on CQ 2 but fails on CQ master version, at least over here.



## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
