### PR TITLE
added extrusion_start_offset to extruded shapes

### DIFF
--- a/paramak/parametric_shapes/extruded_circle_shape.py
+++ b/paramak/parametric_shapes/extruded_circle_shape.py
@@ -23,6 +23,7 @@ class ExtrudeCircleShape(Shape):
         self,
         distance,
         radius,
+        extrusion_start_offset=0,
         rotation_angle=360,
         extrude_both=True,
         stp_filename="ExtrudeCircleShape.stp",
@@ -40,6 +41,7 @@ class ExtrudeCircleShape(Shape):
         self.distance = distance
         self.rotation_angle = rotation_angle
         self.extrude_both = extrude_both
+        self.extrusion_start_offset = extrusion_start_offset
 
     @property
     def radius(self):
@@ -65,6 +67,14 @@ class ExtrudeCircleShape(Shape):
     def rotation_angle(self, value):
         self._rotation_angle = value
 
+    @property
+    def extrusion_start_offset(self):
+        return self._extrusion_start_offset
+
+    @extrusion_start_offset.setter
+    def extrusion_start_offset(self, value):
+        self._extrusion_start_offset = value
+
     def create_solid(self):
         """Creates an extruded 3d solid using points connected with circular
         edges.
@@ -73,6 +83,9 @@ class ExtrudeCircleShape(Shape):
         :rtype: a cadquery solid
         """
 
+        # so a positive offset moves extrusion further from axis of azimuthal placement rotation
+        extrusion_offset = -self.extrusion_start_offset
+
         if not self.extrude_both:
             extrusion_distance = -self.distance
         else:
@@ -80,6 +93,7 @@ class ExtrudeCircleShape(Shape):
 
         solid = (
             cq.Workplane(self.workplane)
+            .workplane(offset=extrusion_offset)
             .moveTo(self.points[0][0], self.points[0][1])
             .circle(self.radius)
             .extrude(distance=extrusion_distance, both=self.extrude_both)

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -25,6 +25,7 @@ class ExtrudeMixedShape(Shape):
         distance,
         extrude_both=True,
         rotation_angle=360.0,
+        extrusion_start_offset=0,
         stp_filename="ExtrudeMixedShape.stp",
         stl_filename="ExtrudeMixedShape.stl",
         **kwargs
@@ -38,6 +39,7 @@ class ExtrudeMixedShape(Shape):
         self.distance = distance
         self.extrude_both = extrude_both
         self.rotation_angle = rotation_angle
+        self.extrusion_start_offset = extrusion_start_offset
 
     @property
     def distance(self):
@@ -54,6 +56,14 @@ class ExtrudeMixedShape(Shape):
     @rotation_angle.setter
     def rotation_angle(self, value):
         self._rotation_angle = value
+
+    @property
+    def extrusion_start_offset(self):
+        return self._extrusion_start_offset
+
+    @extrusion_start_offset.setter
+    def extrusion_start_offset(self, value):
+        self._extrusion_start_offset = value
 
     def create_solid(self):
         """Creates an extruded 3d solid using points connected with straight

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -574,6 +574,10 @@ class Shape:
             else:
                 # for rotate and extrude shapes
                 solid = cq.Workplane(self.workplane)
+                # for extrude shapes
+                if hasattr(self, "extrusion_start_offset"):
+                    extrusion_offset = -self.extrusion_start_offset
+                    solid = solid.workplane(offset=extrusion_offset)
 
             for entry in instructions:
                 if list(entry.keys())[0] == "spline":


### PR DESCRIPTION
## Proposed changes

PR which adds an extrusion_start_offset parameter to ExtrudeCircleShape so that the extrusion can be offset in the plane perpendicular to the face. This can be done easily for the ExtrudeCircleShape as the workplane can be offset before the face construction at the parametric_shape level. However, for other extruded shapes, the face is already constructed in super().create_solid() and is not easy to offset afterwards at the parametric_shape level, so the offset will have to be implemented in the base Shape class.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
