### PR TITLE
allowing user to specify cores

### DIFF
--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -13,5 +13,5 @@ jobs:
    - uses: actions/checkout@v1
    - name: Build and test with Docker
      run: |
-       docker build -t paramak --build-arg include_neutronics=true --build-arg cq_version=master .
+       docker build -t paramak --build-arg include_neutronics=true --build-arg cq_version=master --build-arg compile_cores=2 .
        docker run --rm paramak  /bin/bash -c "pytest /tests -v --cov=paramak --cov-append --cov-report term --cov-report html:htmlcov --cov-report xml --junitxml=test-reports/junit.xml && curl -s https://codecov.io/bash | bash"

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@
 # docker run -p 8888:8888 ukaea/paramak /bin/bash -c "jupyter notebook --notebook-dir=/examples --ip='*' --port=8888 --no-browser --allow-root"
 
 
-# Once build the docker image can be tested with the following command
+# Once built, the docker image can be tested with the following command
 # docker run --rm ukaea/paramak pytest /tests
 
 FROM continuumio/miniconda3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,42 @@
 # This dockerfile can be built in a few different ways.
-
-# Building using the latest release version of CadQuery (default)
-# Run command from within the base repository directory
+# Docker build commands must be run from within the base repository directory
+#
+# There are build args availalbe for specifying the:
+# - cq_version
+#   The version of CadQuery to use master or 2. 
+#   Default is 2.
+#   Options: [master, 2]
+#
+# - include_neutronics
+#   If software dependencies needed for neutronics simulations should be
+#   included true or false.
+#   Default is false.
+#   Options: [true, false]
+#
+# - compile_cores
+#   The number of CPU cores to compile the image with.
+#   Default is 1.
+#   Options: [1, 2, 3, 4, 5, 6...]
+#
+# Example builds:
+# Building using the defaults (cq_version 2, no neutronics and 1 core compile)
 # docker build -t ukaea/paramak .
-
-# Building using master branch version of CadQuery.
-# Run with the following command for terminal access
-# docker build -t ukaea/paramak --build-arg cq_version=master .
-
-# Building using the latest release version of CadQuery (default) and MOAB.
+#
+# Building to include neutronics dependencies and using 8 cores.
 # Run command from within the base repository directory
-# docker build -t ukaea/paramak --build-arg include_neutronics=true  --build-arg cq_version=master .
+# docker build -t ukaea/paramak --build-arg include_neutronics=true --build-arg compile_cores=8 .
 
-# Building using the master version of CadQuery and MOAB.
-# Run command from within the base repository directory
-# docker build -t ukaea/paramak --build-arg include_neutronics=true --build-arg cq_version=master .
 
-# This dockerfile can be run in a few different ways.
-
-# Run with the following command for a jupyter notebook interface
+# Once build the dockerimage can be run in a few different ways.
+#
+# Run with the following command for a terminal notebook interface
 # docker run -it ukaea/paramak .
-
+#
 # Run with the following command for a jupyter notebook interface
 # docker run -p 8888:8888 ukaea/paramak /bin/bash -c "jupyter notebook --notebook-dir=/examples --ip='*' --port=8888 --no-browser --allow-root"
 
 
-# test with the folowing command
+# Once build the dockerimage cna be tested with the folowing command
 # docker run --rm ukaea/paramak pytest /tests
 
 FROM continuumio/miniconda3
@@ -33,6 +44,7 @@ FROM continuumio/miniconda3
 # By default this Dockerfile builds with the latest release of CadQuery 2
 ARG cq_version=release
 ARG include_neutronics=false
+ARG compile_cores=1
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
@@ -95,8 +107,8 @@ RUN if [ "$include_neutronics" = "true" ] ; \
                 -DBUILD_SHARED_LIBS=OFF \
                 -DENABLE_FORTRAN=OFF \
                 -DCMAKE_INSTALL_PREFIX=/MOAB ; \
-    make -j2 ; \
-    make -j2  install ; \
+    make -j"$compile_cores" ; \
+    make -j"$compile_cores" install ; \
     rm -rf * ; \
     cmake ../moab -DBUILD_SHARED_LIBS=ON \
                 -DENABLE_HDF5=ON \
@@ -104,8 +116,8 @@ RUN if [ "$include_neutronics" = "true" ] ; \
                 -DENABLE_BLASLAPACK=OFF \
                 -DENABLE_FORTRAN=OFF \
                 -DCMAKE_INSTALL_PREFIX=/MOAB ; \
-    make -j2  ; \
-    make -j2  install ; \
+    make -j"$compile_cores" ; \
+    make -j"$compile_cores" install ; \
     cd pymoab ; \
     bash install.sh ; \
     python setup.py install ; \


### PR DESCRIPTION
## Proposed changes

This small change to the dockerfile allows the use of another --build-arg in the dockerfile

This build arg controls the number of cores the image is built with. 

Compiling with mutliple cores can speed up the MOAB compile step. 

Using -j is an option but sometimes this can result in other applications closing while the compile takes all of the cpu cores. 

Therefore this setting allows the user or config.yml to specify the number of cores used

Also the documentation at the top of the dockerfile has been updated

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
