### PR TITLE
moved graveyard generation out of reactor

### DIFF
--- a/paramak/__init__.py
+++ b/paramak/__init__.py
@@ -69,6 +69,7 @@ from .parametric_components.toroidal_field_coil_princeton_d import ToroidalField
 from .parametric_components.tf_coil_casing import TFCoilCasing
 
 from .parametric_components.vacuum_vessel import VacuumVessel
+from .parametric_components.hollow_cube import HollowCube
 
 from .parametric_reactors.ball_reactor import BallReactor
 from .parametric_reactors.submersion_reactor import SubmersionTokamak

--- a/paramak/parametric_components/hollow_cube.py
+++ b/paramak/parametric_components/hollow_cube.py
@@ -11,7 +11,7 @@ class HollowCube(RotateStraightShape):
     Arguments:
         length (float): The length to use for the height, width, depth of the
             inner dimentions of the cube.
-        thickness (float): thickness of the vessel
+        thickness (float, optional): thickness of the vessel. Defaults to 10.0.
         stp_filename (str, optional): Defaults to "HollowCube.stp".
         stl_filename (str, optional): Defaults to "HollowCube.stl".
         material_tag (str, optional): defaults to "hollow_cube_mat".

--- a/paramak/parametric_components/hollow_cube.py
+++ b/paramak/parametric_components/hollow_cube.py
@@ -1,0 +1,78 @@
+
+import cadquery as cq
+from paramak import RotateStraightShape
+from paramak.utils import get_hash
+
+
+class HollowCube(RotateStraightShape):
+    """A hollow cube with a constant thickness. Can be used to create a DAGMC
+    Graveyard.
+
+    Arguments:
+        length (float): The length to use for the height, width, depth of the
+            inner dimentions of the cube.
+        thickness (float): thickness of the vessel
+        stp_filename (str, optional): Defaults to "HollowCube.stp".
+        stl_filename (str, optional): Defaults to "HollowCube.stl".
+        material_tag (str, optional): defaults to "hollow_cube_mat".
+    """
+
+    def __init__(
+        self,
+        length,
+        thickness=10.,
+        stp_filename="HollowCube.stp",
+        stl_filename="HollowCube.stl",
+        material_tag="hollow_cube_mat",
+        **kwargs
+    ):
+        self.length = length
+        self.thickness = thickness
+        super().__init__(
+            material_tag=material_tag,
+            stp_filename=stp_filename,
+            stl_filename=stl_filename,
+            **kwargs
+        )
+
+    @property
+    def thickness(self):
+        return self._thickness
+
+    @thickness.setter
+    def thickness(self, value):
+        self._thickness = value
+
+    @property
+    def length(self):
+        return self._length
+
+    @length.setter
+    def length(self, value):
+        self._length = value
+
+    def create_solid(self):
+
+        # creates a small box that surrounds the geometry
+        inner_box = cq.Workplane("front").box(
+            self.length,
+            self.length,
+            self.length
+        )
+        
+        # creates a large box that surrounds the smaller box
+        outer_box = cq.Workplane("front").box(
+            self.length + self.thickness,
+            self.length + self.thickness,
+            self.length + self.thickness
+        )
+
+        # subtracts the two boxes to leave a hollow box
+        new_shape = outer_box.cut(inner_box)
+
+        self.solid = new_shape
+
+        # Calculate hash value for current solid
+        self.hash_value = get_hash(self)
+
+        return new_shape

--- a/paramak/parametric_components/hollow_cube.py
+++ b/paramak/parametric_components/hollow_cube.py
@@ -4,7 +4,7 @@ from paramak import RotateStraightShape
 from paramak.utils import get_hash
 
 
-class HollowCube(RotateStraightShape):
+class HollowCube(Shape):
     """A hollow cube with a constant thickness. Can be used to create a DAGMC
     Graveyard.
 

--- a/paramak/parametric_components/hollow_cube.py
+++ b/paramak/parametric_components/hollow_cube.py
@@ -1,6 +1,6 @@
 
 import cadquery as cq
-from paramak import RotateStraightShape
+from paramak import Shape
 from paramak.utils import get_hash
 
 
@@ -71,8 +71,5 @@ class HollowCube(Shape):
         new_shape = outer_box.cut(inner_box)
 
         self.solid = new_shape
-
-        # Calculate hash value for current solid
-        self.hash_value = get_hash(self)
 
         return new_shape

--- a/paramak/parametric_components/hollow_cube.py
+++ b/paramak/parametric_components/hollow_cube.py
@@ -1,7 +1,6 @@
 
 import cadquery as cq
 from paramak import Shape
-from paramak.utils import get_hash
 
 
 class HollowCube(Shape):

--- a/paramak/parametric_neutronics/neutronics_model_from_reactor.py
+++ b/paramak/parametric_neutronics/neutronics_model_from_reactor.py
@@ -439,23 +439,20 @@ class NeutronicsModelFromReactor():
         if self.mesh_tally_2D is not None:
 
             # Create mesh which will be used for tally
-            mesh_width = self.mesh_2D_resolution[1]
-            mesh_height = self.mesh_2D_resolution[0]
-
             mesh_xz = openmc.RegularMesh()
-            mesh_xz.dimension = [mesh_width, 1, mesh_height]
-            mesh_xz.lower_left = [-1200, -1, -1200]
-            mesh_xz.upper_right = [1200, 1, 1200]
+            mesh_xz.dimension = [self.mesh_2D_resolution[1], 1, self.mesh_2D_resolution[0]]
+            mesh_xz.lower_left = [-self.reactor.largest_dimension, -1, -self.reactor.largest_dimension]
+            mesh_xz.upper_right = [self.reactor.largest_dimension, 1, self.reactor.largest_dimension]
 
             mesh_xy = openmc.RegularMesh()
-            mesh_xy.dimension = [mesh_width, mesh_height, 1]
-            mesh_xy.lower_left = [-1200, -1200, -1]
-            mesh_xy.upper_right = [1200, 1200, 1]
+            mesh_xy.dimension = [self.mesh_2D_resolution[1], self.mesh_2D_resolution[0], 1]
+            mesh_xy.lower_left = [-self.reactor.largest_dimension, -self.reactor.largest_dimension, -1]
+            mesh_xy.upper_right = [self.reactor.largest_dimension, self.reactor.largest_dimension, 1]
 
             mesh_yz = openmc.RegularMesh()
-            mesh_yz.dimension = [1, mesh_width, mesh_height]
-            mesh_yz.lower_left = [-1, -1200, -1200]
-            mesh_yz.upper_right = [1, 1200, 1200]
+            mesh_yz.dimension = [1, self.mesh_2D_resolution[1], self.mesh_2D_resolution[0]]
+            mesh_yz.lower_left = [-1, -self.reactor.largest_dimension, -self.reactor.largest_dimension]
+            mesh_yz.upper_right = [1, self.reactor.largest_dimension, self.reactor.largest_dimension]
 
             if 'tritium_production' in self.mesh_tally_2D:
                 mesh_filter = openmc.MeshFilter(mesh_xz)

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -64,6 +64,21 @@ class Reactor:
         self._stl_filenames = value
 
     @property
+    def largest_dimension(self):
+        """Calculates a bounding box for the Reactor and returns the largest
+        absolute value of the largest dimension of the bounding box"""
+        largest_dimension = 0
+        for component in self.shapes_and_components:
+            print(component.stp_filename, component.largest_dimension)
+            largest_dimension = max(largest_dimension, component.largest_dimension)
+        self._largest_dimension = largest_dimension
+        return largest_dimension
+
+    @largest_dimension.setter
+    def largest_dimension(self, value):
+        self._largest_dimension = value
+
+    @property
     def material_tags(self):
         """Returns a set of all the materials_tags used in the Reactor
         (excluding the plasma)"""
@@ -574,14 +589,8 @@ class Reactor:
             if component.solid is None:
                 component.create_solid()
 
-        # finds the largest dimenton in all the Shapes that are in the reactor
-        largest_dimension = 0
-        for component in self.shapes_and_components:
-            print(component.stp_filename, component.largest_dimension)
-            largest_dimension = max(largest_dimension, component.largest_dimension)
-
         graveyard_shape = paramak.HollowCube(
-            length = largest_dimension * 2 + graveyard_offset * 2,
+            length = self.largest_dimension * 2 + graveyard_offset * 2,
             name = "Graveyard",
             material_tag = "Graveyard",
             stp_filename = "Graveyard.stp",

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -577,57 +577,16 @@ class Reactor:
         # finds the largest dimenton in all the Shapes that are in the reactor
         largest_dimension = 0
         for component in self.shapes_and_components:
+            print(component.stp_filename, component.largest_dimension)
+            largest_dimension = max(largest_dimension, component.largest_dimension)
 
-            if isinstance(component.solid, cq.Compound):
-                for solid in component.solid.Solids():
-                    largest_dimension = max(
-                        abs(solid.BoundingBox().xmax),
-                        abs(solid.BoundingBox().xmin),
-                        abs(solid.BoundingBox().ymax),
-                        abs(solid.BoundingBox().ymin),
-                        abs(solid.BoundingBox().zmax),
-                        abs(solid.BoundingBox().zmin),
-                        largest_dimension
-                    )
-            else:
-                largest_dimension = max(
-                    abs(component.solid.val().BoundingBox().xmax),
-                    abs(component.solid.val().BoundingBox().xmin),
-                    abs(component.solid.val().BoundingBox().ymax),
-                    abs(component.solid.val().BoundingBox().ymin),
-                    abs(component.solid.val().BoundingBox().zmax),
-                    abs(component.solid.val().BoundingBox().zmin),
-                    largest_dimension
-                )
-
-        largest_dimension = largest_dimension * 2
-
-        graveyard_offset = graveyard_offset * 2
-
-        # creates a small box that surrounds the geometry
-        inner_box = cq.Workplane("front").box(
-            largest_dimension + graveyard_offset,
-            largest_dimension + graveyard_offset,
-            largest_dimension + graveyard_offset
+        graveyard_shape = paramak.HollowCube(
+            length = largest_dimension * 2 + graveyard_offset * 2,
+            name = "Graveyard",
+            material_tag = "Graveyard",
+            stp_filename = "Graveyard.stp",
+            stl_filename = "Graveyard.stl",
         )
-
-        graveyard_thickness = 10
-        # creates a large box that surrounds the smaller box
-        outer_box = cq.Workplane("front").box(
-            largest_dimension + graveyard_offset + graveyard_thickness,
-            largest_dimension + graveyard_offset + graveyard_thickness,
-            largest_dimension + graveyard_offset + graveyard_thickness
-        )
-
-        # subtracts the two boxes to leave a hollow box
-        graveyard_part = outer_box.cut(inner_box)
-
-        graveyard_shape = Shape()
-        graveyard_shape.name = "Graveyard"
-        graveyard_shape.material_tag = "Graveyard"
-        graveyard_shape.stp_filename = "Graveyard.stp"
-        graveyard_shape.stl_filename = "Graveyard.stl"
-        graveyard_shape.solid = graveyard_part
 
         self.graveyard = graveyard_shape
 

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -184,7 +184,7 @@ class Shape:
                 abs(self.solid.val().BoundingBox().zmin),
                 largest_dimension
             )
-        self._largest_dimension = largest_dimension
+        self.largest_dimension = largest_dimension
         return largest_dimension
 
     @largest_dimension.setter

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -166,22 +166,22 @@ class Shape:
         if isinstance(self.solid, cq.Compound):
             for solid in self.solid.Solids():
                 largest_dimension = max(
-                    abs(solid.BoundingBox().xmax),
-                    abs(solid.BoundingBox().xmin),
-                    abs(solid.BoundingBox().ymax),
-                    abs(solid.BoundingBox().ymin),
-                    abs(solid.BoundingBox().zmax),
-                    abs(solid.BoundingBox().zmin),
+                    abs(self.solid.BoundingBox().xmax),
+                    abs(self.solid.BoundingBox().xmin),
+                    abs(self.solid.BoundingBox().ymax),
+                    abs(self.solid.BoundingBox().ymin),
+                    abs(self.solid.BoundingBox().zmax),
+                    abs(self.solid.BoundingBox().zmin),
                     largest_dimension
                 )
         else:
             largest_dimension = max(
-                abs(solid.val().BoundingBox().xmax),
-                abs(solid.val().BoundingBox().xmin),
-                abs(solid.val().BoundingBox().ymax),
-                abs(solid.val().BoundingBox().ymin),
-                abs(solid.val().BoundingBox().zmax),
-                abs(solid.val().BoundingBox().zmin),
+                abs(self.solid.val().BoundingBox().xmax),
+                abs(self.solid.val().BoundingBox().xmin),
+                abs(self.solid.val().BoundingBox().ymax),
+                abs(self.solid.val().BoundingBox().ymin),
+                abs(self.solid.val().BoundingBox().zmax),
+                abs(self.solid.val().BoundingBox().zmin),
                 largest_dimension
             )
         self._largest_dimension = largest_dimension

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -159,6 +159,40 @@ class Shape:
         self._union = value
 
     @property
+    def largest_dimension(self):
+
+        """Calculates a bounding box for the Shape and returns the largest
+        absolute value of the largest dimension of the bounding box"""
+        largest_dimension = 0
+        if isinstance(self.solid, cq.Compound):
+            for solid in self.solid.Solids():
+                largest_dimension = max(
+                    abs(self.solid.BoundingBox().xmax),
+                    abs(self.solid.BoundingBox().xmin),
+                    abs(self.solid.BoundingBox().ymax),
+                    abs(self.solid.BoundingBox().ymin),
+                    abs(self.solid.BoundingBox().zmax),
+                    abs(self.solid.BoundingBox().zmin),
+                    largest_dimension
+                )
+        else:
+            largest_dimension = max(
+                abs(self.solid.val().BoundingBox().xmax),
+                abs(self.solid.val().BoundingBox().xmin),
+                abs(self.solid.val().BoundingBox().ymax),
+                abs(self.solid.val().BoundingBox().ymin),
+                abs(self.solid.val().BoundingBox().zmax),
+                abs(self.solid.val().BoundingBox().zmin),
+                largest_dimension
+            )
+        self._largest_dimension = largest_dimension
+        return largest_dimension
+
+    @largest_dimension.setter
+    def largest_dimension(self, value):
+        self._largest_dimension = value
+
+    @property
     def workplane(self):
         return self._workplane
 
@@ -788,6 +822,7 @@ class Shape:
         print("Saved file as ", path_filename)
 
         return str(path_filename)
+
 
     def export_html(self, filename):
         """Creates a html graph representation of the points and connections

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -166,22 +166,22 @@ class Shape:
         if isinstance(self.solid, cq.Compound):
             for solid in self.solid.Solids():
                 largest_dimension = max(
-                    abs(self.solid.BoundingBox().xmax),
-                    abs(self.solid.BoundingBox().xmin),
-                    abs(self.solid.BoundingBox().ymax),
-                    abs(self.solid.BoundingBox().ymin),
-                    abs(self.solid.BoundingBox().zmax),
-                    abs(self.solid.BoundingBox().zmin),
+                    abs(solid.BoundingBox().xmax),
+                    abs(solid.BoundingBox().xmin),
+                    abs(solid.BoundingBox().ymax),
+                    abs(solid.BoundingBox().ymin),
+                    abs(solid.BoundingBox().zmax),
+                    abs(solid.BoundingBox().zmin),
                     largest_dimension
                 )
         else:
             largest_dimension = max(
-                abs(self.solid.val().BoundingBox().xmax),
-                abs(self.solid.val().BoundingBox().xmin),
-                abs(self.solid.val().BoundingBox().ymax),
-                abs(self.solid.val().BoundingBox().ymin),
-                abs(self.solid.val().BoundingBox().zmax),
-                abs(self.solid.val().BoundingBox().zmin),
+                abs(solid.val().BoundingBox().xmax),
+                abs(solid.val().BoundingBox().xmin),
+                abs(solid.val().BoundingBox().ymax),
+                abs(solid.val().BoundingBox().ymin),
+                abs(solid.val().BoundingBox().zmax),
+                abs(solid.val().BoundingBox().zmin),
                 largest_dimension
             )
         self._largest_dimension = largest_dimension

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -770,12 +770,24 @@ class test_object_properties(unittest.TestCase):
         test_reactor = paramak.Reactor([test_shape])
         assert test_reactor.tet_meshes is not None
 
+    def test_largest_dimention(self):
+        test_shape = paramak.RotateStraightShape(
+            points=[(0, 0), (0, 20), (20, 20)])
+        test_shape.rotation_angle = 360
+        test_reactor = paramak.Reactor([test_shape])
+        assert test_reactor.largest_dimension == 20
+        test_shape = paramak.RotateStraightShape(
+            points=[(0, 0), (0, 20), (30, 20)])
+        test_shape.rotation_angle = 360
+        test_reactor = paramak.Reactor([test_shape])
+        assert test_reactor.largest_dimension == 30
+
     def test_shapes_and_components(self):
         test_shape = paramak.RotateStraightShape(
             points=[(0, 0), (0, 20), (20, 20)])
 
         def incorrect_shapes_and_components():
-            test_reactor = paramak.Reactor(test_shape)
+            paramak.Reactor(test_shape)
         self.assertRaises(ValueError, incorrect_shapes_and_components)
 
     def test_graveyard_error(self):

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -432,7 +432,7 @@ class test_object_properties(unittest.TestCase):
             os.system("rm " + filepath)
 
         assert test_reactor.graveyard is not None
-        assert test_reactor.graveyard.__class__.__name__ == "Shape"
+        assert test_reactor.graveyard.__class__.__name__ == "HollowCube"
 
     def test_export_graveyard_offset(self):
         """checks that the graveyard can be exported with the correct default parameters

--- a/tests/test_parametric_shapes/test_RotateStraightShape.py
+++ b/tests/test_parametric_shapes/test_RotateStraightShape.py
@@ -15,6 +15,11 @@ class test_object_properties(unittest.TestCase):
             points=[(0, 0), (0, 20), (20, 20), (20, 0)]
         )
 
+    def test_largest_dimension(self):
+        """Checks that the largest_dimension is correct."""
+
+        assert self.test_shape.largest_dimension == 20
+
     def test_default_parameters(self):
         """Checks that the default parameters of a RotateStraightShape are correct."""
 


### PR DESCRIPTION
## Proposed changes

This PR moves some of the graveyard creation from Reactor

the largest_dimension has been moved into the attributes of of Shape objects
the 3d hollow cube creation has been moved into a new parametric component called HollowCube.

This is useful as the the Shape objects will need their own Graveyard bounding box if we want to do neutronics simulations on the Shapes.

@billingsley-john  I think the inclusion of a Dagmc Graveyard for Shape objects will now be easier as the useful code is now in more accessable places in the code

This solves #586

Also the largest_dimention attribute can be used to determine 3D and 2D mesh tallies sizes in the neutronics simulations


## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
