### PR TITLE
removed get_hash

### DIFF
--- a/paramak/parametric_components/poloidal_field_coil_case_set.py
+++ b/paramak/parametric_components/poloidal_field_coil_case_set.py
@@ -1,7 +1,6 @@
 
 import cadquery as cq
 from paramak import RotateStraightShape
-from paramak.utils import get_hash
 
 
 class PoloidalFieldCoilCaseSet(RotateStraightShape):
@@ -49,16 +48,6 @@ class PoloidalFieldCoilCaseSet(RotateStraightShape):
         self.heights = heights
         self.widths = widths
         self.casing_thicknesses = casing_thicknesses
-
-    @property
-    def solid(self):
-        if get_hash(self) != self.hash_value:
-            self.create_solid()
-        return self._solid
-
-    @solid.setter
-    def solid(self, value):
-        self._solid = value
 
     @property
     def center_points(self):
@@ -201,8 +190,5 @@ class PoloidalFieldCoilCaseSet(RotateStraightShape):
         )
 
         self.solid = compound
-
-        # Calculate hash value for current solid
-        self.hash_value = get_hash(self)
 
         return compound

--- a/paramak/parametric_components/poloidal_field_coil_case_set_fc.py
+++ b/paramak/parametric_components/poloidal_field_coil_case_set_fc.py
@@ -1,7 +1,6 @@
 
 import cadquery as cq
 from paramak import PoloidalFieldCoilSet, RotateStraightShape
-from paramak.utils import get_hash
 
 
 class PoloidalFieldCoilCaseSetFC(RotateStraightShape):
@@ -41,16 +40,6 @@ class PoloidalFieldCoilCaseSetFC(RotateStraightShape):
 
         self.casing_thicknesses = casing_thicknesses
         self.pf_coils = pf_coils
-
-    @property
-    def solid(self):
-        if get_hash(self) != self.hash_value:
-            self.create_solid()
-        return self._solid
-
-    @solid.setter
-    def solid(self, value):
-        self._solid = value
 
     @property
     def casing_thicknesses(self):
@@ -193,8 +182,5 @@ class PoloidalFieldCoilCaseSetFC(RotateStraightShape):
         )
 
         self.solid = compound
-
-        # Calculate hash value for current solid
-        self.hash_value = get_hash(self)
 
         return compound

--- a/paramak/parametric_components/poloidal_field_coil_set.py
+++ b/paramak/parametric_components/poloidal_field_coil_set.py
@@ -1,7 +1,6 @@
 
 import cadquery as cq
 from paramak import RotateStraightShape
-from paramak.utils import get_hash
 
 
 class PoloidalFieldCoilSet(RotateStraightShape):
@@ -51,18 +50,6 @@ class PoloidalFieldCoilSet(RotateStraightShape):
                 self.center_points):
             raise ValueError("The length of widthts, height and center_points \
                 must be the same when making a PoloidalFieldCoilSet")
-
-    @property
-    def solid(self):
-        """Returns a CadQuery compound object consisting of 1 or more 3d
-        volumes"""
-        if get_hash(self) != self.hash_value:
-            self.create_solid()
-        return self._solid
-
-    @solid.setter
-    def solid(self, value):
-        self._solid = value
 
     @property
     def center_points(self):
@@ -153,8 +140,5 @@ class PoloidalFieldCoilSet(RotateStraightShape):
         )
 
         self.solid = compound
-
-        # Calculate hash value for current solid
-        self.hash_value = get_hash(self)
 
         return compound

--- a/paramak/parametric_components/poloidal_segmenter.py
+++ b/paramak/parametric_components/poloidal_segmenter.py
@@ -92,16 +92,6 @@ class PoloidalSegments(RotateStraightShape):
     def max_distance_from_center(self, value):
         self._max_distance_from_center = value
 
-    @property
-    def solid(self):
-        if get_hash(self) != self.hash_value:
-            self.create_solid()
-        return self._solid
-
-    @solid.setter
-    def solid(self, value):
-        self._solid = value
-
     def find_points(self):
         """Finds the XZ points joined by straight connections that describe
         the 2D profile of the poloidal segmentation shape."""
@@ -184,7 +174,5 @@ class PoloidalSegments(RotateStraightShape):
             )
 
         self.solid = compound
-
-        self.hash_value = get_hash(self)
 
         return compound

--- a/paramak/parametric_components/port_cutters_rotated.py
+++ b/paramak/parametric_components/port_cutters_rotated.py
@@ -2,7 +2,7 @@
 import math
 
 from paramak import RotateStraightShape
-from paramak.utils import coefficients_of_line_from_points, get_hash, rotate
+from paramak.utils import coefficients_of_line_from_points, rotate
 
 
 class PortCutterRotated(RotateStraightShape):
@@ -87,16 +87,6 @@ class PortCutterRotated(RotateStraightShape):
     @max_distance_from_center.setter
     def max_distance_from_center(self, value):
         self._max_distance_from_center = value
-
-    @property
-    def solid(self):
-        if get_hash(self) != self.hash_value:
-            self.create_solid()
-        return self._solid
-
-    @solid.setter
-    def solid(self, value):
-        self._solid = value
 
     def find_points(self):
         """Finds the XZ points joined by straight connections that describe the


### PR DESCRIPTION
## Proposed changes

Following from from some previous suggestions in the recent catch up I thought I would see if the get_hash call can be removed from all the parametric components. Also nice to reduce the lines of code for a change :-)

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
