### PR TITLE
Fix z_pos and add automatic port cutting to parametric reactors

### DIFF
--- a/examples/example_parametric_components/make_all_parametric_components.py
+++ b/examples/example_parametric_components/make_all_parametric_components.py
@@ -334,7 +334,7 @@ def main():
 
     component = paramak.PortCutterRectangular(
         distance=3,
-        z_pos=0,
+        center_point=(0, 0),
         height=0.2,
         width=0.4,
         fillet_radius=0.02,
@@ -344,7 +344,7 @@ def main():
 
     component = paramak.PortCutterCircular(
         distance=3,
-        z_pos=0.25,
+        center_point=(0.25, 0),
         radius=0.1,
         # azimuth_placement_angle=[0, 45, 90, 180], # TODO: fix issue #548
         azimuth_placement_angle=[0, 45, 90],

--- a/examples/example_parametric_components/make_vacuum_vessel_with_ports.py
+++ b/examples/example_parametric_components/make_vacuum_vessel_with_ports.py
@@ -25,7 +25,7 @@ def main():
     # makes the middle row of ports
     circular_ports = paramak.PortCutterCircular(
         distance=5,
-        z_pos=0,
+        center_point=(0, 0),
         radius=0.2,
         azimuth_placement_angle=angles_for_ports
     )
@@ -33,7 +33,7 @@ def main():
     # makes the lower row of ports
     rectangular_ports = paramak.PortCutterRectangular(
         distance=5,
-        z_pos=-1,
+        center_point=(-1, 0),
         height=0.3,
         width=0.4,
         fillet_radius=0.08,

--- a/paramak/parametric_components/port_cutters_circular.py
+++ b/paramak/parametric_components/port_cutters_circular.py
@@ -51,4 +51,4 @@ class PortCutterCircular(ExtrudeCircleShape):
         self.radius = radius
 
     def find_points(self):
-        self.points = [(0, self.z_pos)]
+        self.points = [(self.z_pos, 0)]

--- a/paramak/parametric_components/port_cutters_circular.py
+++ b/paramak/parametric_components/port_cutters_circular.py
@@ -7,10 +7,9 @@ class PortCutterCircular(ExtrudeCircleShape):
     other components (eg. blanket, vessel,..) in order to create ports.
 
     Args:
-        z_pos (float): Z position (cm) of the port
-        height (float): height (cm) of the port
-        width (float): width (cm) of the port
-        distance (float): extruded distance (cm) of the cutter
+        center_point (tuple of floats): Defaults to (0, 0).
+        radius (float): radius (cm) of port.
+        distance (float): extruded distance (cm) of the cutter.
         stp_filename (str, optional): defaults to "PortCutterCircular.stp".
         stl_filename (str, optional): defaults to "PortCutterCircular.stl".
         name (str, optional): defaults to "circular_port_cutter".
@@ -21,9 +20,9 @@ class PortCutterCircular(ExtrudeCircleShape):
 
     def __init__(
         self,
-        z_pos,
         radius,
         distance,
+        center_point=(0, 0),
         workplane="ZY",
         rotation_axis="Z",
         extrusion_start_offset=1.,
@@ -47,8 +46,8 @@ class PortCutterCircular(ExtrudeCircleShape):
             **kwargs
         )
 
-        self.z_pos = z_pos
+        self.center_point = center_point
         self.radius = radius
 
     def find_points(self):
-        self.points = [(self.z_pos, 0)]
+        self.points = [self.center_point]

--- a/paramak/parametric_components/port_cutters_circular.py
+++ b/paramak/parametric_components/port_cutters_circular.py
@@ -7,7 +7,7 @@ class PortCutterCircular(ExtrudeCircleShape):
     other components (eg. blanket, vessel,..) in order to create ports.
 
     Args:
-        center_point (tuple of floats): Defaults to (0, 0).
+        center_point ((float, float)): Defaults to (0, 0).
         radius (float): radius (cm) of port.
         distance (float): extruded distance (cm) of the cutter.
         stp_filename (str, optional): defaults to "PortCutterCircular.stp".

--- a/paramak/parametric_components/port_cutters_rectangular.py
+++ b/paramak/parametric_components/port_cutters_rectangular.py
@@ -65,7 +65,8 @@ class PortCutterRectangular(ExtrudeStraightShape):
             (self.width / 2, self.height / 2),
             (-self.width / 2, self.height / 2),
         ]
-        points = [(e[0]+self.center_point[0], e[1]+self.center_point[1]) for e in points]
+        points = [(e[0] + self.center_point[0], e[1] +
+                   self.center_point[1]) for e in points]
         self.points = points
 
     def add_fillet(self):

--- a/paramak/parametric_components/port_cutters_rectangular.py
+++ b/paramak/parametric_components/port_cutters_rectangular.py
@@ -56,7 +56,7 @@ class PortCutterRectangular(ExtrudeStraightShape):
         self.height = height
         self.width = width
         self.fillet_radius = fillet_radius
-        self.add_fillet()
+        # self.add_fillet()
 
     def find_points(self):
         points = [
@@ -69,6 +69,13 @@ class PortCutterRectangular(ExtrudeStraightShape):
                    self.center_point[1]) for e in points]
         self.points = points
 
-    def add_fillet(self):
+    def add_fillet(self, solid):
+        if "X" not in self.workplane:
+            filleting_edge = "|X"
+        if "Y" not in self.workplane:
+            filleting_edge = "|Y"
+        if "Z" not in self.workplane:
+            filleting_edge = "|Z"
         if self.fillet_radius is not None and self.fillet_radius != 0:
-            self.solid = self.solid.edges().fillet(self.fillet_radius)
+            solid = solid.edges(filleting_edge).fillet(self.fillet_radius)
+        return solid

--- a/paramak/parametric_components/port_cutters_rectangular.py
+++ b/paramak/parametric_components/port_cutters_rectangular.py
@@ -65,7 +65,7 @@ class PortCutterRectangular(ExtrudeStraightShape):
             (self.width / 2, self.height / 2),
             (-self.width / 2, self.height / 2),
         ]
-        points = [(e[0], e[1] + self.z_pos) for e in points]
+        points = [(e[1] + self.z_pos, e[0]) for e in points]
         self.points = points
 
     def add_fillet(self):

--- a/paramak/parametric_components/port_cutters_rectangular.py
+++ b/paramak/parametric_components/port_cutters_rectangular.py
@@ -7,7 +7,7 @@ class PortCutterRectangular(ExtrudeStraightShape):
     other components (eg. blanket, vessel,..) in order to create ports.
 
     Args:
-        center_point (tuple of floats): Defaults to (0, 0).
+        center_point ((float, float)): Defaults to (0, 0).
         height (float): height (cm) of the port.
         width (float): width (cm) of the port.
         distance (float): extruded distance (cm) of the cutter.

--- a/paramak/parametric_components/port_cutters_rectangular.py
+++ b/paramak/parametric_components/port_cutters_rectangular.py
@@ -71,4 +71,4 @@ class PortCutterRectangular(ExtrudeStraightShape):
 
     def add_fillet(self):
         if self.fillet_radius is not None and self.fillet_radius != 0:
-            self.solid = self.solid.edges('#Z').fillet(self.fillet_radius)
+            self.solid = self.solid.edges().fillet(self.fillet_radius)

--- a/paramak/parametric_components/port_cutters_rectangular.py
+++ b/paramak/parametric_components/port_cutters_rectangular.py
@@ -7,10 +7,10 @@ class PortCutterRectangular(ExtrudeStraightShape):
     other components (eg. blanket, vessel,..) in order to create ports.
 
     Args:
-        z_pos (float): Z position (cm) of the port
-        height (float): height (cm) of the port
-        width (float): width (cm) of the port
-        distance (float): extruded distance (cm) of the cutter
+        center_point (tuple of floats): Defaults to (0, 0).
+        height (float): height (cm) of the port.
+        width (float): width (cm) of the port.
+        distance (float): extruded distance (cm) of the cutter.
         fillet_radius (float, optional): If not None, radius (cm) of fillets
             added to edges orthogonal to the Z direction. Defaults to None.
         stp_filename (str, optional): defaults to "PortCutterRectangular.stp".
@@ -24,10 +24,10 @@ class PortCutterRectangular(ExtrudeStraightShape):
 
     def __init__(
         self,
-        z_pos,
         height,
         width,
         distance,
+        center_point=(0, 0),
         workplane="ZY",
         rotation_axis="Z",
         extrusion_start_offset=1.,
@@ -52,7 +52,7 @@ class PortCutterRectangular(ExtrudeStraightShape):
             **kwargs
         )
 
-        self.z_pos = z_pos
+        self.center_point = center_point
         self.height = height
         self.width = width
         self.fillet_radius = fillet_radius
@@ -65,7 +65,7 @@ class PortCutterRectangular(ExtrudeStraightShape):
             (self.width / 2, self.height / 2),
             (-self.width / 2, self.height / 2),
         ]
-        points = [(e[1] + self.z_pos, e[0]) for e in points]
+        points = [(e[0]+self.center_point[0], e[1]+self.center_point[1]) for e in points]
         self.points = points
 
     def add_fillet(self):

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -167,7 +167,7 @@ class BallReactor(paramak.Reactor):
 
         self.port_type = port_type
         self.number_of_ports = number_of_ports
-        self.port_z_pos = port_z_pos
+        self.port_center_point = port_center_point
         self.port_radius = port_radius
         self.port_height = port_height
         self.port_width = port_width

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -182,10 +182,12 @@ class BallReactor(paramak.Reactor):
                     0, 360, self.number_of_ports, endpoint=False
                 )
             else:
-                if self.number_of_ports == len(self.port_azimuth_placement_angle):
+                if self.number_of_ports == len(
+                        self.port_azimuth_placement_angle):
                     self.port_azimuth_placement_angle = port_azimuth_placement_angle
                 else:
-                    raise ValueError('number of ports does not equal number of port azimuthal placement angles')
+                    raise ValueError(
+                        'number of ports does not equal number of port azimuthal placement angles')
         else:
             if self.port_azimuth_placement_angle is not None:
                 self.number_of_ports = len(self.port_azimuth_placement_angle)
@@ -467,7 +469,8 @@ class BallReactor(paramak.Reactor):
             cut=[self._center_column_cutter],
         )
 
-        self._firstwall, self._blanket, self._blanket_rear_wall = perform_port_cutting(self, self._firstwall, self._blanket, self._blanket_rear_wall)
+        self._firstwall, self._blanket, self._blanket_rear_wall = perform_port_cutting(
+            self, self._firstwall, self._blanket, self._blanket_rear_wall)
 
         return [self._firstwall, self._blanket, self._blanket_rear_wall]
 

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -3,6 +3,8 @@ import warnings
 
 import paramak
 
+from paramak.utils import perform_port_cutting
+
 
 class BallReactor(paramak.Reactor):
     """Creates geometry for a simple ball reactor including a plasma,

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -465,6 +465,8 @@ class BallReactor(paramak.Reactor):
             cut=[self._center_column_cutter],
         )
 
+        self._firstwall, self._blanket, self._blanket_rear_wall = perform_port_cutting(self, self._firstwall, self._blanket, self._blanket_rear_wall)
+
         return [self._firstwall, self._blanket, self._blanket_rear_wall]
 
     def _make_divertor(self):

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -68,7 +68,7 @@ class BallReactor(paramak.Reactor):
         number_of_ports (int, optional): number of ports. Defaults to None.
         port_center_point ((float, float), optional): position of port center
             point in the workplane given. Defaults to (0, 0).
-        port_radius (float, optional): radius of circular ports. Defaults to 
+        port_radius (float, optional): radius of circular ports. Defaults to
             None.
         port_height (float, optional): height of rectangular ports. Defaults
             to None.
@@ -76,7 +76,7 @@ class BallReactor(paramak.Reactor):
             None.
         port_distance (float, optional): extrusion distance of port cutter.
             Defaults to None.
-        port_azimuth_placement_angle (float or list of floats, optional): 
+        port_azimuth_placement_angle (float or list of floats, optional):
             azimuthal placement of each port. Defualts to None if no ports
             are created. Defaults to list of equally spaced floats between 0
             and 360 of length equal to number_of_ports if number_of_ports is
@@ -492,7 +492,8 @@ class BallReactor(paramak.Reactor):
             cut=[self._center_column_cutter],
         )
 
-        self._firstwall, self._blanket, self._blanket_rear_wall = perform_port_cutting(self, self._firstwall, self._blanket, self._blanket_rear_wall)
+        self._firstwall, self._blanket, self._blanket_rear_wall = perform_port_cutting(
+            self, self._firstwall, self._blanket, self._blanket_rear_wall)
 
         return [self._firstwall, self._blanket, self._blanket_rear_wall]
 

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -88,6 +88,17 @@ class BallReactor(paramak.Reactor):
             outboard_tf_coil_poloidal_thickness=None,
             divertor_position="both",
             rotation_angle=360.0,
+            port_type=None,
+            number_of_ports=None,
+            port_center_point=(0, 0),
+            port_radius=None,
+            port_height=None,
+            port_width=None,
+            port_distance=None,
+            port_azimuth_placement_angle=None,
+            port_start_radius=None,
+            port_fillet_radius=0,
+            **kwargs
     ):
 
         super().__init__([])
@@ -151,6 +162,37 @@ class BallReactor(paramak.Reactor):
             self.outer_plasma_gap_radial_thickness,
             self.plasma_gap_vertical_thickness,
             self.major_radius - self.minor_radius]
+
+        self.port_type = port_type
+        self.number_of_ports = number_of_ports
+        self.port_z_pos = port_z_pos
+        self.port_radius = port_radius
+        self.port_height = port_height
+        self.port_width = port_width
+        self.port_distance = port_distance
+        self.port_start_radius = port_start_radius
+        self.port_azimuth_placement_angle = port_azimuth_placement_angle
+        self.port_fillet_radius = port_fillet_radius
+
+        if self.number_of_ports is not None:
+            if self.port_azimuth_placement_angle is None:
+                self.port_azimuth_placement_angle = np.linspace(
+                    0, 360, self.number_of_ports, endpoint=False
+                )
+            else:
+                if self.number_of_ports == len(self.port_azimuth_placement_angle):
+                    self.port_azimuth_placement_angle = port_azimuth_placement_angle
+                else:
+                    raise ValueError('number of ports does not equal number of port azimuthal placement angles')
+        else:
+            if self.port_azimuth_placement_angle is not None:
+                self.number_of_ports = len(self.port_azimuth_placement_angle)
+
+        self.port_start_radius = port_start_radius
+
+        if self.port_azimuth_placement_angle is not None:
+            if self.port_start_radius is None:
+                self.port_start_radius = self.major_radius
 
     @property
     def pf_coil_radial_thicknesses(self):

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -65,7 +65,6 @@ class BallReactor(paramak.Reactor):
         rotation_angle (float): the angle of the sector that is desired.
             Defaults to 360.0.
         port_type (str, optional): type of port to be cut. Defaults to None.
-        number_of_ports (int, optional): number of ports. Defaults to None.
         port_center_point ((float, float), optional): position of port center
             point in the workplane given. Defaults to (0, 0).
         port_radius (float, optional): radius of circular ports. Defaults to
@@ -82,8 +81,7 @@ class BallReactor(paramak.Reactor):
             and 360 of length equal to number_of_ports if number_of_ports is
             provided but port_azimuth_placement_angle is not.
         port_start_radius (float, optional): extrusion start point of port
-            cutter. Defaults to None if no ports are created. Defaults to
-            major_radius otherwise.
+            cutter. Defaults to major_radius.
         port_fillet_radius (float, optional): fillet radius of rectangular
             ports. Defaults to 0.
     """
@@ -114,7 +112,6 @@ class BallReactor(paramak.Reactor):
             divertor_position="both",
             rotation_angle=360.0,
             port_type=None,
-            number_of_ports=None,
             port_center_point=(0, 0),
             port_radius=None,
             port_height=None,
@@ -189,7 +186,6 @@ class BallReactor(paramak.Reactor):
             self.major_radius - self.minor_radius]
 
         self.port_type = port_type
-        self.number_of_ports = number_of_ports
         self.port_center_point = port_center_point
         self.port_radius = port_radius
         self.port_height = port_height
@@ -199,27 +195,16 @@ class BallReactor(paramak.Reactor):
         self.port_azimuth_placement_angle = port_azimuth_placement_angle
         self.port_fillet_radius = port_fillet_radius
 
-        if self.number_of_ports is not None:
-            if self.port_azimuth_placement_angle is None:
-                self.port_azimuth_placement_angle = np.linspace(
-                    0, 360, self.number_of_ports, endpoint=False
-                )
-            else:
-                if self.number_of_ports == len(
-                        self.port_azimuth_placement_angle):
-                    self.port_azimuth_placement_angle = port_azimuth_placement_angle
-                else:
-                    raise ValueError(
-                        'number of ports does not equal number of port azimuthal placement angles')
+    @property
+    def port_start_radius(self):
+        return self._port_start_radius
+
+    @port_start_radius.setter
+    def port_start_radius(self, value):
+        if value is None:
+            self._port_start_radius = self.major_radius
         else:
-            if self.port_azimuth_placement_angle is not None:
-                self.number_of_ports = len(self.port_azimuth_placement_angle)
-
-        self.port_start_radius = port_start_radius
-
-        if self.port_azimuth_placement_angle is not None:
-            if self.port_start_radius is None:
-                self.port_start_radius = self.major_radius
+            self._port_start_radius = value
 
     @property
     def pf_coil_radial_thicknesses(self):

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -64,6 +64,28 @@ class BallReactor(paramak.Reactor):
             "upper", "lower" or "both". Defaults to "both".
         rotation_angle (float): the angle of the sector that is desired.
             Defaults to 360.0.
+        port_type (str, optional): type of port to be cut. Defaults to None.
+        number_of_ports (int, optional): number of ports. Defaults to None.
+        port_center_point ((float, float), optional): position of port center
+            point in the workplane given. Defaults to (0, 0).
+        port_radius (float, optional): radius of circular ports. Defaults to 
+            None.
+        port_height (float, optional): height of rectangular ports. Defaults
+            to None.
+        port_width (float, optional): width of rectangular ports. Defaults to
+            None.
+        port_distance (float, optional): extrusion distance of port cutter.
+            Defaults to None.
+        port_azimuth_placement_angle (float or list of floats, optional): 
+            azimuthal placement of each port. Defualts to None if no ports
+            are created. Defaults to list of equally spaced floats between 0
+            and 360 of length equal to number_of_ports if number_of_ports is
+            provided but port_azimuth_placement_angle is not.
+        port_start_radius (float, optional): extrusion start point of port
+            cutter. Defaults to None if no ports are created. Defaults to
+            major_radius otherwise.
+        port_fillet_radius (float, optional): fillet radius of rectangular
+            ports. Defaults to 0.
     """
 
     def __init__(
@@ -470,8 +492,7 @@ class BallReactor(paramak.Reactor):
             cut=[self._center_column_cutter],
         )
 
-        self._firstwall, self._blanket, self._blanket_rear_wall = perform_port_cutting(
-            self, self._firstwall, self._blanket, self._blanket_rear_wall)
+        self._firstwall, self._blanket, self._blanket_rear_wall = perform_port_cutting(self, self._firstwall, self._blanket, self._blanket_rear_wall)
 
         return [self._firstwall, self._blanket, self._blanket_rear_wall]
 

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -1,4 +1,5 @@
 
+import numpy as np
 import warnings
 
 import paramak

--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -64,7 +64,6 @@ class SubmersionTokamak(paramak.Reactor):
         support_position (str, optional): the position of the supports,
             "upper", "lower" or "both". Defaults to "both".
         port_type (str, optional): type of port to be cut. Defaults to None.
-        number_of_ports (int, optional): number of ports. Defaults to None.
         port_center_point ((float, float), optional): position of port center
             point in the workplane given. Defaults to (0, 0).
         port_radius (float, optional): radius of circular ports. Defaults to
@@ -115,7 +114,6 @@ class SubmersionTokamak(paramak.Reactor):
         divertor_position="both",
         support_position="both",
         port_type=None,
-        number_of_ports=None,
         port_center_point=(0, 0),
         port_radius=None,
         port_height=None,
@@ -183,7 +181,6 @@ class SubmersionTokamak(paramak.Reactor):
         self.minor_radius = self.major_radius - inner_equatorial_point
 
         self.port_type = port_type
-        self.number_of_ports = number_of_ports
         self.port_center_point = port_center_point
         self.port_radius = port_radius
         self.port_height = port_height
@@ -193,27 +190,16 @@ class SubmersionTokamak(paramak.Reactor):
         self.port_azimuth_placement_angle = port_azimuth_placement_angle
         self.port_fillet_radius = port_fillet_radius
 
-        if self.number_of_ports is not None:
-            if self.port_azimuth_placement_angle is None:
-                self.port_azimuth_placement_angle = np.linspace(
-                    0, 360, self.number_of_ports, endpoint=False
-                )
-            else:
-                if self.number_of_ports == len(
-                        self.port_azimuth_placement_angle):
-                    self.port_azimuth_placement_angle = port_azimuth_placement_angle
-                else:
-                    raise ValueError(
-                        'number of ports does not equal number of port azimuthal placement angles')
+    @property
+    def port_start_radius(self):
+        return self._port_start_radius
+
+    @port_start_radius.setter
+    def port_start_radius(self, value):
+        if value is None:
+            self._port_start_radius = self.major_radius
         else:
-            if self.port_azimuth_placement_angle is not None:
-                self.number_of_ports = len(self.port_azimuth_placement_angle)
-
-        self.port_start_radius = port_start_radius
-
-        if self.port_azimuth_placement_angle is not None:
-            if self.port_start_radius is None:
-                self.port_start_radius = self.major_radius
+            self._port_start_radius = value
 
     @property
     def pf_coil_radial_thicknesses(self):

--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -67,7 +67,7 @@ class SubmersionTokamak(paramak.Reactor):
         number_of_ports (int, optional): number of ports. Defaults to None.
         port_center_point ((float, float), optional): position of port center
             point in the workplane given. Defaults to (0, 0).
-        port_radius (float, optional): radius of circular ports. Defaults to 
+        port_radius (float, optional): radius of circular ports. Defaults to
             None.
         port_height (float, optional): height of rectangular ports. Defaults
             to None.
@@ -75,7 +75,7 @@ class SubmersionTokamak(paramak.Reactor):
             None.
         port_distance (float, optional): extrusion distance of port cutter.
             Defaults to None.
-        port_azimuth_placement_angle (float or list of floats, optional): 
+        port_azimuth_placement_angle (float or list of floats, optional):
             azimuthal placement of each port. Defualts to None if no ports
             are created. Defaults to list of equally spaced floats between 0
             and 360 of length equal to number_of_ports if number_of_ports is

--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -90,6 +90,17 @@ class SubmersionTokamak(paramak.Reactor):
         pf_coil_case_thickness=10,
         divertor_position="both",
         support_position="both",
+        port_type=None,
+        number_of_ports=None,
+        port_center_point=(0, 0),
+        port_radius=None,
+        port_height=None,
+        port_width=None,
+        port_distance=None,
+        port_azimuth_placement_angle=None,
+        port_start_radius=None,
+        port_fillet_radius=0,
+        **kwargs
     ):
 
         super().__init__([])
@@ -146,6 +157,39 @@ class SubmersionTokamak(paramak.Reactor):
         self.major_radius = \
             (outer_equatorial_point + inner_equatorial_point) / 2
         self.minor_radius = self.major_radius - inner_equatorial_point
+
+        self.port_type = port_type
+        self.number_of_ports = number_of_ports
+        self.port_center_point = port_center_point
+        self.port_radius = port_radius
+        self.port_height = port_height
+        self.port_width = port_width
+        self.port_distance = port_distance
+        self.port_start_radius = port_start_radius
+        self.port_azimuth_placement_angle = port_azimuth_placement_angle
+        self.port_fillet_radius = port_fillet_radius
+
+        if self.number_of_ports is not None:
+            if self.port_azimuth_placement_angle is None:
+                self.port_azimuth_placement_angle = np.linspace(
+                    0, 360, self.number_of_ports, endpoint=False
+                )
+            else:
+                if self.number_of_ports == len(
+                        self.port_azimuth_placement_angle):
+                    self.port_azimuth_placement_angle = port_azimuth_placement_angle
+                else:
+                    raise ValueError(
+                        'number of ports does not equal number of port azimuthal placement angles')
+        else:
+            if self.port_azimuth_placement_angle is not None:
+                self.number_of_ports = len(self.port_azimuth_placement_angle)
+
+        self.port_start_radius = port_start_radius
+
+        if self.port_azimuth_placement_angle is not None:
+            if self.port_start_radius is None:
+                self.port_start_radius = self.major_radius
 
     @property
     def pf_coil_radial_thicknesses(self):

--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -681,7 +681,8 @@ class SubmersionTokamak(paramak.Reactor):
                 self._outboard_rear_blanket_wall_lower],
         )
 
-        self._outboard_rear_blanket_wall = perform_port_cutting(self, self._outboard_rear_blanket_wall)
+        self._outboard_rear_blanket_wall = perform_port_cutting(
+            self, self._outboard_rear_blanket_wall)
 
         return self._outboard_rear_blanket_wall
 

--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -4,6 +4,8 @@ import warnings
 import cadquery as cq
 import paramak
 
+from paramak.utils import perform_port_cutting
+
 
 class SubmersionTokamak(paramak.Reactor):
     """Creates geometry for a simple submersion reactor including a plasma,
@@ -490,6 +492,7 @@ class SubmersionTokamak(paramak.Reactor):
             material_tag="firstwall_mat",
             union=self._inboard_firstwall,
         )
+        self._firstwall = perform_port_cutting(self, self._firstwall)
         return self._firstwall
 
     def _make_divertor(self):
@@ -539,8 +542,7 @@ class SubmersionTokamak(paramak.Reactor):
             name="divertor",
             material_tag="divertor_mat"
         )
-
-        self._firstwall.cut = self._divertor
+        self._firstwall.cut = self._firstwall.cut + [self._divertor]
         self._inboard_firstwall.cut = self._divertor
         return self._divertor
 
@@ -575,6 +577,7 @@ class SubmersionTokamak(paramak.Reactor):
             material_tag="blanket_mat",
             union=self._inboard_blanket,
         )
+        self._blanket = perform_port_cutting(self, self._blanket)
         return self._blanket
 
     def _make_supports(self):
@@ -611,7 +614,7 @@ class SubmersionTokamak(paramak.Reactor):
             material_tag="supports_mat",
             intersect=blanket_enveloppe,
         )
-        self._blanket.cut = self._supports
+        self._blanket.cut = self._blanket.cut + [self._supports]
 
         return self._supports
 
@@ -677,6 +680,8 @@ class SubmersionTokamak(paramak.Reactor):
                 self._outboard_rear_blanket_wall_upper,
                 self._outboard_rear_blanket_wall_lower],
         )
+
+        self._outboard_rear_blanket_wall = perform_port_cutting(self, self._outboard_rear_blanket_wall)
 
         return self._outboard_rear_blanket_wall
 

--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -564,7 +564,10 @@ class SubmersionTokamak(paramak.Reactor):
             name="divertor",
             material_tag="divertor_mat"
         )
-        self._firstwall.cut = self._firstwall.cut + [self._divertor]
+        if self._firstwall.cut is None:
+            self._firstwall.cut = [self._divertor]
+        else:
+            self._firstwall.cut = self._firstwall.cut + [self._divertor]
         self._inboard_firstwall.cut = self._divertor
         return self._divertor
 
@@ -636,7 +639,10 @@ class SubmersionTokamak(paramak.Reactor):
             material_tag="supports_mat",
             intersect=blanket_enveloppe,
         )
-        self._blanket.cut = self._blanket.cut + [self._supports]
+        if self._blanket.cut is None:
+            self._blanket.cut = [self._supports]
+        else:
+            self._blanket.cut = self._blanket.cut + [self._supports]
 
         return self._supports
 

--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -63,6 +63,28 @@ class SubmersionTokamak(paramak.Reactor):
             "upper", "lower" or "both". Defaults to "both".
         support_position (str, optional): the position of the supports,
             "upper", "lower" or "both". Defaults to "both".
+        port_type (str, optional): type of port to be cut. Defaults to None.
+        number_of_ports (int, optional): number of ports. Defaults to None.
+        port_center_point ((float, float), optional): position of port center
+            point in the workplane given. Defaults to (0, 0).
+        port_radius (float, optional): radius of circular ports. Defaults to 
+            None.
+        port_height (float, optional): height of rectangular ports. Defaults
+            to None.
+        port_width (float, optional): width of rectangular ports. Defaults to
+            None.
+        port_distance (float, optional): extrusion distance of port cutter.
+            Defaults to None.
+        port_azimuth_placement_angle (float or list of floats, optional): 
+            azimuthal placement of each port. Defualts to None if no ports
+            are created. Defaults to list of equally spaced floats between 0
+            and 360 of length equal to number_of_ports if number_of_ports is
+            provided but port_azimuth_placement_angle is not.
+        port_start_radius (float, optional): extrusion start point of port
+            cutter. Defaults to None if no ports are created. Defaults to
+            major_radius otherwise.
+        port_fillet_radius (float, optional): fillet radius of rectangular
+            ports. Defaults to 0.
     """
 
     def __init__(

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -84,6 +84,8 @@ class ExtrudeMixedShape(Shape):
             distance=extrusion_distance,
             both=self.extrude_both)
 
+        # used for filleting rectangular port cutter edges
+        # must be done before azimuthal placement
         if hasattr(self, "add_fillet"):
             solid = self.add_fillet(solid)
 

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -84,6 +84,9 @@ class ExtrudeMixedShape(Shape):
             distance=extrusion_distance,
             both=self.extrude_both)
 
+        if hasattr(self, "add_fillet"):
+            solid = self.add_fillet(solid)
+
         solid = self.rotate_solid(solid)
         cutting_wedge = calculate_wedge_cut(self)
         solid = self.perform_boolean_operations(solid, wedge_cut=cutting_wedge)

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -217,6 +217,8 @@ def perform_port_cutting(self, *args):
 
         for component in args:
             components.append(component)
+        if len(args) == 1:
+            return component
         return components
 
     else:

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -259,7 +259,7 @@ def perform_port_cutting(self, *args):
             if component.cut is None:
                 component.cut = [port_cutter]
             else:
-                component.cut = [port_cutter] + component.cut
+                component.cut.insert(0, port_cutter)
             components.append(component)
             if len(args) == 1:
                 return component

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -212,8 +212,8 @@ def perform_port_cutting(self, *args):
 
     components = []
 
-    if self.port_type == None and self.port_azimuth_placement_angle == None \
-        and self.port_distance == None and self.port_start_radius == None:
+    if self.port_type is None and self.port_azimuth_placement_angle is None \
+            and self.port_distance is None and self.port_start_radius is None:
 
         for component in args:
             components.append(component)
@@ -221,42 +221,44 @@ def perform_port_cutting(self, *args):
 
     else:
         if self.port_type == "circular":
-            if self.port_height != None or self.port_width != None:
+            if self.port_height is not None or self.port_width is not None:
                 raise ValueError('only port_radius should be specified')
-            if self.port_radius == None:
+            if self.port_radius is None:
                 raise ValueError('port_radius must be specified')
-            
+
             port_cutter = paramak.PortCutterCircular(
-                center_point = self.port_center_point,
-                radius = self.port_radius,
-                distance = self.port_distance,
-                extrusion_start_offset = self.port_start_radius,
-                azimuth_placement_angle = self.port_azimuth_placement_angle
+                center_point=self.port_center_point,
+                radius=self.port_radius,
+                distance=self.port_distance,
+                extrusion_start_offset=self.port_start_radius,
+                azimuth_placement_angle=self.port_azimuth_placement_angle
             )
 
         elif self.port_type == "rectangular":
-            if self.port_radius != None:
-                raise ValueError('only port_height and port_width should be specified')
-            if self.port_height == None or self.port_width == None:
-                raise ValueError('port_height and port_width must be specified')
+            if self.port_radius is not None:
+                raise ValueError(
+                    'only port_height and port_width should be specified')
+            if self.port_height is None or self.port_width is None:
+                raise ValueError(
+                    'port_height and port_width must be specified')
 
             port_cutter = paramak.PortCutterRectangular(
-                center_point = self.port_center_point,
-                height = self.port_height,
-                width = self.port_width,
-                distance = self.port_distance,
-                extrusion_start_offset = self.port_start_radius,
-                fillet_radius = self.port_fillet_radius,
-                azimuth_placement_angle = self.port_azimuth_placement_angle
+                center_point=self.port_center_point,
+                height=self.port_height,
+                width=self.port_width,
+                distance=self.port_distance,
+                extrusion_start_offset=self.port_start_radius,
+                fillet_radius=self.port_fillet_radius,
+                azimuth_placement_angle=self.port_azimuth_placement_angle
             )
-        
+
         else:
             raise ValueError('invalid port_type')
 
         for component in args:
             component.cut = [port_cutter] + component.cut
             components.append(component)
-        
+
         return components
 
 

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -212,8 +212,7 @@ def perform_port_cutting(self, *args):
 
     components = []
 
-    if self.port_type is None and self.port_azimuth_placement_angle is None \
-            and self.port_distance is None and self.port_start_radius is None:
+    if self.port_type is None:
 
         for component in args:
             components.append(component)

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -208,6 +208,58 @@ def calculate_wedge_cut(self):
     return cutting_wedge
 
 
+def perform_port_cutting(self, *args):
+
+    components = []
+
+    if self.port_type == None and self.port_azimuth_placement_angle == None \
+        and self.port_distance == None and self.port_start_radius == None:
+
+        for component in args:
+            components.append(component)
+        return components
+
+    else:
+        if self.port_type == "circular":
+            if self.port_height != None or self.port_width != None:
+                raise ValueError('only port_radius should be specified')
+            if self.port_radius == None:
+                raise ValueError('port_radius must be specified')
+            
+            port_cutter = paramak.PortCutterCircular(
+                center_point = self.port_center_point,
+                radius = self.port_radius,
+                distance = self.port_distance,
+                extrusion_start_offset = self.port_start_radius,
+                azimuth_placement_angle = self.port_azimuth_placement_angle
+            )
+
+        elif self.port_type == "rectangular":
+            if self.port_radius != None:
+                raise ValueError('only port_height and port_width should be specified')
+            if self.port_height == None or self.port_width == None:
+                raise ValueError('port_height and port_width must be specified')
+
+            port_cutter = paramak.PortCutterRectangular(
+                center_point = self.port_center_point,
+                height = self.port_height,
+                width = self.port_width,
+                distance = self.port_distance,
+                extrusion_start_offset = self.port_start_radius,
+                fillet_radius = self.port_fillet_radius,
+                azimuth_placement_angle = self.port_azimuth_placement_angle
+            )
+        
+        else:
+            raise ValueError('invalid port_type')
+
+        for component in args:
+            component.cut = [port_cutter] + component.cut
+            components.append(component)
+        
+        return components
+
+
 def add_thickness(x, y, thickness, dy_dx=None):
     """Computes outer curve points based on thickness
 

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -256,9 +256,13 @@ def perform_port_cutting(self, *args):
             raise ValueError('invalid port_type')
 
         for component in args:
-            component.cut = [port_cutter] + component.cut
+            if component.cut is None:
+                component.cut = [port_cutter]
+            else:
+                component.cut = [port_cutter] + component.cut
             components.append(component)
-
+            if len(args) == 1:
+                return component
         return components
 
 

--- a/tests/test_parametric_components/test_PortCutterCircular.py
+++ b/tests/test_parametric_components/test_PortCutterCircular.py
@@ -1,4 +1,5 @@
 
+import math
 import unittest
 
 import paramak
@@ -42,3 +43,15 @@ class test_component(unittest.TestCase):
         self.test_shape.azimuth_placement_angle = [0, 90, 180, 270]
 
         assert self.test_shape.volume == pytest.approx(test_volume * 4)
+
+    def test_absolute_volume(self):
+        """Creates a PortCutterCircular shape and checks that its volume is correct."""
+
+        assert self.test_shape.volume == pytest.approx(math.pi * (20**2) * 300)
+
+        self.test_shape.extrusion_start_offset = 20
+        self.test_shape.azimuth_placement_angle = [0, 90, 180, 270]
+        self.test_shape.radius = 10
+
+        assert self.test_shape.volume == pytest.approx(math.pi * (10**2) * 300 * 4)
+

--- a/tests/test_parametric_components/test_PortCutterCircular.py
+++ b/tests/test_parametric_components/test_PortCutterCircular.py
@@ -3,6 +3,8 @@ import unittest
 
 import paramak
 
+import pytest
+
 
 class test_component(unittest.TestCase):
 
@@ -14,18 +16,29 @@ class test_component(unittest.TestCase):
     def test_default_parameters(self):
         """Checks that the default parameters of a PortCutterCircular are correct."""
 
-        assert self.center_point == (0, 0)
-        assert self.workplane == "ZY"
-        assert self.rotation_axis == "Z"
-        assert self.extrusion_start_offset == 1
-        assert self.stp_filename == "PortCutterCircular.stp"
-        assert self.stl_filename == "PortCutterCircular.stl"
-        assert self.name == "circular_port_cutter"
-        assert self.material_tag == "circular_port_cutter_mat"
+        assert self.test_shape.center_point == (0, 0)
+        assert self.test_shape.workplane == "ZY"
+        assert self.test_shape.rotation_axis == "Z"
+        assert self.test_shape.extrusion_start_offset == 1
+        assert self.test_shape.stp_filename == "PortCutterCircular.stp"
+        assert self.test_shape.stl_filename == "PortCutterCircular.stl"
+        assert self.test_shape.name == "circular_port_cutter"
+        assert self.test_shape.material_tag == "circular_port_cutter_mat"
 
     def test_creation(self):
         """Creates a circular port cutter using the PortCutterCircular parametric
         component and checks that a cadquery solid is created."""
 
         assert self.test_shape.solid is not None
-        assert self.test_shape.volume > 1000 
+        assert self.test_shape.volume > 1000
+
+    def test_relative_volume(self):
+        """Creates PortCutterCircular shapes and checks that their relative volumes
+        are correct."""
+
+        test_volume = self.test_shape.volume
+
+        self.test_shape.extrusion_start_offset = 20
+        self.test_shape.azimuth_placement_angle = [0, 90, 180, 270]
+
+        assert self.test_shape.volume == pytest.approx(test_volume * 4)

--- a/tests/test_parametric_components/test_PortCutterCircular.py
+++ b/tests/test_parametric_components/test_PortCutterCircular.py
@@ -6,15 +6,26 @@ import paramak
 
 class test_component(unittest.TestCase):
 
-    def test_creation(self):
-        """Checks a PortCutterCircular creation."""
-
-        test_component = paramak.PortCutterCircular(
-            center_point=(0, 0),
-            distance=3,
-            radius=0.1,
-            extrusion_start_offset=1,
-            azimuth_placement_angle=[0, 45, 90, 180]
+    def setUp(self):
+        self.test_shape = paramak.PortCutterCircular(
+            distance=300, radius=20
         )
 
-        assert test_component.solid is not None
+    def test_default_parameters(self):
+        """Checks that the default parameters of a PortCutterCircular are correct."""
+
+        assert self.center_point == (0, 0)
+        assert self.workplane == "ZY"
+        assert self.rotation_axis == "Z"
+        assert self.extrusion_start_offset == 1
+        assert self.stp_filename == "PortCutterCircular.stp"
+        assert self.stl_filename == "PortCutterCircular.stl"
+        assert self.name == "circular_port_cutter"
+        assert self.material_tag == "circular_port_cutter_mat"
+
+    def test_creation(self):
+        """Creates a circular port cutter using the PortCutterCircular parametric
+        component and checks that a cadquery solid is created."""
+
+        assert self.test_shape.solid is not None
+        assert self.test_shape.volume > 1000 

--- a/tests/test_parametric_components/test_PortCutterCircular.py
+++ b/tests/test_parametric_components/test_PortCutterCircular.py
@@ -53,5 +53,5 @@ class test_component(unittest.TestCase):
         self.test_shape.azimuth_placement_angle = [0, 90, 180, 270]
         self.test_shape.radius = 10
 
-        assert self.test_shape.volume == pytest.approx(math.pi * (10**2) * 300 * 4)
-
+        assert self.test_shape.volume == pytest.approx(
+            math.pi * (10**2) * 300 * 4)

--- a/tests/test_parametric_components/test_PortCutterCircular.py
+++ b/tests/test_parametric_components/test_PortCutterCircular.py
@@ -4,16 +4,17 @@ import unittest
 import paramak
 
 
-# class test_component(unittest.TestCase):
-# TODO: fix issue 548
-#     def test_creation(self):
-#         """Checks a PortCutterCircular creation."""
+class test_component(unittest.TestCase):
 
-#         test_component = paramak.PortCutterCircular(
-#             distance=3,
-#             z_pos=0.25,
-#             radius=0.1,
-#             azimuth_placement_angle=[0, 45, 90, 180]
-#         )
+    def test_creation(self):
+        """Checks a PortCutterCircular creation."""
 
-#         assert test_component.solid is not None
+        test_component = paramak.PortCutterCircular(
+            center_point=(0, 0),
+            distance=3,
+            radius=0.1,
+            extrusion_start_offset=1,
+            azimuth_placement_angle=[0, 45, 90, 180]
+        )
+
+        assert test_component.solid is not None

--- a/tests/test_parametric_components/test_PortCutterRectangular.py
+++ b/tests/test_parametric_components/test_PortCutterRectangular.py
@@ -19,6 +19,7 @@ class TestPortCutterRectangular(unittest.TestCase):
         assert self.test_shape.workplane == "ZY"
         assert self.test_shape.rotation_axis == "Z"
         assert self.test_shape.extrusion_start_offset == 1
+        assert self.test_shape.fillet_radius == None
         assert self.test_shape.stp_filename == "PortCutterRectangular.stp"
         assert self.test_shape.stl_filename == "PortCutterRectangular.stl"
         assert self.test_shape.name == "rectangular_port_cutter"

--- a/tests/test_parametric_components/test_PortCutterRectangular.py
+++ b/tests/test_parametric_components/test_PortCutterRectangular.py
@@ -6,17 +6,26 @@ import paramak
 
 class TestPortCutterRectangular(unittest.TestCase):
 
-    def test_creation(self):
-        """Checks a PortCutterRectangular creation."""
-
-        test_component = paramak.PortCutterRectangular(
-            center_point = (0, 0),
-            distance=3,
-            height=0.2,
-            width=0.4,
-            fillet_radius=0.02,
-            extrusion_start_offset=1,
-            azimuth_placement_angle=[0, 45, 90, 180]
+    def setUp(self):
+        self.test_shape = paramak.PortCutterRectangular(
+            width=40, height=40, distance=300
         )
 
-        assert test_component.solid is not None
+    def test_default_parameters(self):
+        """Checks that the default parameters of a PortCutterRectangular are correct."""
+
+        assert self.center_point = (0, 0)
+        assert self.workplane = "ZY"
+        assert self.rotation_axis == "Z"
+        assert self.extrusion_start_offset == 1
+        assert self.stp_filename == "PortCutterRectangular.stp"
+        assert self.stl_filename == "PortCutterRectangular.stl"
+        assert self.name == "rectangular_port_cutter"
+        assert self.material_tag == "rectangular_port_cutter_mat"
+
+    def test_creation(self):
+        """Creates a rectangular port cutter using the PortCutterRectangular parametric
+        component and checks that a cadquery solid is created."""
+
+        assert self.test_shape.solid is not None
+        assert self.test_shape.volume > 1000

--- a/tests/test_parametric_components/test_PortCutterRectangular.py
+++ b/tests/test_parametric_components/test_PortCutterRectangular.py
@@ -41,3 +41,15 @@ class TestPortCutterRectangular(unittest.TestCase):
         self.test_shape.azimuth_placement_angle = [0, 90, 180, 270]
         
         assert self.test_shape.volume == pytest.approx(test_volume * 4)
+
+    def test_absolute_volume(self):
+        """Creates a PortCutterRectangular shape and checks that its volume is correct."""
+
+        assert self.test_shape.volume == pytest.approx(40 * 40 * 300)
+
+        self.test_shape.extrusion_start_offset = 20
+        self.test_shape.azimuth_placement_angle = [0, 90, 180, 270]
+        self.test_shape.width = 20
+        self.test_shape.height = 20
+
+        assert self.test_shape.volume == pytest.approx(20 * 20 * 300 * 4)

--- a/tests/test_parametric_components/test_PortCutterRectangular.py
+++ b/tests/test_parametric_components/test_PortCutterRectangular.py
@@ -20,7 +20,7 @@ class TestPortCutterRectangular(unittest.TestCase):
         assert self.test_shape.workplane == "ZY"
         assert self.test_shape.rotation_axis == "Z"
         assert self.test_shape.extrusion_start_offset == 1
-        assert self.test_shape.fillet_radius == None
+        assert self.test_shape.fillet_radius is None
         assert self.test_shape.stp_filename == "PortCutterRectangular.stp"
         assert self.test_shape.stl_filename == "PortCutterRectangular.stl"
         assert self.test_shape.name == "rectangular_port_cutter"

--- a/tests/test_parametric_components/test_PortCutterRectangular.py
+++ b/tests/test_parametric_components/test_PortCutterRectangular.py
@@ -5,6 +5,7 @@ import paramak
 
 import pytest
 
+
 class TestPortCutterRectangular(unittest.TestCase):
 
     def setUp(self):
@@ -39,7 +40,7 @@ class TestPortCutterRectangular(unittest.TestCase):
 
         self.test_shape.extrusion_start_offset = 20
         self.test_shape.azimuth_placement_angle = [0, 90, 180, 270]
-        
+
         assert self.test_shape.volume == pytest.approx(test_volume * 4)
 
     def test_absolute_volume(self):

--- a/tests/test_parametric_components/test_PortCutterRectangular.py
+++ b/tests/test_parametric_components/test_PortCutterRectangular.py
@@ -10,11 +10,12 @@ class TestPortCutterRectangular(unittest.TestCase):
         """Checks a PortCutterRectangular creation."""
 
         test_component = paramak.PortCutterRectangular(
+            center_point = (0, 0),
             distance=3,
-            z_pos=0,
             height=0.2,
             width=0.4,
             fillet_radius=0.02,
+            extrusion_start_offset=1,
             azimuth_placement_angle=[0, 45, 90, 180]
         )
 

--- a/tests/test_parametric_components/test_PortCutterRectangular.py
+++ b/tests/test_parametric_components/test_PortCutterRectangular.py
@@ -3,6 +3,7 @@ import unittest
 
 import paramak
 
+import pytest
 
 class TestPortCutterRectangular(unittest.TestCase):
 
@@ -14,14 +15,14 @@ class TestPortCutterRectangular(unittest.TestCase):
     def test_default_parameters(self):
         """Checks that the default parameters of a PortCutterRectangular are correct."""
 
-        assert self.center_point = (0, 0)
-        assert self.workplane = "ZY"
-        assert self.rotation_axis == "Z"
-        assert self.extrusion_start_offset == 1
-        assert self.stp_filename == "PortCutterRectangular.stp"
-        assert self.stl_filename == "PortCutterRectangular.stl"
-        assert self.name == "rectangular_port_cutter"
-        assert self.material_tag == "rectangular_port_cutter_mat"
+        assert self.test_shape.center_point == (0, 0)
+        assert self.test_shape.workplane == "ZY"
+        assert self.test_shape.rotation_axis == "Z"
+        assert self.test_shape.extrusion_start_offset == 1
+        assert self.test_shape.stp_filename == "PortCutterRectangular.stp"
+        assert self.test_shape.stl_filename == "PortCutterRectangular.stl"
+        assert self.test_shape.name == "rectangular_port_cutter"
+        assert self.test_shape.material_tag == "rectangular_port_cutter_mat"
 
     def test_creation(self):
         """Creates a rectangular port cutter using the PortCutterRectangular parametric
@@ -29,3 +30,14 @@ class TestPortCutterRectangular(unittest.TestCase):
 
         assert self.test_shape.solid is not None
         assert self.test_shape.volume > 1000
+
+    def test_relative_volume(self):
+        """Creates PortCutterRectangular shapes and checks that their relative volumes
+        are correct."""
+
+        test_volume = self.test_shape.volume
+
+        self.test_shape.extrusion_start_offset = 20
+        self.test_shape.azimuth_placement_angle = [0, 90, 180, 270]
+        
+        assert self.test_shape.volume == pytest.approx(test_volume * 4)

--- a/tests/test_parametric_components/test_VacuumVessel.py
+++ b/tests/test_parametric_components/test_VacuumVessel.py
@@ -22,15 +22,16 @@ class TestVacuumVessel(unittest.TestCase):
         caquery solid is created."""
 
         cutter1 = paramak.PortCutterRectangular(
-            distance=3, z_pos=0, height=0.2, width=0.4, fillet_radius=0.01)
+            center_point=(0, 0),
+            distance=3, extrusion_start_offset=0, height=0.2, width=0.4, fillet_radius=0.01)
         cutter2 = paramak.PortCutterRectangular(
-            distance=3, z_pos=0.5, height=0.2, width=0.4, fillet_radius=0.00)
+            center_point=(0.5, 0),
+            distance=3, extrusion_start_offset=0, height=0.2, width=0.4, fillet_radius=0.00)
         cutter3 = paramak.PortCutterRectangular(
-            distance=3, z_pos=-0.5, height=0.2, width=0.4,
-            physical_groups=None)
+            distance=3, center_point=(-0.5, 0), height=0.2, width=0.4)
         cutter4 = paramak.PortCutterCircular(
-            distance=3, z_pos=0.25, radius=0.1, azimuth_placement_angle=45,
-            physical_groups=None)
+            center_point=(0.25, 0),
+            distance=3, extrusion_start_offset=0, radius=0.1, azimuth_placement_angle=45)
         cutter5 = paramak.PortCutterRotated(
             (0, 0), azimuth_placement_angle=-90, rotation_angle=10,
             fillet_radius=0.01, physical_groups=None)

--- a/tests/test_parametric_components/test_VacuumVessel.py
+++ b/tests/test_parametric_components/test_VacuumVessel.py
@@ -22,16 +22,33 @@ class TestVacuumVessel(unittest.TestCase):
         caquery solid is created."""
 
         cutter1 = paramak.PortCutterRectangular(
-            center_point=(0, 0),
-            distance=3, extrusion_start_offset=0, height=0.2, width=0.4, fillet_radius=0.01)
+            center_point=(
+                0,
+                0),
+            distance=3,
+            extrusion_start_offset=0,
+            height=0.2,
+            width=0.4,
+            fillet_radius=0.01)
         cutter2 = paramak.PortCutterRectangular(
-            center_point=(0.5, 0),
-            distance=3, extrusion_start_offset=0, height=0.2, width=0.4, fillet_radius=0.00)
+            center_point=(
+                0.5,
+                0),
+            distance=3,
+            extrusion_start_offset=0,
+            height=0.2,
+            width=0.4,
+            fillet_radius=0.00)
         cutter3 = paramak.PortCutterRectangular(
             distance=3, center_point=(-0.5, 0), height=0.2, width=0.4)
         cutter4 = paramak.PortCutterCircular(
-            center_point=(0.25, 0),
-            distance=3, extrusion_start_offset=0, radius=0.1, azimuth_placement_angle=45)
+            center_point=(
+                0.25,
+                0),
+            distance=3,
+            extrusion_start_offset=0,
+            radius=0.1,
+            azimuth_placement_angle=45)
         cutter5 = paramak.PortCutterRotated(
             (0, 0), azimuth_placement_angle=-90, rotation_angle=10,
             fillet_radius=0.01, physical_groups=None)


### PR DESCRIPTION
## Proposed changes

PR which fixes the problem with port positioning. The z_pos parameter has been replaced with a center_point parameter which allows the port cutter faces to be translated in 2 dimensions rather than 1. This ensures placement can be controlled in all workplanes.

PR also attempts to add automatic port cutting to the parametric reactors.
A utility method called perform_port_cutting has been added to the utility.py script to perform this function.
CURRENT STATUS: Works as expected for large ports and small fillet radii.
KNOWN BUGS: For small ports, sometimes not all ports are cut from the outboard blankets and large fillet radii can cause errors.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

No further comments
