### PR TITLE
removed number_of_ports as argument

### DIFF
--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -65,7 +65,6 @@ class BallReactor(paramak.Reactor):
         rotation_angle (float): the angle of the sector that is desired.
             Defaults to 360.0.
         port_type (str, optional): type of port to be cut. Defaults to None.
-        number_of_ports (int, optional): number of ports. Defaults to None.
         port_center_point ((float, float), optional): position of port center
             point in the workplane given. Defaults to (0, 0).
         port_radius (float, optional): radius of circular ports. Defaults to
@@ -82,8 +81,7 @@ class BallReactor(paramak.Reactor):
             and 360 of length equal to number_of_ports if number_of_ports is
             provided but port_azimuth_placement_angle is not.
         port_start_radius (float, optional): extrusion start point of port
-            cutter. Defaults to None if no ports are created. Defaults to
-            major_radius otherwise.
+            cutter. Defaults to major_radius.
         port_fillet_radius (float, optional): fillet radius of rectangular
             ports. Defaults to 0.
     """
@@ -114,7 +112,6 @@ class BallReactor(paramak.Reactor):
             divertor_position="both",
             rotation_angle=360.0,
             port_type=None,
-            number_of_ports=None,
             port_center_point=(0, 0),
             port_radius=None,
             port_height=None,
@@ -189,7 +186,6 @@ class BallReactor(paramak.Reactor):
             self.major_radius - self.minor_radius]
 
         self.port_type = port_type
-        self.number_of_ports = number_of_ports
         self.port_center_point = port_center_point
         self.port_radius = port_radius
         self.port_height = port_height
@@ -199,27 +195,16 @@ class BallReactor(paramak.Reactor):
         self.port_azimuth_placement_angle = port_azimuth_placement_angle
         self.port_fillet_radius = port_fillet_radius
 
-        if self.number_of_ports is not None:
-            if self.port_azimuth_placement_angle is None:
-                self.port_azimuth_placement_angle = np.linspace(
-                    0, 360, self.number_of_ports, endpoint=False
-                )
-            else:
-                if self.number_of_ports == len(
-                        self.port_azimuth_placement_angle):
-                    self.port_azimuth_placement_angle = port_azimuth_placement_angle
-                else:
-                    raise ValueError(
-                        'number of ports does not equal number of port azimuthal placement angles')
+    @property
+    def port_start_radius(self):
+        return self._port_start_radius
+
+    @port_start_radius.setter
+    def port_start_radius(self, value):
+        if value is None:
+            self._port_start_radius = self.major_radius
         else:
-            if self.port_azimuth_placement_angle is not None:
-                self.number_of_ports = len(self.port_azimuth_placement_angle)
-
-        self.port_start_radius = port_start_radius
-
-        if self.port_azimuth_placement_angle is not None:
-            if self.port_start_radius is None:
-                self.port_start_radius = self.major_radius
+            self._port_start_radius = value
 
     @property
     def pf_coil_radial_thicknesses(self):

--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -64,7 +64,6 @@ class SubmersionTokamak(paramak.Reactor):
         support_position (str, optional): the position of the supports,
             "upper", "lower" or "both". Defaults to "both".
         port_type (str, optional): type of port to be cut. Defaults to None.
-        number_of_ports (int, optional): number of ports. Defaults to None.
         port_center_point ((float, float), optional): position of port center
             point in the workplane given. Defaults to (0, 0).
         port_radius (float, optional): radius of circular ports. Defaults to
@@ -115,7 +114,6 @@ class SubmersionTokamak(paramak.Reactor):
         divertor_position="both",
         support_position="both",
         port_type=None,
-        number_of_ports=None,
         port_center_point=(0, 0),
         port_radius=None,
         port_height=None,
@@ -183,7 +181,6 @@ class SubmersionTokamak(paramak.Reactor):
         self.minor_radius = self.major_radius - inner_equatorial_point
 
         self.port_type = port_type
-        self.number_of_ports = number_of_ports
         self.port_center_point = port_center_point
         self.port_radius = port_radius
         self.port_height = port_height
@@ -193,27 +190,16 @@ class SubmersionTokamak(paramak.Reactor):
         self.port_azimuth_placement_angle = port_azimuth_placement_angle
         self.port_fillet_radius = port_fillet_radius
 
-        if self.number_of_ports is not None:
-            if self.port_azimuth_placement_angle is None:
-                self.port_azimuth_placement_angle = np.linspace(
-                    0, 360, self.number_of_ports, endpoint=False
-                )
-            else:
-                if self.number_of_ports == len(
-                        self.port_azimuth_placement_angle):
-                    self.port_azimuth_placement_angle = port_azimuth_placement_angle
-                else:
-                    raise ValueError(
-                        'number of ports does not equal number of port azimuthal placement angles')
+    @property
+    def port_start_radius(self):
+        return self._port_start_radius
+
+    @port_start_radius.setter
+    def port_start_radius(self, value):
+        if value is None:
+            self._port_start_radius = self.major_radius
         else:
-            if self.port_azimuth_placement_angle is not None:
-                self.number_of_ports = len(self.port_azimuth_placement_angle)
-
-        self.port_start_radius = port_start_radius
-
-        if self.port_azimuth_placement_angle is not None:
-            if self.port_start_radius is None:
-                self.port_start_radius = self.major_radius
+            self._port_start_radius = value
 
     @property
     def pf_coil_radial_thicknesses(self):


### PR DESCRIPTION
## Proposed changes

PR which removes number_of_ports as a reactor argument. This was causing competition with port_azimuth_placement_angle and the simplest solution was to remove.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

No further comments