### PR TITLE
added wires export option for stl export to shape

### DIFF
--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -734,13 +734,16 @@ class Shape:
 
         return self.x_min, self.x_max, self.z_min, self.z_max
 
-    def export_stl(self, filename, tolerance=0.001):
+    def export_stl(self, filename, tolerance=0.001, solid_or_wire='solid'):
         """Exports an stl file for the Shape.solid. If the provided filename
             doesn't end with .stl it will be added
 
         Args:
-            filename (str): the filename of the stl file to be exported
-            tolerance (float): the precision of the faceting
+            filename (str): the filename of the stl file to be exported.
+            tolerance (float): the precision of the faceting.
+            solid_or_wire (str, optional): the object to export can be either
+                'solid' which exports 3D solid shapes or the 'wire' which
+                exports the wire edges of the shape. Defaults to 'solid'.
         """
 
         path_filename = Path(filename)
@@ -751,7 +754,14 @@ class Shape:
         path_filename.parents[0].mkdir(parents=True, exist_ok=True)
 
         with open(path_filename, "w") as out_file:
-            exporters.exportShape(self.solid, "STL", out_file, tolerance)
+            if solid_or_wire == 'solid':
+                exporters.exportShape(self.solid, "STL", out_file, tolerance)
+            elif solid_or_wire == 'wire':
+                exporters.exportShape(self.wire, "STL", out_file, tolerance)
+            else:
+                raise ValueError("The solid_or_wire argument for export_stl \
+                    only accepts 'solid' or 'wire'", self)
+
         print("Saved file as ", path_filename)
 
         return str(path_filename)

--- a/tests/test_parametric_shapes/test_ExtrudeMixedShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeMixedShape.py
@@ -99,7 +99,7 @@ class TestExtrudeMixedShape(unittest.TestCase):
         assert Path("filename.stp").exists() is True
         os.system("rm filename.stp")
 
-    def test_export_stl(self):
+    def test_export_stl_with_extention(self):
         """Creates a ExtrudeMixedShape and checks that a stl file of the shape
         can be exported with the correct suffix using the export_stl method."""
 
@@ -141,7 +141,7 @@ class TestExtrudeMixedShape(unittest.TestCase):
         self.test_shape.export_stp('test_solid.stp',solid_or_wire='solid')
         self.test_shape.export_stp('test_solid2.stp')
         self.test_shape.export_stp('test_wire.stp',solid_or_wire='wire')
-        
+
         assert Path("test_solid.stp").exists() is True
         assert Path("test_solid2.stp").exists() is True
         assert Path("test_wire.stp").exists() is True
@@ -154,6 +154,31 @@ class TestExtrudeMixedShape(unittest.TestCase):
         os.system("rm test_solid.stp")
         os.system("rm test_solid2.stp")
         os.system("rm test_wire.stp")
+
+    def test_export_stl(self):
+        """Exports and stl file with solid_or_wire = solid and wire and checks
+        that the outputs exist and relative file sizes are correct."""
+
+        os.system("rm test_solid.stl")
+        os.system("rm test_solid2.stl")
+        os.system("rm test_wire.stl")
+
+        self.test_shape.export_stl('test_solid.stl', solid_or_wire='solid')
+        self.test_shape.export_stl('test_solid2.stl')
+        self.test_shape.export_stl('test_wire.stl', solid_or_wire='wire')
+
+        assert Path("test_solid.stl").exists() is True
+        assert Path("test_solid2.stl").exists() is True
+        assert Path("test_wire.stl").exists() is True
+
+        assert Path("test_solid.stl").stat().st_size == \
+            Path("test_solid2.stl").stat().st_size
+        assert Path("test_wire.stl").stat().st_size < \
+            Path("test_solid2.stl").stat().st_size
+
+        # os.system("rm test_solid.stl")
+        # os.system("rm test_solid2.stl")
+        # os.system("rm test_wire.stl")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Proposed changes

This adds the wire export feature to the export_stl. This is in a separate PR to #626 as the feature does not currently work in the CadQuery STL export. This could be merged in if the STL export in CadQuery is changed.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
