### PR TITLE
added shellFS component and tests

### DIFF
--- a/paramak/__init__.py
+++ b/paramak/__init__.py
@@ -71,6 +71,7 @@ from .parametric_components.tf_coil_casing import TFCoilCasing
 
 from .parametric_components.vacuum_vessel import VacuumVessel
 from .parametric_components.hollow_cube import HollowCube
+from .parametric_components.shell_fs import ShellFS
 
 from .parametric_reactors.ball_reactor import BallReactor
 from .parametric_reactors.submersion_reactor import SubmersionTokamak

--- a/paramak/parametric_components/shell_fs.py
+++ b/paramak/parametric_components/shell_fs.py
@@ -1,0 +1,80 @@
+
+from paramak import CuttingWedgeFS, Shape
+
+
+class ShellFS(Shape):
+    """Shell From Shape. Creates a shell casing for the provided shape object.
+    Warning some shapes are too complex to shell. The Shell is cut / trimmed
+    with a paramak.CuttingWedgeFS based on the shape passed. This ensures that
+    the shell does does not exceed the rotation angle of the passed shape.
+
+    Args:
+        shape (paramak.Shape): the shape to create a shell / 3D offset around
+        thickness (float): the thickness of the shell casing around the shape
+            (cm). Passed directly to CadQuery.shell(). Defaults to 10.
+        kind (str, optional) : the method used to connect gaps in the resulting
+            shelled shape. Options include 'arc' or 'intersection'. Use 'arc'
+            for rounded edges 'intersection' for sharp edges. Passed directly
+            to CadQuery.shell(). Defaults to intersection.
+        stp_filename (str, optional): defaults to
+            "ShellFS.stp".
+        stl_filename (str, optional): defaults to
+            "ShellFS.stl".
+        material_tag (str, optional): defaults to "pf_coil_case_mat".
+    """
+
+    def __init__(
+        self,
+        shape,
+        thickness=10,
+        kind='intersection',
+        stp_filename="ShellFS.stp",
+        stl_filename="ShellFS.stl",
+        material_tag="pf_coil_case_mat",
+        **kwargs
+    ):
+
+        super().__init__(
+            material_tag=material_tag,
+            stp_filename=stp_filename,
+            stl_filename=stl_filename,
+            **kwargs
+        )
+
+        self.shape = shape
+        self.thickness = thickness
+        self.kind = kind
+
+    @property
+    def shape(self):
+        return self._shape
+
+    @shape.setter
+    def shape(self, value):
+        self._shape = value
+
+    @property
+    def thickness(self):
+        return self._thickness
+
+    @thickness.setter
+    def thickness(self, thickness):
+        self._thickness = thickness
+
+    def create_solid(self):
+        """Creates a 3D solid by creating a shell around a Shape"""
+
+        solid = self.shape.solid.shell(
+            thickness=self.thickness,
+            kind=self.kind,
+        )
+
+        if self.shape.rotation_angle < 360:
+            # rotation angle is set by the self.shapes rotation angle
+            cutting_wedge = CuttingWedgeFS(self.shape)
+            # this trims the sold so that it does not exceed the rotation angle 
+            solid = solid.cut(cutting_wedge.solid)
+
+        self.solid = solid
+
+        return solid     

--- a/paramak/parametric_components/shell_fs.py
+++ b/paramak/parametric_components/shell_fs.py
@@ -11,22 +11,22 @@ class ShellFS(Shape):
     Args:
         shape (paramak.Shape): the shape to create a shell / 3D offset around
         thickness (float): the thickness of the shell casing around the shape
-            (cm). Passed directly to CadQuery.shell(). Defaults to 10.
+            (cm). Passed directly to CadQuery.shell(). Defaults to 10.0.
         kind (str, optional) : the method used to connect gaps in the resulting
             shelled shape. Options include 'arc' or 'intersection'. Use 'arc'
             for rounded edges 'intersection' for sharp edges. Passed directly
             to CadQuery.shell(). Defaults to intersection.
-        stp_filename (str, optional): defaults to
+        stp_filename (str, optional): Defaults to
             "ShellFS.stp".
-        stl_filename (str, optional): defaults to
+        stl_filename (str, optional): Defaults to
             "ShellFS.stl".
-        material_tag (str, optional): defaults to "pf_coil_case_mat".
+        material_tag (str, optional): Defaults to "pf_coil_case_mat".
     """
 
     def __init__(
         self,
         shape,
-        thickness=10,
+        thickness=10.0,
         kind='intersection',
         stp_filename="ShellFS.stp",
         stl_filename="ShellFS.stl",

--- a/paramak/parametric_components/shell_fs.py
+++ b/paramak/parametric_components/shell_fs.py
@@ -72,9 +72,9 @@ class ShellFS(Shape):
         if self.shape.rotation_angle < 360:
             # rotation angle is set by the self.shapes rotation angle
             cutting_wedge = CuttingWedgeFS(self.shape)
-            # this trims the sold so that it does not exceed the rotation angle 
+            # this trims the sold so that it does not exceed the rotation angle
             solid = solid.cut(cutting_wedge.solid)
 
         self.solid = solid
 
-        return solid     
+        return solid

--- a/tests/test_parametric_components/test_ShellFS.py
+++ b/tests/test_parametric_components/test_ShellFS.py
@@ -12,12 +12,13 @@ class TestShellFS(unittest.TestCase):
             height=50,
             width=50,
             rotation_angle=90,
-            center_point=(100,100)
+            center_point=(100, 100)
         )
 
     def test_creation_with_different_kinds(self):
 
-        casing_int = paramak.ShellFS(shape=self.test_shape, kind='intersection')
+        casing_int = paramak.ShellFS(
+            shape=self.test_shape, kind='intersection')
         casing_int.export_stp('int.stp')
         casing_arc = paramak.ShellFS(shape=self.test_shape, kind='arc')
         casing_arc.export_stp('arc.stp')

--- a/tests/test_parametric_components/test_ShellFS.py
+++ b/tests/test_parametric_components/test_ShellFS.py
@@ -1,0 +1,37 @@
+
+import unittest
+
+import paramak
+
+
+class TestShellFS(unittest.TestCase):
+
+    def setUp(self):
+        # this is the shape that gets shelled
+        self.test_shape = paramak.PoloidalFieldCoil(
+            height=50,
+            width=50,
+            rotation_angle=90,
+            center_point=(100,100)
+        )
+
+    def test_creation_with_different_kinds(self):
+
+        casing_int = paramak.ShellFS(shape=self.test_shape, kind='intersection')
+        casing_int.export_stp('int.stp')
+        casing_arc = paramak.ShellFS(shape=self.test_shape, kind='arc')
+        casing_arc.export_stp('arc.stp')
+
+        assert casing_int.solid is not None
+        assert casing_int.solid is not None
+        assert casing_int.volume > casing_arc.volume
+
+    def test_creation_with_different_thickness(self):
+
+        casing_small = paramak.ShellFS(shape=self.test_shape, thickness=5)
+
+        casing_large = paramak.ShellFS(shape=self.test_shape, thickness=20)
+
+        assert casing_small.solid is not None
+        assert casing_large.solid is not None
+        assert casing_large.volume > casing_small.volume


### PR DESCRIPTION
## Proposed changes

This adds the shell from shape parametric component that we discussed earlier today with @RemDelaporteMathurin and @billingsley-john . 

The final solution is based on a discovery @billingsley-john who found the .shell method. 

The result is a versatile shape with quite a small amount of code.

The shell shape is cut using a WedgeCutterFS() based on the shape passed into the ShellFS()

Unfortunately it fails when trying to offset a certain blanket I'm working on. I believe that is due to the use of splines on the outer part. It works when the blanket is make entirely from straight sections

Also it can fail when the filleted edges make contact each other

TODO
- Docs and images for docs
- add a spline shape to the test
- add a mixed shape to the tests
- add an extrude shape to the tests
- add a hollow shape to the tests


Here are some examples of the shape in use

```python
base_shape = paramak.PoloidalFieldCoil(
    height=50,
    width=50,
    rotation_angle=90,
    center_point=(100,100)
)
casing_int = paramak.ShellFS(shape=base_shape, kind='intersection')
casing_int.export_stp('int.stp')
casing_arc = paramak.ShellFS(shape=base_shape, kind='arc')
casing_arc.export_stp('arc.stp')
```

![Screenshot from 2020-12-09 22-43-51](https://user-images.githubusercontent.com/8583900/101699465-143b1b00-3a73-11eb-9dd4-8968a92a8daa.png)

![Screenshot from 2020-12-09 22-43-27](https://user-images.githubusercontent.com/8583900/101699486-1b622900-3a73-11eb-9895-ca0699cab0fd.png)




## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)



