### PR TITLE
added csg vs cad simulation test

### DIFF
--- a/tests/test_parametric_neutronics/test_Shape_neutronics.py
+++ b/tests/test_parametric_neutronics/test_Shape_neutronics.py
@@ -73,18 +73,25 @@ class test_object_properties(unittest.TestCase):
 
 class test_object_properties(unittest.TestCase):
 
-    def simulate_cylinder_cask_csg(self, material, source, height,
-        outer_radius, thickness, batches, particles):
+    def simulate_cylinder_cask_csg(
+            self,
+            material,
+            source,
+            height,
+            outer_radius,
+            thickness,
+            batches,
+            particles):
         """Makes a CSG cask geometry runs a simulation and returns the result"""
 
         mats = openmc.Materials([material])
 
         outer_cylinder = openmc.ZCylinder(r=outer_radius)
-        inner_cylinder = openmc.ZCylinder(r=outer_radius-thickness)
-        inner_top = openmc.ZPlane(z0=height*0.5)
-        inner_bottom = openmc.ZPlane(z0=-height*0.5)
-        outer_top = openmc.ZPlane(z0=(height*0.5)+thickness)
-        outer_bottom = openmc.ZPlane(z0=(-height*0.5)-thickness)
+        inner_cylinder = openmc.ZCylinder(r=outer_radius - thickness)
+        inner_top = openmc.ZPlane(z0=height * 0.5)
+        inner_bottom = openmc.ZPlane(z0=-height * 0.5)
+        outer_top = openmc.ZPlane(z0=(height * 0.5) + thickness)
+        outer_bottom = openmc.ZPlane(z0=(-height * 0.5) - thickness)
 
         sphere_1 = openmc.Sphere(r=100, boundary_type='vacuum')
 
@@ -152,18 +159,25 @@ class test_object_properties(unittest.TestCase):
 
         return df['mean'].sum()
 
-    def simulate_cylinder_cask_cad(self, material, source, height,
-        outer_radius, thickness, batches, particles):
+    def simulate_cylinder_cask_cad(
+            self,
+            material,
+            source,
+            height,
+            outer_radius,
+            thickness,
+            batches,
+            particles):
         """Makes a CAD cask geometry runs a simulation and returns the result"""
 
         top_cap_cell = paramak.RotateStraightShape(
             stp_filename='top_cap_cell.stp',
             material_tag='test_mat',
             points=[
-                (outer_radius, height*0.5),
-                (outer_radius, (height*0.5)+thickness),
-                (0, (height*0.5)+thickness),
-                (0, height*0.5),
+                (outer_radius, height * 0.5),
+                (outer_radius, (height * 0.5) + thickness),
+                (0, (height * 0.5) + thickness),
+                (0, height * 0.5),
             ],
         )
 
@@ -171,21 +185,22 @@ class test_object_properties(unittest.TestCase):
             stp_filename='bottom_cap_cell.stp',
             material_tag='test_mat',
             points=[
-                (outer_radius, -height*0.5),
-                (outer_radius, (-height*0.5)-thickness),
-                (0, (-height*0.5)-thickness),
-                (0, -height*0.5),
+                (outer_radius, -height * 0.5),
+                (outer_radius, (-height * 0.5) - thickness),
+                (0, (-height * 0.5) - thickness),
+                (0, -height * 0.5),
             ]
         )
 
         cylinder_cell = paramak.CenterColumnShieldCylinder(
             height=height,
-            inner_radius=outer_radius-thickness,
+            inner_radius=outer_radius - thickness,
             outer_radius=outer_radius,
             material_tag='test_mat',
         )
 
-        my_geometry = paramak.Reactor([cylinder_cell, bottom_cap_cell, top_cap_cell])
+        my_geometry = paramak.Reactor(
+            [cylinder_cell, bottom_cap_cell, top_cap_cell])
 
         my_model = paramak.NeutronicsModel(
             geometry=my_geometry,
@@ -199,7 +214,7 @@ class test_object_properties(unittest.TestCase):
         my_model.simulate(method='pymoab')
 
         # scaled from MeV to eV
-        return my_model.results['test_mat_heating']['MeV per source particle']['result']*1e6
+        return my_model.results['test_mat_heating']['MeV per source particle']['result'] * 1e6
 
     def test_cylinder_cask(self):
         """Runs the same source and material with CAD and CSG geoemtry"""
@@ -221,11 +236,11 @@ class test_object_properties(unittest.TestCase):
         source.angle = openmc.stats.Isotropic()
         source.energy = openmc.stats.Discrete([14e6], [1.0])
 
-        csg_result = self.simulate_cylinder_cask_csg(test_material, source,
-            height, outer_radius, thickness, batches, particles)
+        csg_result = self.simulate_cylinder_cask_csg(
+            test_material, source, height, outer_radius, thickness, batches, particles)
 
-        cad_result = self.simulate_cylinder_cask_cad(test_material, source,
-            height, outer_radius, thickness, batches, particles)
+        cad_result = self.simulate_cylinder_cask_cad(
+            test_material, source, height, outer_radius, thickness, batches, particles)
 
         assert pytest.approx(csg_result, rel=0.001) == cad_result
 

--- a/tests/test_parametric_neutronics/test_Shape_neutronics.py
+++ b/tests/test_parametric_neutronics/test_Shape_neutronics.py
@@ -3,7 +3,9 @@ import os
 import unittest
 from pathlib import Path
 
+import openmc
 import paramak
+import pytest
 
 
 class test_object_properties(unittest.TestCase):
@@ -67,6 +69,165 @@ class test_object_properties(unittest.TestCase):
         self.test_shape.make_graveyard(graveyard_offset=1000)
         large_offset = self.test_shape.graveyard.volume
         assert small_offset < large_offset
+
+
+class test_object_properties(unittest.TestCase):
+
+    def simulate_cylinder_cask_csg(self, material, source, height,
+        outer_radius, thickness, batches, particles):
+        """Makes a CSG cask geometry runs a simulation and returns the result"""
+
+        mats = openmc.Materials([material])
+
+        outer_cylinder = openmc.ZCylinder(r=outer_radius)
+        inner_cylinder = openmc.ZCylinder(r=outer_radius-thickness)
+        inner_top = openmc.ZPlane(z0=height*0.5)
+        inner_bottom = openmc.ZPlane(z0=-height*0.5)
+        outer_top = openmc.ZPlane(z0=(height*0.5)+thickness)
+        outer_bottom = openmc.ZPlane(z0=(-height*0.5)-thickness)
+
+        sphere_1 = openmc.Sphere(r=100, boundary_type='vacuum')
+
+        cylinder_region = -outer_cylinder & +inner_cylinder & -inner_top & + inner_bottom
+        cylinder_cell = openmc.Cell(region=cylinder_region)
+        cylinder_cell.fill = material
+
+        top_cap_region = -outer_top & +inner_top & -outer_cylinder
+        top_cap_cell = openmc.Cell(region=top_cap_region)
+        top_cap_cell.fill = material
+
+        bottom_cap_region = +outer_bottom & -inner_bottom & -outer_cylinder
+        bottom_cap_cell = openmc.Cell(region=bottom_cap_region)
+        bottom_cap_cell.fill = material
+
+        inner_void_region = -inner_cylinder & -inner_top & +inner_bottom
+        inner_void_cell = openmc.Cell(region=inner_void_region)
+
+        # sphere 1 region is below -sphere_1 and not (~) in the other regions
+        sphere_1_region = -sphere_1
+        sphere_1_cell = openmc.Cell(
+            region=sphere_1_region
+            & ~bottom_cap_region
+            & ~top_cap_region
+            & ~cylinder_region
+            & ~inner_void_region
+        )
+
+        universe = openmc.Universe(cells=[
+            inner_void_cell, cylinder_cell, top_cap_cell,
+            bottom_cap_cell, sphere_1_cell
+        ])
+
+        geom = openmc.Geometry(universe)
+
+        # Instantiate a Settings object
+        sett = openmc.Settings()
+        sett.batches = batches
+        sett.particles = particles
+        sett.inactive = 0
+        sett.run_mode = 'fixed source'
+        sett.photon_transport = True
+        sett.source = source
+
+        cell_filter = openmc.CellFilter([
+            cylinder_cell,
+            top_cap_cell,
+            bottom_cap_cell])
+
+        tally = openmc.Tally(name='csg_heating')
+        tally.filters = [cell_filter]
+        tally.scores = ['heating']
+        tallies = openmc.Tallies()
+        tallies.append(tally)
+
+        model = openmc.model.Model(geom, mats, sett, tallies)
+        sp_filename = model.run()
+
+        # open the results file
+        sp = openmc.StatePoint(sp_filename)
+
+        # access the tally using pandas dataframes
+        tally = sp.get_tally(name='csg_heating')
+        df = tally.get_pandas_dataframe()
+
+        return df['mean'].sum()
+
+    def simulate_cylinder_cask_cad(self, material, source, height,
+        outer_radius, thickness, batches, particles):
+        """Makes a CAD cask geometry runs a simulation and returns the result"""
+
+        top_cap_cell = paramak.RotateStraightShape(
+            stp_filename='top_cap_cell.stp',
+            material_tag='test_mat',
+            points=[
+                (outer_radius, height*0.5),
+                (outer_radius, (height*0.5)+thickness),
+                (0, (height*0.5)+thickness),
+                (0, height*0.5),
+            ],
+        )
+
+        bottom_cap_cell = paramak.RotateStraightShape(
+            stp_filename='bottom_cap_cell.stp',
+            material_tag='test_mat',
+            points=[
+                (outer_radius, -height*0.5),
+                (outer_radius, (-height*0.5)-thickness),
+                (0, (-height*0.5)-thickness),
+                (0, -height*0.5),
+            ]
+        )
+
+        cylinder_cell = paramak.CenterColumnShieldCylinder(
+            height=height,
+            inner_radius=outer_radius-thickness,
+            outer_radius=outer_radius,
+            material_tag='test_mat',
+        )
+
+        my_geometry = paramak.Reactor([cylinder_cell, bottom_cap_cell, top_cap_cell])
+
+        my_model = paramak.NeutronicsModel(
+            geometry=my_geometry,
+            source=source,
+            simulation_batches=batches,
+            simulation_particles_per_batch=particles,
+            materials={'test_mat': material},
+            cell_tallies=['heating']
+        )
+
+        my_model.simulate(method='pymoab')
+
+        # scaled from MeV to eV
+        return my_model.results['test_mat_heating']['MeV per source particle']['result']*1e6
+
+    def test_cylinder_cask(self):
+        """Runs the same source and material with CAD and CSG geoemtry"""
+
+        height = 100
+        outer_radius = 50
+        thickness = 10
+
+        batches = 10
+        particles = 500
+
+        test_material = openmc.Material(name='test_material')
+        test_material.set_density('g/cm3', 7.75)
+        test_material.add_element('Fe', 0.95, percent_type='wo')
+        test_material.add_element('C', 0.05, percent_type='wo')
+
+        source = openmc.Source()
+        source.space = openmc.stats.Point((0, 0, 0))
+        source.angle = openmc.stats.Isotropic()
+        source.energy = openmc.stats.Discrete([14e6], [1.0])
+
+        csg_result = self.simulate_cylinder_cask_csg(test_material, source,
+            height, outer_radius, thickness, batches, particles)
+
+        cad_result = self.simulate_cylinder_cask_cad(test_material, source,
+            height, outer_radius, thickness, batches, particles)
+
+        assert pytest.approx(csg_result, rel=0.001) == cad_result
 
 
 if __name__ == "__main__":

--- a/tests/test_parametric_neutronics/test_Shape_neutronics.py
+++ b/tests/test_parametric_neutronics/test_Shape_neutronics.py
@@ -8,7 +8,8 @@ import paramak
 import pytest
 
 
-class test_object_properties(unittest.TestCase):
+class TestObjectNeutronicsArguments(unittest.TestCase):
+    """Tests Shape object arguments that involve neutronics usage"""
 
     def setUp(self):
         self.test_shape = paramak.ExtrudeMixedShape(
@@ -71,7 +72,9 @@ class test_object_properties(unittest.TestCase):
         assert small_offset < large_offset
 
 
-class test_object_properties(unittest.TestCase):
+class TestSimulationResultsVsCsg(unittest.TestCase):
+    """Makes a geometry in the paramak and in CSG geometry, simulates and
+    compares the results"""
 
     def simulate_cylinder_cask_csg(
             self,
@@ -151,13 +154,13 @@ class test_object_properties(unittest.TestCase):
         sp_filename = model.run()
 
         # open the results file
-        sp = openmc.StatePoint(sp_filename)
+        results = openmc.StatePoint(sp_filename)
 
         # access the tally using pandas dataframes
-        tally = sp.get_tally(name='csg_heating')
-        df = tally.get_pandas_dataframe()
+        tally = results.get_tally(name='csg_heating')
+        tally_df = tally.get_pandas_dataframe()
 
-        return df['mean'].sum()
+        return tally_df['mean'].sum()
 
     def simulate_cylinder_cask_cad(
             self,


### PR DESCRIPTION
## Proposed changes

This adds a geometry comparison to the test suite. The same source, materials and geometry is simulated using CSG and CAD based geometry. 

The CSG geometry is made using the OpenMC Python API and requires about 40 lines of code.
The CAD geometry is made using the Paramak Python API and requires about 70 lines of code.

The heating tally is obtained with a neutron source (photon transport enabled), 10 batches and 500 particles.

Pytest.approx is then used to check that both simulations return an answer within +/- a relative fraction of 0.001 of each other.

The conversion of the CAD geometry to DAGMC geometry is performed via STL and PyMoab functonality added by @pshriwise 

![Screenshot from 2020-12-17 22-29-22](https://user-images.githubusercontent.com/8583900/102551952-432b3f80-40b8-11eb-99f1-d0241cbcd86c.png)
The CSG cask viewed from above

![Screenshot from 2020-12-17 22-29-15](https://user-images.githubusercontent.com/8583900/102551973-4d4d3e00-40b8-11eb-8434-144421b8c5db.png)
The CSG cask viewed from the side

![Screenshot from 2020-12-17 22-26-03](https://user-images.githubusercontent.com/8583900/102552001-56d6a600-40b8-11eb-9fad-ea83ecf675ca.png)
The CSG cask converted to VTK and seen in 3D

![Screenshot from 2020-12-17 22-39-21](https://user-images.githubusercontent.com/8583900/102552270-d5334800-40b8-11eb-8a21-ab2abaa045ed.png)
The CAD exported to stp file and viewed in FreeCAD with Transparency turned up

![Screenshot from 2020-12-17 22-39-58](https://user-images.githubusercontent.com/8583900/102552325-ebd99f00-40b8-11eb-85ab-a28df1327f43.png)
The CAD exported to stl file and viewed in FreeCAD with Transparency turned up

![Screenshot from 2020-12-17 22-40-06](https://user-images.githubusercontent.com/8583900/102552330-eda36280-40b8-11eb-8dd2-0c88db82cb59.png)
The CAD exported to stl file and viewed in FreeCAD with Transparency turned up



## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
