### PR TITLE
Spectra tally on cells

### DIFF
--- a/examples/example_neutronics_simulations/shape_with_spectra_cell_tally.py
+++ b/examples/example_neutronics_simulations/shape_with_spectra_cell_tally.py
@@ -40,9 +40,9 @@ fig = go.Figure()
 
 # this sets the axis titles and range
 fig.update_layout(
-        xaxis={'title': 'Energy (eV)',
-                'range': (0, 14.1e6)},
-        yaxis={'title': 'Neutrons per cm2 per source neutron'}
+    xaxis={'title': 'Energy (eV)',
+           'range': (0, 14.1e6)},
+    yaxis={'title': 'Neutrons per cm2 per source neutron'}
 )
 
 # this adds the neutron spectra line to the plot
@@ -51,7 +51,7 @@ fig.add_trace(go.Scatter(
     y=neutron_spectra[:-85],  # trims off the high energy range
     name='neutron spectra',
     line=dict(shape='hv')
-    )
+)
 )
 
 # this adds the photon spectra line to the plot
@@ -60,7 +60,7 @@ fig.add_trace(go.Scatter(
     y=photon_spectra[:-85],  # trims off the high energy range
     name='photon spectra',
     line=dict(shape='hv')
-    )
+)
 )
 
 # this adds the drop down menu fo log and linear scales
@@ -72,7 +72,7 @@ fig.update_layout(
                     args=[{
                         "xaxis.type": 'lin', "yaxis.type": 'lin',
                         'xaxis.range': (0, 14.1e6)
-                        }],
+                    }],
                     label="linear(x) , linear(y)",
                     method="relayout"
                 ),
@@ -88,8 +88,8 @@ fig.update_layout(
                 ),
                 dict(
                     args=[{"xaxis.type": 'lin', "yaxis.type": 'log',
-                        'xaxis.range': (0, 14.1e6)
-                    }],
+                           'xaxis.range': (0, 14.1e6)
+                           }],
                     label="linear(x) , log(y)",
                     method="relayout"
                 )

--- a/examples/example_neutronics_simulations/shape_with_spectra_cell_tally.py
+++ b/examples/example_neutronics_simulations/shape_with_spectra_cell_tally.py
@@ -1,0 +1,107 @@
+
+import openmc
+import paramak
+import plotly.graph_objects as go
+
+my_shape = paramak.CenterColumnShieldHyperbola(
+    height=500,
+    inner_radius=50,
+    mid_radius=60,
+    outer_radius=100,
+    material_tag='center_column_shield_mat'
+)
+
+# makes the openmc neutron source at x,y,z 0, 0, 0 with isotropic directions
+source = openmc.Source()
+source.space = openmc.stats.Point((0, 0, 0))
+source.energy = openmc.stats.Discrete([14e6], [1])
+source.angle = openmc.stats.Isotropic()
+
+
+# converts the geometry into a neutronics geometry
+my_model = paramak.NeutronicsModel(
+    geometry=my_shape,
+    source=source,
+    materials={'center_column_shield_mat': 'Be'},
+    cell_tallies=['heating', 'flux', 'TBR', 'spectra'],
+    simulation_batches=10,
+    simulation_particles_per_batch=200
+)
+
+# performs an openmc simulation on the model
+output_filename = my_model.simulate(method='pymoab')
+
+# this extracts the values from the results dictionary
+energy_bins = my_model.results['center_column_shield_mat_photon_spectra']['Flux per source particle']['energy']
+neutron_spectra = my_model.results['center_column_shield_mat_neutron_spectra']['Flux per source particle']['result']
+photon_spectra = my_model.results['center_column_shield_mat_photon_spectra']['Flux per source particle']['result']
+
+fig = go.Figure()
+
+# this sets the axis titles and range
+fig.update_layout(
+        xaxis={'title': 'Energy (eV)',
+                'range': (0, 14.1e6)},
+        yaxis={'title': 'Neutrons per cm2 per source neutron'}
+)
+
+# this adds the neutron spectra line to the plot
+fig.add_trace(go.Scatter(
+    x=energy_bins[:-85],  # trims off the high energy range
+    y=neutron_spectra[:-85],  # trims off the high energy range
+    name='neutron spectra',
+    line=dict(shape='hv')
+    )
+)
+
+# this adds the photon spectra line to the plot
+fig.add_trace(go.Scatter(
+    x=energy_bins[:-85],  # trims off the high energy range
+    y=photon_spectra[:-85],  # trims off the high energy range
+    name='photon spectra',
+    line=dict(shape='hv')
+    )
+)
+
+# this adds the drop down menu fo log and linear scales
+fig.update_layout(
+    updatemenus=[
+        go.layout.Updatemenu(
+            buttons=list([
+                dict(
+                    args=[{
+                        "xaxis.type": 'lin', "yaxis.type": 'lin',
+                        'xaxis.range': (0, 14.1e6)
+                        }],
+                    label="linear(x) , linear(y)",
+                    method="relayout"
+                ),
+                dict(
+                    args=[{"xaxis.type": 'log', "yaxis.type": 'log'}],
+                    label="log(x) , log(y)",
+                    method="relayout"
+                ),
+                dict(
+                    args=[{"xaxis.type": 'log', "yaxis.type": 'lin'}],
+                    label="log(x) , linear(y)",
+                    method="relayout"
+                ),
+                dict(
+                    args=[{"xaxis.type": 'lin', "yaxis.type": 'log',
+                        'xaxis.range': (0, 14.1e6)
+                    }],
+                    label="linear(x) , log(y)",
+                    method="relayout"
+                )
+            ]),
+            pad={"r": 10, "t": 10},
+            showactive=True,
+            x=0.5,
+            xanchor="left",
+            y=1.1,
+            yanchor="top"
+        ),
+    ]
+)
+
+fig.show()

--- a/paramak/parametric_neutronics/neutronics_model.py
+++ b/paramak/parametric_neutronics/neutronics_model.py
@@ -109,8 +109,9 @@ class NeutronicsModel():
         self.merge_tolerance = merge_tolerance
         self.mesh_2D_resolution = mesh_2D_resolution
         self.mesh_3D_resolution = mesh_3D_resolution
-        self.model = None
         self.fusion_power = fusion_power
+        self.model = None
+        self.tallies = None
 
     @property
     def faceting_tolerance(self):
@@ -155,8 +156,6 @@ class NeutronicsModel():
                 raise TypeError(
                     "NeutronicsModelFromReactor.cell_tallies should be a\
                     list")
-            # TODO add standard openmc tallies such as '(n,2n)' and
-            # 'absorbtion'
             output_options = ['TBR', 'heating', 'flux', 'spectra', 'dose']
             for entry in value:
                 if entry not in output_options:
@@ -560,7 +559,7 @@ class NeutronicsModel():
             geom, self.mats, settings, self.tallies)
 
     def _add_tally_for_every_material(self, sufix: str, score: str,
-                                      additional_filters: List = []) -> None:
+                                      additional_filters: List) -> None:
         """Adds a tally to self.tallies for every material.
 
         Arguments:
@@ -568,7 +567,8 @@ class NeutronicsModel():
                 identify the tally later.
             score: the openmc.Tally().scores value that contribute to the tally
         """
-
+        if additional_filters is None:
+            additional_filters = []
         for key, value in self.openmc_materials.items():
             if key != 'DT_plasma':
                 material_filter = openmc.MaterialFilter(value)

--- a/tests/test_parametric_neutronics/test_NeutronicModel.py
+++ b/tests/test_parametric_neutronics/test_NeutronicModel.py
@@ -22,7 +22,7 @@ class TestShape(unittest.TestCase):
         )
 
         # makes the openmc neutron source at x,y,z 0, 0, 0 with isotropic
-        # diections
+        # directions
         self.source = openmc.Source()
         self.source.space = openmc.stats.Point((0, 0, 0))
         self.source.angle = openmc.stats.Isotropic()
@@ -254,8 +254,9 @@ class TestShape(unittest.TestCase):
         flux = my_model.results['center_column_shield_mat_flux']['Flux per source particle']['result']
         mat_tbr = my_model.results['center_column_shield_mat_TBR']['result']
         tbr = my_model.results['TBR']['result']
-        spectra = my_model.results['center_column_shield_mat_neutron_spectra']['Flux per source particle']['result']
-        energy = my_model.results['center_column_shield_mat_photon_spectra']['Flux per source particle']['result']
+        spectra_neutrons = my_model.results['center_column_shield_mat_neutron_spectra']['Flux per source particle']['result']
+        spectra_photons = my_model.results['center_column_shield_mat_photon_spectra']['Flux per source particle']['result']
+        energy = my_model.results['center_column_shield_mat_photon_spectra']['Flux per source particle']['energy']
 
         assert heat > 0
         assert flux > 0
@@ -263,7 +264,8 @@ class TestShape(unittest.TestCase):
         assert mat_tbr > 0
         assert mat_tbr == tbr  # as there is just one shape
         assert len(energy) == 709
-        assert len(spectra) == 709
+        assert len(spectra_neutrons) == 709
+        assert len(spectra_photons) == 709
 
 
     def test_neutronics_component_2d_mesh_simulation(self):

--- a/tests/test_parametric_neutronics/test_NeutronicModel.py
+++ b/tests/test_parametric_neutronics/test_NeutronicModel.py
@@ -222,17 +222,20 @@ class TestShape(unittest.TestCase):
             incorrect_simulation_batches_to_small
         )
 
-    def test_neutronics_component_cell_simulation(self):
+    def test_neutronics_component_cell_simulation_heating(self):
         """Makes a neutronics model and simulates with a cell tally"""
 
         os.system('rm *.h5')
+        mat = openmc.Material()
+        mat.add_element('Li', 1)
+        mat.set_density('g/cm3', 2.1)
 
         # converts the geometry into a neutronics geometry
         my_model = paramak.NeutronicsModel(
             geometry=self.my_shape,
             source=self.source,
-            materials={'center_column_shield_mat': 'Be'},
-            cell_tallies=['heating'],
+            materials={'center_column_shield_mat': mat},
+            cell_tallies=['heating', 'flux', 'TBR', 'spectra'],
             simulation_batches=2,
             simulation_particles_per_batch=2
         )
@@ -241,13 +244,27 @@ class TestShape(unittest.TestCase):
         output_filename = my_model.simulate(method='pymoab')
 
         results = openmc.StatePoint(output_filename)
-        assert len(results.tallies.items()) == 1
+        # spectra add two tallies in this case (photons and neutrons)
+        # TBR adds two tallies global TBR and material TBR
+        assert len(results.tallies.items()) == 6
         assert len(results.meshes) == 0
 
         # extracts the heat from the results dictionary
         heat = my_model.results['center_column_shield_mat_heating']['Watts']['result']
+        flux = my_model.results['center_column_shield_mat_flux']['Flux per source particle']['result']
+        mat_tbr = my_model.results['center_column_shield_mat_TBR']['result']
+        tbr = my_model.results['TBR']['result']
+        spectra = my_model.results['center_column_shield_mat_neutron_spectra']['Flux per source particle']['result']
+        energy = my_model.results['center_column_shield_mat_photon_spectra']['Flux per source particle']['result']
 
         assert heat > 0
+        assert flux > 0
+        assert tbr > 0
+        assert mat_tbr > 0
+        assert mat_tbr == tbr  # as there is just one shape
+        assert len(energy) == 709
+        assert len(spectra) == 709
+
 
     def test_neutronics_component_2d_mesh_simulation(self):
         """Makes a neutronics model and simulates with a 2D mesh tally"""


### PR DESCRIPTION
## Proposed changes

This adds the ability to tally neutron and photon spectra on the cells.

When defining a model we now have a few cell tallies that are supported (heating, flux, TBR, spectra).

The next tally to add is fast flux which is can be done in a very similar way to spectra but with a two group energy bin and then deletion of the values in the first (thermal) group. Admittedly this is probably not the most efficient way to implement such a tally but good to start somewhere.

Anyway the spectra is by default 709 CCFE energy group so perhaps this should also a user controllable an option in the future.

```
my_model = paramak.NeutronicsModel(
    geometry=self.my_shape,
    source=self.source,
    materials={'center_column_shield_mat': mat},
    cell_tallies=['heating', 'flux', 'TBR', 'spectra'],
    simulation_batches=2,
    simulation_particles_per_batch=2
)
```

Note the new keyword **'spectra'**

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [x] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
