### PR TITLE
Fix sweep shapes

### DIFF
--- a/paramak/parametric_shapes/sweep_circle_shape.py
+++ b/paramak/parametric_shapes/sweep_circle_shape.py
@@ -96,17 +96,17 @@ class SweepCircleShape(Shape):
             factor *= -1
 
         if self.force_cross_section:
-            wire = cq.Workplane(self.workplane).moveTo(0, 0)
+            wire = cq.Workplane(self.workplane).center(0, 0)
             for point in self.path_points[:-1]:
                 wire = wire.workplane(offset=point[1] * factor).\
-                    moveTo(point[0], 0).\
+                    center(point[0], 0).\
                     circle(self.radius).\
-                    moveTo(0, 0).\
+                    center(-point[0], 0).\
                     workplane(offset=-point[1] * factor)
 
             self.wire = wire
 
-            solid = wire.workplane(offset=self.path_points[-1][1] * factor).moveTo(
+            solid = wire.workplane(offset=self.path_points[-1][1] * factor).center(
                 self.path_points[-1][0], 0).circle(self.radius).sweep(path, multisection=True)
 
         if not self.force_cross_section:
@@ -114,13 +114,13 @@ class SweepCircleShape(Shape):
             wire = (
                 cq.Workplane(self.workplane)
                 .workplane(offset=self.path_points[0][1] * factor)
-                .moveTo(self.path_points[0][0], 0)
+                .center(self.path_points[0][0], 0)
                 .workplane()
                 .circle(self.radius)
-                .moveTo(-self.path_points[0][0], 0)
+                .center(-self.path_points[0][0], 0)
                 .workplane(offset=-self.path_points[0][1] * factor)
                 .workplane(offset=self.path_points[-1][1] * factor)
-                .moveTo(self.path_points[-1][0], 0)
+                .center(self.path_points[-1][0], 0)
                 .workplane()
                 .circle(self.radius)
             )

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -580,13 +580,13 @@ class Shape:
                 if self.workplane in ["XZ", "YX", "ZY"]:
                     factor *= -1
 
-                solid = cq.Workplane(self.workplane).moveTo(0, 0)
+                solid = cq.Workplane(self.workplane).center(0, 0)
 
                 if self.force_cross_section:
                     for point in self.path_points[:-1]:
                         solid = solid.workplane(
                             offset=point[1] *
-                            factor).moveTo(
+                            factor).center(
                             point[0],
                             0).workplane()
                         for entry in instructions:
@@ -597,16 +597,16 @@ class Shape:
                                 solid = solid.polyline(list(entry.values())[0])
                             if list(entry.keys())[0] == "circle":
                                 p0, p1, p2 = list(entry.values())[0][:3]
-                                solid = solid.moveTo(
+                                solid = solid.center(
                                     p0[0], p0[1]).threePointArc(
                                     p1, p2)
-                        solid = solid.close().moveTo(
-                            0, 0).moveTo(-point[0], 0).workplane(offset=-point[1] * factor)
+                        solid = solid.close().center(
+                            0, 0).center(-point[0], 0).workplane(offset=-point[1] * factor)
 
                 elif self.force_cross_section == False:
                     solid = solid.workplane(
                         offset=self.path_points[0][1] *
-                        factor).moveTo(
+                        factor).center(
                         self.path_points[0][0],
                         0).workplane()
                     for entry in instructions:
@@ -619,16 +619,16 @@ class Shape:
                             p0 = list(entry.values())[0][0]
                             p1 = list(entry.values())[0][1]
                             p2 = list(entry.values())[0][2]
-                            solid = solid.moveTo(
+                            solid = solid.center(
                                 p0[0], p0[1]).threePointArc(
                                 p1, p2)
 
-                    solid = solid.close().moveTo(0,
-                                                 0).moveTo(-self.path_points[0][0],
+                    solid = solid.close().center(0,
+                                                 0).center(-self.path_points[0][0],
                                                            0).workplane(offset=-self.path_points[0][1] * factor)
 
                 solid = solid.workplane(
-                    offset=self.path_points[-1][1] * factor).moveTo(self.path_points[-1][0], 0).workplane()
+                    offset=self.path_points[-1][1] * factor).center(self.path_points[-1][0], 0).workplane()
 
             else:
                 # for rotate and extrude shapes

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -594,7 +594,7 @@ class Shape:
                                 solid = solid.polyline(list(entry.values())[0])
                             if list(entry.keys())[0] == "circle":
                                 p0, p1, p2 = list(entry.values())[0][:3]
-                                solid = solid.center(p0[0], p0[1]).\
+                                solid = solid.moveTo(p0[0], p0[1]).\
                                     threePointArc(p1, p2)
                         solid = solid.close()
                         solid = solid.center(-point[0], 0).\
@@ -616,7 +616,7 @@ class Shape:
                             p0 = list(entry.values())[0][0]
                             p1 = list(entry.values())[0][1]
                             p2 = list(entry.values())[0][2]
-                            solid = solid.center(
+                            solid = solid.moveTo(
                                 p0[0], p0[1]).threePointArc(
                                 p1, p2)
 

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -584,11 +584,8 @@ class Shape:
 
                 if self.force_cross_section:
                     for point in self.path_points[:-1]:
-                        solid = solid.workplane(
-                            offset=point[1] *
-                            factor).center(
-                            point[0],
-                            0).workplane()
+                        solid = solid.workplane(offset=point[1] * factor).\
+                            center(point[0], 0).workplane()
                         for entry in instructions:
                             if list(entry.keys())[0] == "spline":
                                 solid = solid.spline(
@@ -597,11 +594,11 @@ class Shape:
                                 solid = solid.polyline(list(entry.values())[0])
                             if list(entry.keys())[0] == "circle":
                                 p0, p1, p2 = list(entry.values())[0][:3]
-                                solid = solid.center(
-                                    p0[0], p0[1]).threePointArc(
-                                    p1, p2)
-                        solid = solid.close().center(
-                            0, 0).center(-point[0], 0).workplane(offset=-point[1] * factor)
+                                solid = solid.center(p0[0], p0[1]).\
+                                    threePointArc(p1, p2)
+                        solid = solid.close()
+                        solid = solid.center(-point[0], 0).\
+                            workplane(offset=-point[1] * factor)
 
                 elif self.force_cross_section == False:
                     solid = solid.workplane(
@@ -623,12 +620,12 @@ class Shape:
                                 p0[0], p0[1]).threePointArc(
                                 p1, p2)
 
-                    solid = solid.close().center(0,
-                                                 0).center(-self.path_points[0][0],
-                                                           0).workplane(offset=-self.path_points[0][1] * factor)
+                    solid = solid.close().center(0, 0).\
+                        center(-self.path_points[0][0], 0).\
+                        workplane(offset=-self.path_points[0][1] * factor)
 
-                solid = solid.workplane(
-                    offset=self.path_points[-1][1] * factor).center(self.path_points[-1][0], 0).workplane()
+                solid = solid.workplane(offset=self.path_points[-1][1] * factor).\
+                    center(self.path_points[-1][0], 0).workplane()
 
             else:
                 # for rotate and extrude shapes


### PR DESCRIPTION
## Proposed changes

PR to fix the sweep shapes. Faces placed at path_points were not being translated along the required axis, resulting in faces all being placed at x/y/z=0, at varying offsets. Instead of moveTo(), center() is a better alternative for translating the workplane origin (as suggested by the Cadquery developers).

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

No further comments
