### PR TITLE
Testing geometry only

### DIFF
--- a/.github/workflows/docker_ci_geometry.yml
+++ b/.github/workflows/docker_ci_geometry.yml
@@ -1,0 +1,17 @@
+
+name: CI
+on:  
+  pull_request:    
+    branches:
+    - develop  
+    - main
+jobs:  
+  build:     
+   runs-on: ubuntu-latest
+
+   steps:    
+   - uses: actions/checkout@v1
+   - name: Build and test with Docker
+     run: |
+       docker build -t paramak --build-arg include_neutronics=false --build-arg cq_version=master --build-arg compile_cores=2 .
+       docker run --rm paramak  /bin/bash -c "cd .. && bash run_tests_geometry.sh && curl -s https://codecov.io/bash | bash"

--- a/run_tests_geometry.sh
+++ b/run_tests_geometry.sh
@@ -1,0 +1,10 @@
+pytest tests/test_optional_imports.py -v --cov=paramak --cov-append --cov-report term --cov-report xml
+pytest tests/test_utils.py -v --cov=paramak --cov-append --cov-report term --cov-report xml
+pytest tests/test_Shape.py -v --cov=paramak --cov-append --cov-report term --cov-report xml
+pytest tests/test_Reactor.py -v --cov=paramak --cov-append --cov-report term --cov-report xml
+pytest tests/test_parametric_shapes/ -v --cov=paramak --cov-append --cov-report term --cov-report xml
+pytest tests/test_parametric_components/ -v --cov=paramak --cov-append --cov-report term --cov-report xml
+pytest tests/test_parametric_reactors/ -v --cov=paramak --cov-append --cov-report term --cov-report xml
+pytest tests/test_example_shapes.py -v --cov=paramak --cov-append --cov-report term --cov-report xml
+pytest tests/test_example_components.py -v --cov=paramak --cov-append --cov-report term --cov-report xml
+pytest tests/test_example_reactors.py -v --cov=paramak --cov-append --cov-report term --cov-report xml

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -747,15 +747,15 @@ class TestReactor(unittest.TestCase):
 
         def str_graveyard_offset():
             test_reactor.graveyard_offset = 'coucou'
+        self.assertRaises(TypeError, str_graveyard_offset)
 
         def negative_graveyard_offset():
             test_reactor.graveyard_offset = -2
+        self.assertRaises(ValueError, negative_graveyard_offset)
 
         def list_graveyard_offset():
             test_reactor.graveyard_offset = [1.2]
-        self.assertRaises(ValueError, str_graveyard_offset)
-        self.assertRaises(ValueError, negative_graveyard_offset)
-        self.assertRaises(ValueError, list_graveyard_offset)
+        self.assertRaises(TypeError, list_graveyard_offset)
 
     def test_compound_in_shapes(self):
         shape1 = paramak.RotateStraightShape(

--- a/tests/test_optional_imports.py
+++ b/tests/test_optional_imports.py
@@ -25,7 +25,9 @@ class TestImportErrors(unittest.TestCase):
 
         def get_neutronics_results_from_statepoint_file_raises_error():
             paramak.get_neutronics_results_from_statepoint_file('no_file.h5m')
-        self.assertRaises(ImportError, get_neutronics_results_from_statepoint_file_raises_error)
+        self.assertRaises(
+            ImportError,
+            get_neutronics_results_from_statepoint_file_raises_error)
 
 
 # neutronics material make_graveyard

--- a/tests/test_optional_imports.py
+++ b/tests/test_optional_imports.py
@@ -1,0 +1,37 @@
+
+import unittest
+
+import paramak
+
+
+class TestImportErrors(unittest.TestCase):
+
+    def test_pymoab_imports_raise_error(self):
+        """Checks errors are raised when a pymoab import is attempted"""
+
+        def test_pymoab_import_warning():
+            paramak.define_moab_core_and_tags
+        self.assertRaises(ImportError, test_pymoab_import_warning)
+
+    def test_save_2d_mesh_tally_as_png_raises_error(self):
+        """Checks errors are raised when a openmc import is attempted"""
+
+        def save_2d_mesh_tally_as_png_raises_error():
+            paramak._save_2d_mesh_tally_as_png('score', 'no_file.png', 'tally')
+        self.assertRaises(ImportError, save_2d_mesh_tally_as_png_raises_error)
+
+    def test_get_neutronics_results_from_statepoint_file_raises_error(self):
+        """Checks errors are raised when a openmc import is attempted"""
+
+        def get_neutronics_results_from_statepoint_file_raises_error():
+            paramak.get_neutronics_results_from_statepoint_file('no_file.h5m')
+        self.assertRaises(ImportError, get_neutronics_results_from_statepoint_file_raises_error)
+
+
+# neutronics material make_graveyard
+# openmc
+# vtk
+# parametric plasma source
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parametric_components/test_PoloidalSegments.py
+++ b/tests/test_parametric_components/test_PoloidalSegments.py
@@ -23,7 +23,7 @@ class TestPoloidalSegments(unittest.TestCase):
             )
 
         self.assertRaises(
-            ValueError, create_shape)
+            TypeError, create_shape)
 
     def test_solid_count_with_incorect_inputs2(self):
         """Checks the segmenter does not take a negative int as an input."""


### PR DESCRIPTION
## Proposed changes

This PR adds testing for the geometry only methods in the paramak.

The base docker image for this only has cadquery and the paramak, there are no neutronics packages.

This also allows us to test some of the rasiing of ImportErrors

It is nice to check that we don't accidentally introduce a mandatory neutronics package to the geometry aspects of the package

TODO

This testing done in github actions but could also be extended to Circle CI which could potentially raise the code coverage reported (as it would include the ImportError which are currently untested)


## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
