### PR TITLE
new double down build and mesh tally arg names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   # test:
   build:
     docker:
-      - image: ukaea/paramak:dependances
+      - image: ukaea/paramak:dependencies
     steps:
       - checkout
       - run:

--- a/.github/workflows/dockerhub-publish-dependencies.yml
+++ b/.github/workflows/dockerhub-publish-dependencies.yml
@@ -31,9 +31,9 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          dockerfile: DockerfileDependances
+          dockerfile: DockerfileDependencies
           push: true
-          tags: ukaea/paramak:dependances
+          tags: ukaea/paramak:dependencies
           build-args: |
             cq_version=master
             compile_cores=2

--- a/.github/workflows/dockerhub-publish-dependencies.yml
+++ b/.github/workflows/dockerhub-publish-dependencies.yml
@@ -31,7 +31,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          dockerfile: DockerfileDependencies
+          file: DockerfileDependencies
           push: true
           tags: ukaea/paramak:dependencies
           build-args: |

--- a/.github/workflows/dockerhub-publish-dependencies.yml
+++ b/.github/workflows/dockerhub-publish-dependencies.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           dockerfile: DockerfileDependances
           push: true
-          tags: ukaea/paramak:latest
+          tags: ukaea/paramak:dependances
           build-args: |
             cq_version=master
             compile_cores=2

--- a/.github/workflows/dockerhub-publish-geometry-dependencies.yml
+++ b/.github/workflows/dockerhub-publish-geometry-dependencies.yml
@@ -30,11 +30,11 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ukaea/paramak:dev-cq-master
+          tags: ukaea/paramak:geometry-dependencies
           build-args: |
             cq_version=master
             compile_cores=2
-            include_neutronics=true
+            include_neutronics=false
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN if [ "$include_neutronics" = "true" ] ; \
 
 # Clone and install NJOY2016
 RUN if [ "$include_neutronics" = "true" ] ; \
-    then git clone --single-branch --branch master https://github.com/njoy/NJOY2016 /opt/NJOY2016 ; \
+    then git clone --single-branch --branch master https://github.com/njoy/NJOY2016.git /opt/NJOY2016 ; \
     cd /opt/NJOY2016 ; \
     mkdir build ; \
     cd build ; \
@@ -101,7 +101,7 @@ RUN if [ "$include_neutronics" = "true" ] ; \
 
 # Clone and install Embree
 RUN if [ "$include_neutronics" = "true" ] ; \
-    then git clone --single-branch --branch master https://github.com/embree/embree ; \
+    then git clone --single-branch --branch master https://github.com/embree/embree.git ; \
     cd embree ; \
     mkdir build ; \
     cd build ; \
@@ -117,7 +117,7 @@ RUN if [ "$include_neutronics" = "true" ] ; \
     mkdir MOAB ; \
     cd MOAB ; \
     mkdir build ; \
-    git clone  --single-branch --branch develop https://bitbucket.org/fathomteam/moab/ ; \
+    git clone  --single-branch --branch develop https://bitbucket.org/fathomteam/moab.git ; \
     cd build ; \
     cmake ../moab -DENABLE_HDF5=ON \
                   -DENABLE_NETCDF=ON \
@@ -144,7 +144,7 @@ RUN if [ "$include_neutronics" = "true" ] ; \
 
 # Clone and install Double-Down
 RUN if [ "$include_neutronics" = "true" ] ; \
-    then git clone --single-branch --branch main https://github.com/pshriwise/double-down ; \
+    then git clone --single-branch --branch main https://github.com/pshriwise/double-down.git ; \
     cd double-down ; \
     mkdir build ; \
     cd build ; \
@@ -159,7 +159,7 @@ RUN if [ "$include_neutronics" = "true" ] ; \
 RUN if [ "$include_neutronics" = "true" ] ; \
     then mkdir DAGMC ; \
     cd DAGMC ; \
-    git clone --single-branch --branch develop https://github.com/svalinn/dagmc ; \
+    git clone --single-branch --branch develop https://github.com/svalinn/DAGMC.git ; \
     mkdir build ; \
     cd build ; \
     cmake ../dagmc -DBUILD_TALLY=ON \

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,7 +166,7 @@ RUN if [ "$include_neutronics" = "true" ] ; \
                    -DMOAB_DIR=/MOAB \
                    -DBUILD_STATIC_EXE=OFF \
                    -DBUILD_STATIC_LIBS=OFF \
-                   -DCMAKE_INSTALL_PREFIX=/dagmc/ ; \
+                   -DCMAKE_INSTALL_PREFIX=/DAGMC/ ; \
     make -j"$compile_cores" install ; \
     rm -rf /DAGMC/DAGMC /DAGMC/build ; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -168,7 +168,7 @@ RUN if [ "$include_neutronics" = "true" ] ; \
                    -DBUILD_STATIC_LIBS=OFF \
                    -DCMAKE_INSTALL_PREFIX=/dagmc/ ; \
     make -j"$compile_cores" install ; \
-    rm -rf /DAGMC/dagmc /DAGMC/build ; \
+    rm -rf /DAGMC/DAGMC /DAGMC/build ; \
     fi
 
 # Clone and install OpenMC with DAGMC

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# This Dockerfile creates an enviroment with the optional dependancies and the Paramak
 # This dockerfile can be built in a few different ways.
 # Docker build commands must be run from within the base repository directory
 #
@@ -188,8 +189,6 @@ RUN if [ "$include_neutronics" = "true" ] ; \
     fi
 
 ENV OPENMC_CROSS_SECTIONS=/root/nndc_hdf5/cross_sections.xml
-
-# Copies over the Paramak code from the local repository
 
 RUN if [ "$include_neutronics" = "true" ] ; \
     then pip install vtk ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -162,7 +162,7 @@ RUN if [ "$include_neutronics" = "true" ] ; \
     git clone --single-branch --branch develop https://github.com/svalinn/DAGMC.git ; \
     mkdir build ; \
     cd build ; \
-    cmake ../dagmc -DBUILD_TALLY=ON \
+    cmake ../DAGMC -DBUILD_TALLY=ON \
                    -DMOAB_DIR=/MOAB \
                    -DBUILD_STATIC_EXE=OFF \
                    -DBUILD_STATIC_LIBS=OFF \

--- a/DockerfileDependencies
+++ b/DockerfileDependencies
@@ -1,4 +1,4 @@
-# This Dockerfile creates an enviroment with all the optional dependancies
+# This Dockerfile creates an enviroment with the optional dependancies
 # This dockerfile can be built in a few different ways.
 # Docker build commands must be run from within the base repository directory
 #
@@ -121,17 +121,19 @@ RUN if [ "$include_neutronics" = "true" ] ; \
     cd build ; \
     cmake ../moab -DENABLE_HDF5=ON \
                   -DENABLE_NETCDF=ON \
-                  -DBUILD_SHARED_LIBS=OFF \
                   -DENABLE_FORTRAN=OFF \
-                  -DENABLE_BLASLAPACK=OFF ; \
+                  -DENABLE_BLASLAPACK=OFF \
+                  -DBUILD_SHARED_LIBS=OFF \
+                  -DCMAKE_INSTALL_PREFIX=/MOAB ; \
     make -j"$compile_cores" ; \
     make -j"$compile_cores" install ; \
     rm -rf * ; \
-    cmake ../moab -DBUILD_SHARED_LIBS=ON \
-                  -DENABLE_HDF5=ON \
+    cmake ../moab -DENABLE_HDF5=ON \
                   -DENABLE_PYMOAB=ON \
                   -DENABLE_FORTRAN=OFF \
-                  -DENABLE_BLASLAPACK=OFF ; \
+                  -DBUILD_SHARED_LIBS=ON \
+                  -DENABLE_BLASLAPACK=OFF \
+                  -DCMAKE_INSTALL_PREFIX=/MOAB ; \
     make -j"$compile_cores" ; \
     make -j"$compile_cores" install ; \
     cd pymoab ; \
@@ -146,8 +148,8 @@ RUN if [ "$include_neutronics" = "true" ] ; \
     cd double-down ; \
     mkdir build ; \
     cd build ; \
-    cmake .. -DCMAKE_INSTALL_PREFIX=.. \
-             -DMOAB_DIR=/MOAB \
+    cmake .. -DMOAB_DIR=/MOAB \
+             -DCMAKE_INSTALL_PREFIX=.. \
              -DEMBREE_DIR=/embree/lib/cmake/embree-3.12.1 ; \
     make -j"$compile_cores" ; \
     make -j"$compile_cores" install ; \
@@ -161,10 +163,10 @@ RUN if [ "$include_neutronics" = "true" ] ; \
     mkdir build ; \
     cd build ; \
     cmake ../dagmc -DBUILD_TALLY=ON \
-                   -DCMAKE_INSTALL_PREFIX=/dagmc/ \
                    -DMOAB_DIR=/MOAB \
+                   -DBUILD_STATIC_EXE=OFF \
                    -DBUILD_STATIC_LIBS=OFF \
-                   -DBUILD_STATIC_EXE=OFF ; \
+                   -DCMAKE_INSTALL_PREFIX=/dagmc/ ; \
     make -j"$compile_cores" install ; \
     rm -rf /DAGMC/dagmc /DAGMC/build ; \
     fi

--- a/DockerfileDependencies
+++ b/DockerfileDependencies
@@ -134,6 +134,9 @@ RUN if [ "$include_neutronics" = "true" ] ; \
                   -DENABLE_BLASLAPACK=OFF ; \
     make -j"$compile_cores" ; \
     make -j"$compile_cores" install ; \
+    cd pymoab ; \
+    bash install.sh ; \
+    python setup.py install ; \
     fi
 
 
@@ -144,7 +147,7 @@ RUN if [ "$include_neutronics" = "true" ] ; \
     mkdir build ; \
     cd build ; \
     cmake .. -DCMAKE_INSTALL_PREFIX=.. \
-             -DMOAB_DIR=/usr/local \
+             -DMOAB_DIR=/MOAB \
              -DEMBREE_DIR=/embree/lib/cmake/embree-3.12.1 ; \
     make -j"$compile_cores" ; \
     make -j"$compile_cores" install ; \
@@ -159,7 +162,7 @@ RUN if [ "$include_neutronics" = "true" ] ; \
     cd build ; \
     cmake ../dagmc -DBUILD_TALLY=ON \
                    -DCMAKE_INSTALL_PREFIX=/dagmc/ \
-                   -DMOAB_DIR=/usr/local \
+                   -DMOAB_DIR=/MOAB \
                    -DBUILD_STATIC_LIBS=OFF \
                    -DBUILD_STATIC_EXE=OFF ; \
     make -j"$compile_cores" install ; \

--- a/DockerfileDependencies
+++ b/DockerfileDependencies
@@ -162,13 +162,13 @@ RUN if [ "$include_neutronics" = "true" ] ; \
     git clone --single-branch --branch develop https://github.com/svalinn/DAGMC.git ; \
     mkdir build ; \
     cd build ; \
-    cmake ../dagmc -DBUILD_TALLY=ON \
+    cmake ../DAGMC -DBUILD_TALLY=ON \
                    -DMOAB_DIR=/MOAB \
                    -DBUILD_STATIC_EXE=OFF \
                    -DBUILD_STATIC_LIBS=OFF \
-                   -DCMAKE_INSTALL_PREFIX=/dagmc/ ; \
+                   -DCMAKE_INSTALL_PREFIX=/DAGMC/ ; \
     make -j"$compile_cores" install ; \
-    rm -rf /DAGMC/dagmc /DAGMC/build ; \
+    rm -rf /DAGMC/DAGMC /DAGMC/build ; \
     fi
 
 # Clone and install OpenMC with DAGMC

--- a/DockerfileDependencies
+++ b/DockerfileDependencies
@@ -90,7 +90,7 @@ RUN if [ "$include_neutronics" = "true" ] ; \
 
 # Clone and install NJOY2016
 RUN if [ "$include_neutronics" = "true" ] ; \
-    then git clone https://github.com/njoy/NJOY2016 /opt/NJOY2016 ; \
+    then git clone --single-branch --branch master https://github.com/njoy/NJOY2016.git /opt/NJOY2016 ; \
     cd /opt/NJOY2016 ; \
     mkdir build ; \
     cd build ; \
@@ -101,7 +101,7 @@ RUN if [ "$include_neutronics" = "true" ] ; \
 
 # Clone and install Embree
 RUN if [ "$include_neutronics" = "true" ] ; \
-    then git clone https://github.com/embree/embree ; \
+    then git clone --single-branch --branch master https://github.com/embree/embree.git ; \
     cd embree ; \
     mkdir build ; \
     cd build ; \
@@ -117,7 +117,7 @@ RUN if [ "$include_neutronics" = "true" ] ; \
     mkdir MOAB ; \
     cd MOAB ; \
     mkdir build ; \
-    git clone  --single-branch --branch develop https://bitbucket.org/fathomteam/moab/ ; \
+    git clone  --single-branch --branch develop https://bitbucket.org/fathomteam/moab.git ; \
     cd build ; \
     cmake ../moab -DENABLE_HDF5=ON \
                   -DENABLE_NETCDF=ON \
@@ -144,7 +144,7 @@ RUN if [ "$include_neutronics" = "true" ] ; \
 
 # Clone and install Double-Down
 RUN if [ "$include_neutronics" = "true" ] ; \
-    then git clone https://github.com/pshriwise/double-down ; \
+    then git clone --single-branch --branch main https://github.com/pshriwise/double-down.git ; \
     cd double-down ; \
     mkdir build ; \
     cd build ; \
@@ -159,7 +159,7 @@ RUN if [ "$include_neutronics" = "true" ] ; \
 RUN if [ "$include_neutronics" = "true" ] ; \
     then mkdir DAGMC ; \
     cd DAGMC ; \
-    git clone -b develop https://github.com/svalinn/dagmc ; \
+    git clone --single-branch --branch develop https://github.com/svalinn/DAGMC.git ; \
     mkdir build ; \
     cd build ; \
     cmake ../dagmc -DBUILD_TALLY=ON \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![N|Python](https://www.python.org/static/community_logos/python-powered-w-100x40.png)](https://www.python.org)
 [![CircleCI](https://circleci.com/gh/ukaea/paramak/tree/main.svg?style=svg)](https://circleci.com/gh/ukaea/paramak/tree/main)
 [![codecov](https://codecov.io/gh/ukaea/paramak/branch/main/graph/badge.svg)](https://codecov.io/gh/ukaea/paramak)
-[![PyPI](https://img.shields.io/pypi/v/paramak?color=green&label=green&logo=green&logoColor=green)](https://pypi.org/project/paramak/)
+[![PyPI](https://img.shields.io/pypi/v/paramak?color=brightgreen&label=pypi&logo=grebrightgreenen&logoColor=green)](https://pypi.org/project/paramak/)
 [![Documentation Status](https://readthedocs.org/projects/paramak/badge/?version=main)](https://paramak.readthedocs.io/en/main/?badge=main)
 [![dockerhub-publish-stable](https://github.com/ukaea/paramak/workflows/dockerhub-publish-stable/badge.svg)](https://github.com/ukaea/paramak/actions?query=workflow%3Adockerhub-publish-stable)
 [![DOI](https://zenodo.org/badge/269635577.svg)](https://zenodo.org/badge/latestdoi/269635577)
@@ -263,7 +263,7 @@ my_reactor.export_html('reactor.html')
 
 It is possible to convert a parametric Reactor model into a neutronics model.
 
-To install two additional python packages needed to run neutronics with a
+To install additional python packages needed to run neutronics with a
 modified pip install
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="paramak",
-    version="0.2.0",
+    version="0.2.1",
     author="The Paramak Development Team",
     author_email="jonathan.shimwell@ukaea.uk",
     description="Create 3D fusion reactor CAD models based on input parameters",


### PR DESCRIPTION
## Proposed changes

Keen to get this PR merged in as the I am keen to renamed mesh_tally args before anyone starts using them instead of renaming them in a few weeks and cause more trouble for any users. They are a relatively new feature so I think this tiny breaking change will be unnoticed.

- Changes to the NeutronicsModel arguments to make them conform to pep8. 
    - mesh_tally_2D is now mesh_tally_2d
    - mesh_tally_3D is now mesh_tally_3d


- Minor changes to the dockerfile
    - .git has been added to the endings of cloned repos where it was missing. Thanks to @AI-Pranto for spotting that on the workshop repo
    - double-down is now using the /embree folder as discussed https://github.com/openmc-dev/openmc/issues/1749


## Types of changes


- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [x] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

