### PR TITLE
Added export html for stp files

### DIFF
--- a/examples/example_parametric_components/make_all_parametric_components.py
+++ b/examples/example_parametric_components/make_all_parametric_components.py
@@ -425,6 +425,6 @@ if __name__ == "__main__":
     filenames = []
     for components in all_components:
         components.export_stp()
-        components.export_html()
+        components.export_html(components.stp_filename[:-4] + '.html')
         filenames.append(components.stp_filename)
     print(filenames)

--- a/examples/example_parametric_reactors/segmented_blanket_ball_reactor.py
+++ b/examples/example_parametric_reactors/segmented_blanket_ball_reactor.py
@@ -53,8 +53,6 @@ def make_ball_reactor_seg(outputs=['stp', 'neutronics', 'svg', 'stl', 'html']):
     my_reactor._blanket.solid = my_reactor._blanket.solid.cut(
         my_reactor._blanket.solid)
 
-    my_reactor._blanket.export_stp('firstwall_with_fillet.stp')
-
     if 'stp' in outputs:
         my_reactor.export_stp(output_folder='SegmentedBlanketBallReactor')
     if 'neutronics' in outputs:

--- a/examples/example_parametric_shapes/make_html_diagram_from_stp_file.py
+++ b/examples/example_parametric_shapes/make_html_diagram_from_stp_file.py
@@ -4,42 +4,48 @@ within the stp file."""
 
 import paramak
 
-# this creates a Shape object
-eample_shape = paramak.ExtrudeMixedShape(
-    distance=1,
-    points=[
-        (100, 0, "straight"),
-        (200, 0, "circle"),
-        (250, 50, "circle"),
-        (200, 100, "straight"),
-        (150, 100, "spline"),
-        (140, 75, "spline"),
-        (110, 45, "spline"),
-    ]
-)
-# This exports the Shape object as an stp file that will be imported later
-eample_shape.export_stp("eample_shape.stp")
 
-# this exports the shape as a html image
-fig = eample_shape.export_html()
+def main():
+    # this creates a Shape object
+    eample_shape = paramak.ExtrudeMixedShape(
+        distance=1,
+        points=[
+            (100, 0, "straight"),
+            (200, 0, "circle"),
+            (250, 50, "circle"),
+            (200, 100, "straight"),
+            (150, 100, "spline"),
+            (140, 75, "spline"),
+            (110, 45, "spline"),
+        ]
+    )
+    # This exports the Shape object as an stp file that will be imported later
+    eample_shape.export_stp("example_shape.stp")
 
-# shows the html image resulting from the solid shape directly
-fig.show()
+    # this exports the shape as a html image
+    fig = eample_shape.export_html("example_shape_from_solid.html")
 
-# loads the stp file and obtains the solid 3d shape and list of wires (edges)
-solid, wires = paramak.utils.load_stp_file(
-    filename='eample_shape.stp',
-)
+    # shows the html image resulting from the solid shape directly
+    fig.show()
 
-# produces a plot on the R (radius) Z axis and saves the html file
-fig = paramak.utils.export_wire_to_html(
-    wires=wires,
-    tolerance=0.1,
-    view_plane='XZ',
-    facet_splines=True,
-    facet_circles=True,
-    filename='firstwall.html',
-)
+    # loads the stp file and obtains the solid 3d shape and list of wires (edges)
+    solid, wires = paramak.utils.load_stp_file(
+        filename="example_shape.stp",
+    )
 
-# shows the html image resulting from the stp file load
-fig.show()
+    # produces a plot on the R (radius) Z axis and saves the html file
+    fig = paramak.utils.export_wire_to_html(
+        wires=wires,
+        tolerance=0.1,
+        view_plane="XZ",
+        facet_splines=True,
+        facet_circles=True,
+        filename="example_shape_from_stp.html",
+    )
+
+    # shows the html image resulting from the stp file load
+    fig.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/example_parametric_shapes/make_html_diagram_from_stp_file.py
+++ b/examples/example_parametric_shapes/make_html_diagram_from_stp_file.py
@@ -7,7 +7,7 @@ import paramak
 
 def main():
     # this creates a Shape object
-    eample_shape = paramak.ExtrudeMixedShape(
+    example_shape = paramak.ExtrudeMixedShape(
         distance=1,
         points=[
             (100, 0, "straight"),
@@ -20,10 +20,10 @@ def main():
         ]
     )
     # This exports the Shape object as an stp file that will be imported later
-    eample_shape.export_stp("example_shape.stp")
+    example_shape.export_stp("example_shape.stp")
 
     # this exports the shape as a html image
-    fig = eample_shape.export_html("example_shape_from_solid.html")
+    fig = example_shape.export_html("example_shape_from_solid.html")
 
     # shows the html image resulting from the solid shape directly
     fig.show()

--- a/examples/example_parametric_shapes/make_html_diagram_from_stp_file.py
+++ b/examples/example_parametric_shapes/make_html_diagram_from_stp_file.py
@@ -1,0 +1,45 @@
+"""Creates a stp file and then loads up the stp file and then facets the wires
+(edges) of the geometry and plots the faceted eges along with the vertices
+within the stp file."""
+
+import paramak
+
+# this creates a Shape object
+eample_shape = paramak.ExtrudeMixedShape(
+    distance=1,
+    points=[
+        (100, 0, "straight"),
+        (200, 0, "circle"),
+        (250, 50, "circle"),
+        (200, 100, "straight"),
+        (150, 100, "spline"),
+        (140, 75, "spline"),
+        (110, 45, "spline"),
+    ]
+)
+# This exports the Shape object as an stp file that will be imported later
+eample_shape.export_stp("eample_shape.stp")
+
+# this exports the shape as a html image
+fig = eample_shape.export_html()
+
+# shows the html image resulting from the solid shape directly
+fig.show()
+
+# loads the stp file and obtains the solid 3d shape and list of wires (edges)
+solid, wires = paramak.utils.load_stp_file(
+    filename='eample_shape.stp',
+)
+
+# produces a plot on the R (radius) Z axis and saves the html file
+fig = paramak.utils.export_wire_to_html(
+    wires=wires,
+    tolerance=0.1,
+    view_plane='XZ',
+    facet_splines=True,
+    facet_circles=True,
+    filename='firstwall.html',
+)
+
+# shows the html image resulting from the stp file load
+fig.show()

--- a/examples/example_parametric_shapes/make_html_diagram_from_stp_file.py
+++ b/examples/example_parametric_shapes/make_html_diagram_from_stp_file.py
@@ -28,7 +28,8 @@ def main():
     # shows the html image resulting from the solid shape directly
     fig.show()
 
-    # loads the stp file and obtains the solid 3d shape and list of wires (edges)
+    # loads the stp file and obtains the solid 3d shape and list of wires
+    # (edges)
     solid, wires = paramak.utils.load_stp_file(
         filename="example_shape.stp",
     )

--- a/paramak/parametric_components/cutting_wedge_fs.py
+++ b/paramak/parametric_components/cutting_wedge_fs.py
@@ -1,5 +1,5 @@
 
-from collections import Iterable
+from collections.abc import Iterable
 from operator import itemgetter
 
 from paramak import CuttingWedge

--- a/paramak/parametric_components/inboard_firstwall_fccs.py
+++ b/paramak/parametric_components/inboard_firstwall_fccs.py
@@ -1,5 +1,5 @@
 
-from collections import Iterable
+from collections.abc import Iterable
 
 from paramak import (CenterColumnShieldCircular, CenterColumnShieldCylinder,
                      CenterColumnShieldFlatTopCircular,

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -1,15 +1,13 @@
 
 import json
-from collections import Iterable
+from collections.abc import Iterable
 from pathlib import Path
 
 import cadquery as cq
 import matplotlib.pyplot as plt
-import plotly.graph_objects as go
 from cadquery import exporters
 
 import paramak
-from paramak.utils import facet_wire, plotly_trace
 from paramak.neutronics_utils import (add_stl_to_moab_core,
                                       define_moab_core_and_tags)
 from paramak.utils import get_hash

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -603,8 +603,11 @@ class Reactor:
         plane
 
         Args:
-            filename: the filename used to save the html graph.
-
+            filename: the filename used to save the html graph. Defaults to
+                reactor.html
+            view_plane: The axis to view the points and faceted edges from. The
+                options are 'XZ', 'XY', 'YZ', 'YX', 'ZY', 'ZX', 'RZ'. Defaults
+                to 'RZ'.
         Returns:
             plotly.Figure(): figure object
         """

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -612,8 +612,9 @@ class Reactor:
             plotly.Figure(): figure object
         """
 
-        # accesses the Shape wires for each Shape and builds up a list of traces
-        all_wires=[]
+        # accesses the Shape wires for each Shape and builds up a list of
+        # traces
+        all_wires = []
         for entry in self.shapes_and_components:
             if not isinstance(entry.wire, list):
                 list_of_wires = [entry.wire]
@@ -629,7 +630,7 @@ class Reactor:
             facet_circles=True,
             tolerance=1e-3,
             title="coordinates of the " + self.__class__.__name__ +
-                " reactor, viewed from the "+view_plane+" plane",
+            " reactor, viewed from the " + view_plane + " plane",
         )
 
         return fig

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -881,7 +881,7 @@ class Shape:
                 shape.html
             facet_splines: If True then spline edges will be faceted. Defaults
                 to True.
-            facet_circles: If True then circle edges will be faceted.Defaults
+            facet_circles: If True then circle edges will be faceted. Defaults
                 to True.
             tolerance: faceting toleranceto use when faceting cirles and
                 splines. Defaults to 1e-3.

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -910,7 +910,7 @@ class Shape:
             facet_circles=facet_circles,
             tolerance=1e-3,
             title="coordinates of " + self.__class__.__name__ +
-                " shape, viewed from the " + self.workplane + " plane",
+            " shape, viewed from the " + self.workplane + " plane",
         )
 
         # # sweep shapes have .path_points but not .points attribute

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -913,14 +913,24 @@ class Shape:
             " shape, viewed from the " + self.workplane + " plane",
         )
 
-        # # sweep shapes have .path_points but not .points attribute
-        # if self.points is not None:
-        #     fig.add_trace(plotly_trace(points=self.points, mode="markers"))
-        # if hasattr(self, 'path_points'):
-        #     fig.add_trace(
-        #         plotly_trace(
-        #             points=self.path_points,
-        #             mode="markers"))
+        if self.points is not None:
+            fig.add_trace(
+                plotly_trace(
+                    points=self.points,
+                    mode="markers",
+                    name='Shape.points'
+                )
+            )
+
+        # sweep shapes have .path_points but not .points attribute
+        if hasattr(self, 'path_points'):
+            fig.add_trace(
+                plotly_trace(
+                    points=self.path_points,
+                    mode="markers",
+                    name='Shape.path_points'
+                )
+            )
 
         return fig
 

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -1,15 +1,13 @@
 
 import json
-import math
 import numbers
 import warnings
-from collections import Iterable
+from collections.abc import Iterable
 from pathlib import Path
 from typing import List, Tuple
 
 import cadquery as cq
 import matplotlib.pyplot as plt
-import plotly.graph_objects as go
 from cadquery import exporters
 from matplotlib.collections import PatchCollection
 from matplotlib.patches import Polygon

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -1,6 +1,6 @@
 
 import math
-from collections import Iterable
+from collections.abc import Iterable
 from hashlib import blake2b
 from os import fdopen, remove
 from pathlib import Path
@@ -461,7 +461,7 @@ def extract_points_from_edges(
     view_plane: str = 'XZ',
 ):
 
-    if isinstance(edges, list):
+    if isinstance(edges, Iterable):
         list_of_edges = edges
     else:
         list_of_edges = [edges]

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -458,7 +458,7 @@ def plotly_trace(
 
 def extract_points_from_edges(
             edges,
-            view_plane='XZ',
+            view_plane: str = 'XZ',
         ):
 
     points = []
@@ -486,7 +486,10 @@ def extract_points_from_edges(
     return points
 
 
-def load_stp_file(filename, scale_factor=1.):
+def load_stp_file(
+    filename: str,
+    scale_factor: float = 1.
+):
     part = importers.importStep(filename).val()
 
     scaled_part = part.scale(scale_factor)

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -483,7 +483,7 @@ def extract_points_from_edges(
                         ValueError('view_plane value of ', view_plane,
                                    ' is not supported')
                     vertices.append(correspondance_table[ax])
-                points.append((*vertices))
+                points.append((vertices[0], vertices[1]))
     return points
 
 

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -470,20 +470,24 @@ def extract_points_from_edges(
 
     for edge in list_of_edges:
         for vertex in edge.Vertices():
-            correspondance_table = {
-                "X": vertex.X,
-                "Y": vertex.Y,
-                "Z": vertex.Z,
-                "R": math.sqrt(math.pow(vertex.X, 2) + math.pow(vertex.Y, 2))
-            }
-            vertices = []
-            for edge in list_of_edges:
-                for ax in view_plane:
-                    if ax not in correspondance_table.keys():
-                        ValueError('view_plane value of ', view_plane,
-                                   ' is not supported')
-                    vertices.append(correspondance_table[ax])
-                points.append((vertices[0], vertices[1]))
+            if view_plane == 'XZ':
+                points.append((vertex.X, vertex.Z))
+            elif view_plane == 'XY':
+                points.append((vertex.X, vertex.Y))
+            elif view_plane == 'YZ':
+                points.append((vertex.Y, vertex.Z))
+            elif view_plane == 'YX':
+                points.append((vertex.Y, vertex.X))
+            elif view_plane == 'ZY':
+                points.append((vertex.Z, vertex.Y))
+            elif view_plane == 'ZX':
+                points.append((vertex.Z, vertex.X))
+            elif view_plane == 'RZ':
+                xy = math.pow(vertex.X, 2) + math.pow(vertex.Y, 2)
+                points.append((math.sqrt(xy), vertex.Z))
+            else:
+                raise ValueError('view_plane value of ', view_plane,
+                                ' is not supported')
     return points
 
 

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -490,6 +490,18 @@ def load_stp_file(
     filename: str,
     scale_factor: float = 1.
 ):
+    """Loads a stp file and makes the 3D solid and wires avaialbe for use.
+
+    Args:
+        filename: the filename used to save the html graph.
+        scale_factor: a scaling factor to apply to the geometry that can be
+            used to increase the size or decrease the size of the geometry.
+            Useful when converting the geometry to cm for use in neutronics
+            simulations. 
+
+    Returns:
+        CadQuery.solid, CadQuery.Wires: soild and wires belonging to the object
+    """
     part = importers.importStep(filename).val()
 
     scaled_part = part.scale(scale_factor)
@@ -507,6 +519,29 @@ def export_wire_to_html(
     tolerance: float = 1e-3,
     title=None,
 ):
+    """Creates a html graph representation of the points within the wires.
+    Edges of certain types (spines and circles) can optionally be faceted. 
+    If filename provided doesn't end with .html then .html will be added.
+    Viewed from the XZ plane
+
+    Args:
+        wires (CadQuery.Wire): the wire (edge) to plot points from and to
+            optionally facet.
+        filename: the filename used to save the html graph.
+        view_plane: The axis to view the points and faceted edges from. The
+            options are 'XZ', 'XY', 'YZ', 'YX', 'ZY', 'ZX', 'RZ'. Defaults to
+            'RZ'
+        facet_splines: If True then spline edges will be faceted. Defaults to
+            True.
+        facet_circles: If True then circle edges will be faceted. Defaults to
+            True.
+        tolerance: faceting toleranceto use when faceting cirles and splines.
+            Defaults to 1e-3.
+        title: the title of the plotly plot.
+
+    Returns:
+        plotly.Figure(): figure object
+    """
 
     Path(filename).parents[0].mkdir(parents=True, exist_ok=True)
 

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -457,9 +457,9 @@ def plotly_trace(
 
 
 def extract_points_from_edges(
-            edges,
-            view_plane: str = 'XZ',
-        ):
+    edges,
+    view_plane: str = 'XZ',
+):
 
     points = []
 
@@ -497,7 +497,7 @@ def load_stp_file(
         scale_factor: a scaling factor to apply to the geometry that can be
             used to increase the size or decrease the size of the geometry.
             Useful when converting the geometry to cm for use in neutronics
-            simulations. 
+            simulations.
 
     Returns:
         CadQuery.solid, CadQuery.Wires: soild and wires belonging to the object
@@ -520,7 +520,7 @@ def export_wire_to_html(
     title=None,
 ):
     """Creates a html graph representation of the points within the wires.
-    Edges of certain types (spines and circles) can optionally be faceted. 
+    Edges of certain types (spines and circles) can optionally be faceted.
     If filename provided doesn't end with .html then .html will be added.
     Viewed from the XZ plane
 
@@ -563,10 +563,10 @@ def export_wire_to_html(
     for counter, wire in enumerate(wires):
 
         edges = facet_wire(
-                wire=wire,
-                facet_splines=facet_splines,
-                facet_circles=facet_circles,
-                tolerance=tolerance)
+            wire=wire,
+            facet_splines=facet_splines,
+            facet_circles=facet_circles,
+            tolerance=tolerance)
 
         points = paramak.utils.extract_points_from_edges(
             edges=edges,
@@ -576,7 +576,7 @@ def export_wire_to_html(
             points=points,
             mode="markers+lines",
             name='edge ' + str(counter)
-            )
+        )
         )
 
     for counter, wire in enumerate(wires):
@@ -596,7 +596,7 @@ def export_wire_to_html(
             points=points,
             mode="markers",
             name='points on wire ' + str(counter)
-            )
+        )
         )
 
     fig.write_html(str(path_filename))

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -470,24 +470,20 @@ def extract_points_from_edges(
 
     for edge in list_of_edges:
         for vertex in edge.Vertices():
-            if view_plane == 'XZ':
-                points.append((vertex.X, vertex.Z))
-            elif view_plane == 'XY':
-                points.append((vertex.X, vertex.Y))
-            elif view_plane == 'YZ':
-                points.append((vertex.Y, vertex.Z))
-            elif view_plane == 'YX':
-                points.append((vertex.Y, vertex.X))
-            elif view_plane == 'ZY':
-                points.append((vertex.Z, vertex.Y))
-            elif view_plane == 'ZX':
-                points.append((vertex.Z, vertex.X))
-            elif view_plane == 'RZ':
-                xy = math.pow(vertex.X, 2) + math.pow(vertex.Y, 2)
-                points.append((math.sqrt(xy), vertex.Z))
-            else:
-                raise ValueError('view_plane value of ', view_plane,
-                                 ' is not supported')
+            correspondance_table = {
+                "X": vertex.X,
+                "Y": vertex.Y,
+                "Z": vertex.Z,
+                "R": math.sqrt(math.pow(vertex.X, 2) + math.pow(vertex.Y, 2))
+            }
+            vertices = []
+            for edge in list_of_edges:
+                for ax in view_plane:
+                    if ax not in correspondance_table.keys():
+                        ValueError('view_plane value of ', view_plane,
+                                   ' is not supported')
+                    vertices.append(correspondance_table[ax])
+                points.append((*vertices))
     return points
 
 

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -502,7 +502,8 @@ def load_stp_file(
     Returns:
         CadQuery.solid, CadQuery.Wires: soild and wires belonging to the object
     """
-    part = importers.importStep(filename).val()
+
+    part = importers.importStep(str(filename)).val()
 
     scaled_part = part.scale(scale_factor)
     solid = scaled_part
@@ -525,8 +526,8 @@ def export_wire_to_html(
     Viewed from the XZ plane
 
     Args:
-        wires (CadQuery.Wire): the wire (edge) to plot points from and to
-            optionally facet.
+        wires (CadQuery.Wire): the wire (edge) or list of wires to plot points
+            from and to optionally facet.
         filename: the filename used to save the html graph.
         view_plane: The axis to view the points and faceted edges from. The
             options are 'XZ', 'XY', 'YZ', 'YX', 'ZY', 'ZX', 'RZ'. Defaults to
@@ -560,7 +561,12 @@ def export_wire_to_html(
         }
     )
 
-    for counter, wire in enumerate(wires):
+    if isinstance(wires, list):
+        list_of_wires = wires
+    else:
+        list_of_wires = [wires]
+
+    for counter, wire in enumerate(list_of_wires):
 
         edges = facet_wire(
             wire=wire,
@@ -579,7 +585,7 @@ def export_wire_to_html(
         )
         )
 
-    for counter, wire in enumerate(wires):
+    for counter, wire in enumerate(list_of_wires):
 
         if isinstance(wire, cq.occ_impl.shapes.Wire):
             # this is for imported stp files

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -461,9 +461,14 @@ def extract_points_from_edges(
     view_plane: str = 'XZ',
 ):
 
+    if isinstance(edges, list):
+        list_of_edges = edges
+    else:
+        list_of_edges = [edges]
+
     points = []
 
-    for edge in edges:
+    for edge in list_of_edges:
         for vertex in edge.Vertices():
             if view_plane == 'XZ':
                 points.append((vertex.X, vertex.Z))
@@ -572,17 +577,20 @@ def export_wire_to_html(
             wire=wire,
             facet_splines=facet_splines,
             facet_circles=facet_circles,
-            tolerance=tolerance)
+            tolerance=tolerance
+        )
 
         points = paramak.utils.extract_points_from_edges(
             edges=edges,
-            view_plane=view_plane)
-
-        fig.add_trace(plotly_trace(
-            points=points,
-            mode="markers+lines",
-            name='edge ' + str(counter)
+            view_plane=view_plane
         )
+
+        fig.add_trace(
+            plotly_trace(
+                points=points,
+                mode="markers+lines",
+                name='edge ' + str(counter)
+            )
         )
 
     for counter, wire in enumerate(list_of_wires):

--- a/tests/test_example_shapes.py
+++ b/tests/test_example_shapes.py
@@ -106,7 +106,7 @@ class TestExampleShapes(unittest.TestCase):
         """Checks than a list of wires is an acceptable input
         for export_wire_to_html wires argument.
         """
-        
+
         example_shape = paramak.ExtrudeMixedShape(
             distance=1,
             points=[
@@ -124,7 +124,7 @@ class TestExampleShapes(unittest.TestCase):
             facet_circles=True,
             filename="example_shape_from_stp.html",
         )
-        
+
         assert fig is not None
 
     def test_incorrect_view_plane(self):

--- a/tests/test_example_shapes.py
+++ b/tests/test_example_shapes.py
@@ -102,6 +102,31 @@ class TestExampleShapes(unittest.TestCase):
             assert Path(output_filename).exists() is True
             os.system("rm " + output_filename)
 
+    def test_list_of_wires_can_be_exported(self):
+        """Checks than a list of wires is an acceptable input
+        for export_wire_to_html wires argument.
+        """
+        
+        example_shape = paramak.ExtrudeMixedShape(
+            distance=1,
+            points=[
+                (150, 100, "spline"),
+                (140, 75, "spline"),
+                (110, 45, "spline"),
+            ]
+        )
+
+        fig = paramak.utils.export_wire_to_html(
+            wires=[example_shape.wire],
+            tolerance=0.1,
+            view_plane="XY",
+            facet_splines=True,
+            facet_circles=True,
+            filename="example_shape_from_stp.html",
+        )
+        
+        assert fig is not None
+
     def test_incorrect_view_plane(self):
         """Checks than an error is raised when incorrect values of the
         view_plane is set

--- a/tests/test_example_shapes.py
+++ b/tests/test_example_shapes.py
@@ -7,7 +7,10 @@ from pathlib import Path
 from examples.example_parametric_shapes import (
     make_blanket_from_parameters, make_blanket_from_points,
     make_CAD_from_points, make_can_reactor_from_parameters,
-    make_can_reactor_from_points, make_html_diagram_from_stp_file)
+    make_can_reactor_from_points, make_html_diagram_from_stp_file,
+    )
+
+import paramak
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'examples'))
 
@@ -98,6 +101,36 @@ class TestExampleShapes(unittest.TestCase):
         for output_filename in output_filenames:
             assert Path(output_filename).exists() is True
             os.system("rm " + output_filename)
+
+    def test_incorrect_view_plane(self):
+        """Checks than an error is raised when incorrect values of the
+        view_plane is set
+        """
+
+        def set_value():
+            example_shape = paramak.ExtrudeMixedShape(
+                distance=1,
+                points=[
+                    (100, 0, "straight"),
+                    (200, 0, "circle"),
+                    (250, 50, "circle"),
+                    (200, 100, "straight"),
+                    (150, 100, "spline"),
+                    (140, 75, "spline"),
+                    (110, 45, "spline"),
+                ]
+            )
+
+            paramak.utils.export_wire_to_html(
+                wires=example_shape.wire,
+                tolerance=0.1,
+                view_plane="coucou",
+                facet_splines=True,
+                facet_circles=True,
+                filename="example_shape_from_stp.html",
+            )
+
+        self.assertRaises(ValueError, set_value)
 
 
 if __name__ == "__main__":

--- a/tests/test_example_shapes.py
+++ b/tests/test_example_shapes.py
@@ -8,7 +8,7 @@ from examples.example_parametric_shapes import (
     make_blanket_from_parameters, make_blanket_from_points,
     make_CAD_from_points, make_can_reactor_from_parameters,
     make_can_reactor_from_points, make_html_diagram_from_stp_file,
-    )
+)
 
 import paramak
 

--- a/tests/test_example_shapes.py
+++ b/tests/test_example_shapes.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from examples.example_parametric_shapes import (
     make_blanket_from_parameters, make_blanket_from_points,
     make_CAD_from_points, make_can_reactor_from_parameters,
-    make_can_reactor_from_points)
+    make_can_reactor_from_points, make_html_diagram_from_stp_file)
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'examples'))
 
@@ -81,6 +81,20 @@ class TestExampleShapes(unittest.TestCase):
         for output_filename in output_filenames:
             os.system("rm " + output_filename)
         make_can_reactor_from_points.main()
+        for output_filename in output_filenames:
+            assert Path(output_filename).exists() is True
+            os.system("rm " + output_filename)
+
+    def test_make_html_diagram_from_stp_file(self):
+        """Runs the example and checks the output files are produced"""
+        output_filenames = [
+            "example_shape.stp",
+            "example_shape_from_solid.html",
+            "example_shape_from_stp.html",
+        ]
+        for output_filename in output_filenames:
+            os.system("rm " + output_filename)
+        make_html_diagram_from_stp_file.main()
         for output_filename in output_filenames:
             assert Path(output_filename).exists() is True
             os.system("rm " + output_filename)


### PR DESCRIPTION
## Proposed changes

This PR adds some helpful functions to the utils

The ```paramak.utils.load_stp_file``` function allows stp files to be loaded and returns the solid and wires.

The ```paramak.utils.export_wire_to_html``` function allows a list of wires to be exported to a html plot.

Reactors can now be viewed from different view_planes

This PR also refactors the various export_html methods in Reactor and Shape classes so that their is less duplication

![Screenshot from 2021-01-31 00-12-36](https://user-images.githubusercontent.com/8583900/106371172-28a3e180-6359-11eb-9f55-9a81ded6cd83.png)

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [x] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
