### PR TITLE
moving to new CQ export method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ RUN if [ "$include_neutronics" = "true" ] ; \
     mkdir MOAB ; \
     cd MOAB ; \
     mkdir build ; \
-    git clone  --single-branch --branch master https://bitbucket.org/fathomteam/moab.git ; \
+    git clone  --single-branch --branch develop https://bitbucket.org/fathomteam/moab.git ; \
     cd build ; \
     cmake ../moab -DENABLE_HDF5=ON \
                   -DENABLE_NETCDF=ON \

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ RUN if [ "$include_neutronics" = "true" ] ; \
     mkdir MOAB ; \
     cd MOAB ; \
     mkdir build ; \
-    git clone  --single-branch --branch develop https://bitbucket.org/fathomteam/moab.git ; \
+    git clone  --single-branch --branch master https://bitbucket.org/fathomteam/moab.git ; \
     cd build ; \
     cmake ../moab -DENABLE_HDF5=ON \
                   -DENABLE_NETCDF=ON \

--- a/paramak/parametric_neutronics/make_faceteted_neutronics_model.py
+++ b/paramak/parametric_neutronics/make_faceteted_neutronics_model.py
@@ -109,9 +109,9 @@ def find_all_surfaces_of_reflecting_wedge(new_vols):
         #area = surface.area()
         vertex_in_surface = cubit.parse_cubit_list("vertex", " in surface " + str(surface_id))
         if surface.is_planar() == True and len(vertex_in_surface) == 4:
-        surface_info_dict[surface_id] = {'reflector': True}
+            surface_info_dict[surface_id] = {'reflector': True}
         else:
-        surface_info_dict[surface_id] = {'reflector': False}
+            surface_info_dict[surface_id] = {'reflector': False}
     print('surface_info_dict', surface_info_dict)
     return surface_info_dict
 

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -494,8 +494,8 @@ class Reactor:
 
         path_filename.parents[0].mkdir(parents=True, exist_ok=True)
 
-        with open(path_filename, "w") as out_file:
-            exporters.exportShape(self.solid, "SVG", out_file)
+        exporters.export(self.solid, str(path_filename), exportType='SVG')
+
         print("Saved file as ", path_filename)
 
         return str(path_filename)

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -739,13 +739,15 @@ class Shape:
 
         return self.x_min, self.x_max, self.z_min, self.z_max
 
-    def export_stl(self, filename: str, tolerance: float = 0.001) -> str:
+    def export_stl(self, filename: str, tolerance: float = 0.001,
+                   angular_tolerance: float = 0.1) -> str:
         """Exports an stl file for the Shape.solid. If the provided filename
-            doesn't end with .stl it will be added
+            doesn't end with .stl it will be added.
 
         Args:
-            filename (str): the filename of the stl file to be exported
-            tolerance (float): the precision of the faceting
+            filename: the filename of the stl file to be exported
+            tolerance: the deflection tolerance of the faceting
+            angular_tolerance: the angular tolerance, in radians
         """
 
         path_filename = Path(filename)
@@ -755,8 +757,10 @@ class Shape:
 
         path_filename.parents[0].mkdir(parents=True, exist_ok=True)
 
-        with open(path_filename, "w") as out_file:
-            exporters.exportShape(self.solid, "STL", out_file, tolerance)
+        exporters.export(self.solid, str(path_filename), exportType='STL',
+                         tolerance=tolerance,
+                         angularTolerance=angular_tolerance)
+
         print("Saved file as ", path_filename)
 
         return str(path_filename)
@@ -792,14 +796,10 @@ class Shape:
         elif self.stp_filename is not None:
             path_filename = Path(self.stp_filename)
 
-        with open(path_filename, "w") as out_file:
-            if mode == 'solid':
-                exporters.exportShape(self.solid, "STEP", out_file)
-            elif mode == 'wire':
-                exporters.exportShape(self.wire, "STEP", out_file)
-            else:
-                raise ValueError("The mode argument for export_stp \
-                    only accepts 'solid' or 'wire'", self)
+        if mode == 'solid':
+            exporters.export(self.solid, str(path_filename), exportType='STEP')
+        elif mode == 'wire':
+            exporters.export(self.wire, str(path_filename), exportType='STEP')
 
         if units == 'cm':
             _replace(
@@ -856,8 +856,8 @@ class Shape:
 
         path_filename.parents[0].mkdir(parents=True, exist_ok=True)
 
-        with open(path_filename, "w") as out_file:
-            exporters.exportShape(self.solid, "SVG", out_file)
+        exporters.export(self.solid, str(path_filename), exportType='SVG')
+
         print("Saved file as ", path_filename)
 
         return str(path_filename)

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -800,6 +800,9 @@ class Shape:
             exporters.export(self.solid, str(path_filename), exportType='STEP')
         elif mode == 'wire':
             exporters.export(self.wire, str(path_filename), exportType='STEP')
+        else:
+            raise ValueError("The mode argument for export_stp \
+                only accepts 'solid' or 'wire'", self)
 
         if units == 'cm':
             _replace(

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -757,9 +757,12 @@ class Shape:
 
         path_filename.parents[0].mkdir(parents=True, exist_ok=True)
 
-        exporters.export(self.solid, str(path_filename), exportType='STL',
-                         tolerance=tolerance,
-                         angularTolerance=angular_tolerance)
+        with open(path_filename, "w") as out_file:
+            exporters.exportShape(self.solid, "STL", out_file, tolerance)
+
+        # exporters.export(self.solid, str(path_filename), exportType='STL',
+        #                  tolerance=tolerance,
+        #                  angularTolerance=angular_tolerance)
 
         print("Saved file as ", path_filename)
 


### PR DESCRIPTION
## Proposed changes

This removes the opening of a file and use of exporters.exportShape and replaces it with exporters.export as discussed in #82 

The former is now depreciated.

The new option will also support additional SVG options via an opt keyword once CQ 2.1 is released 

Also slightly more control over the stl export is also offered via the introduction of a new argument called ```angular_tolerance```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
