### PR TITLE
added type hints to args and removed from docstring

### DIFF
--- a/paramak/parametric_shapes/extruded_circle_shape.py
+++ b/paramak/parametric_shapes/extruded_circle_shape.py
@@ -1,4 +1,6 @@
 
+from typing import Optional
+
 import cadquery as cq
 from paramak import Shape
 from paramak.utils import calculate_wedge_cut
@@ -8,26 +10,26 @@ class ExtrudeCircleShape(Shape):
     """Extrudes a circular 3d CadQuery solid from a central point and a radius
 
     Args:
-        distance (float): the extrusion distance to use (cm units if used for
+        distance: the extrusion distance to use (cm units if used for
             neutronics)
-        radius (float): radius of the shape.
-        rotation_angle (float): rotation_angle of solid created. a cut is
-            performed from rotation_angle to 360 degrees. Defaults to 360.
-        extrude_both (bool, optional): if set to True, the extrusion will
-            occur in both directions. Defaults to True.
-        stp_filename (str, optional): Defaults to "ExtrudeCircleShape.stp".
-        stl_filename (str, optional): Defaults to "ExtrudeCircleShape.stl".
+        radius: radius of the shape.
+        rotation_angle: rotation_angle of solid created. a cut is performed
+            from rotation_angle to 360 degrees. Defaults to 360.
+        extrude_both: if set to True, the extrusion will occur in both
+            directions. Defaults to True.
+        stp_filename: Defaults to "ExtrudeCircleShape.stp".
+        stl_filename: Defaults to "ExtrudeCircleShape.stl".
     """
 
     def __init__(
         self,
-        distance,
-        radius,
-        extrusion_start_offset=0.0,
-        rotation_angle=360,
-        extrude_both=True,
-        stp_filename="ExtrudeCircleShape.stp",
-        stl_filename="ExtrudeCircleShape.stl",
+        distance: float,
+        radius: float,
+        extrusion_start_offset: Optional[float] = 0.0,
+        rotation_angle: Optional[float] = 360,
+        extrude_both: Optional[bool] = True,
+        stp_filename: Optional[str] = "ExtrudeCircleShape.stp",
+        stl_filename: Optional[str] = "ExtrudeCircleShape.stl",
         **kwargs
     ):
 

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -14,8 +14,8 @@ class ExtrudeMixedShape(Shape):
             neutronics)
         extrude_both: If set to True, the extrusion will occur in both
             directions. Defaults to True.
-        rotation_angle: rotation angle of solid created. A cut is performed from
-            rotation_angle to 360 degrees. Defaults to 360.0.
+        rotation_angle: rotation angle of solid created. A cut is performed
+            from rotation_angle to 360 degrees. Defaults to 360.0.
         stp_filename: Defaults to "ExtrudeMixedShape.stp".
         stl_filename: Defaults to "ExtrudeMixedShape.stl".
 

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -1,4 +1,6 @@
 
+from typing import Optional
+
 from paramak import Shape
 from paramak.utils import calculate_wedge_cut
 
@@ -8,26 +10,25 @@ class ExtrudeMixedShape(Shape):
     straight and spline connections.
 
     Args:
-        distance (float): the extrusion distance to use (cm units if used for
+        distance: the extrusion distance to use (cm units if used for 
             neutronics)
-        extrude_both (bool, optional): If set to True, the extrusion will
-            occur in both directions. Defaults to True.
-        rotation_angle (float, optional): rotation angle of solid created. A
-            cut is performed from rotation_angle to 360 degrees. Defaults to
-            360.0.
-        stp_filename (str, optional): Defaults to "ExtrudeMixedShape.stp".
-        stl_filename (str, optional): Defaults to "ExtrudeMixedShape.stl".
+        extrude_both: If set to True, the extrusion will occur in both 
+            directions. Defaults to True.
+        rotation_angle: rotation angle of solid created. A cut is performed from
+            rotation_angle to 360 degrees. Defaults to 360.0.
+        stp_filename: Defaults to "ExtrudeMixedShape.stp".
+        stl_filename: Defaults to "ExtrudeMixedShape.stl".
 
     """
 
     def __init__(
         self,
-        distance,
-        extrude_both=True,
-        rotation_angle=360.0,
-        extrusion_start_offset=0.0,
-        stp_filename="ExtrudeMixedShape.stp",
-        stl_filename="ExtrudeMixedShape.stl",
+        distance: float,
+        extrude_both: Optional[bool] = True,
+        rotation_angle: Optional[float] = 360.0,
+        extrusion_start_offset: Optional[float] = 0.0,
+        stp_filename: Optional[str] = "ExtrudeMixedShape.stp",
+        stl_filename: Optional[str] = "ExtrudeMixedShape.stl",
         **kwargs
     ):
 

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -10,9 +10,9 @@ class ExtrudeMixedShape(Shape):
     straight and spline connections.
 
     Args:
-        distance: the extrusion distance to use (cm units if used for 
+        distance: the extrusion distance to use (cm units if used for
             neutronics)
-        extrude_both: If set to True, the extrusion will occur in both 
+        extrude_both: If set to True, the extrusion will occur in both
             directions. Defaults to True.
         rotation_angle: rotation angle of solid created. A cut is performed from
             rotation_angle to 360 degrees. Defaults to 360.0.

--- a/paramak/parametric_shapes/extruded_spline_shape.py
+++ b/paramak/parametric_shapes/extruded_spline_shape.py
@@ -1,4 +1,6 @@
 
+from typing import Optional
+
 from paramak import ExtrudeMixedShape
 
 
@@ -7,17 +9,17 @@ class ExtrudeSplineShape(ExtrudeMixedShape):
     connections.
 
     Args:
-        distance (float): the extrusion distance to use (cm units if used for
+        distance: the extrusion distance to use (cm units if used for
             neutronics).
-        stp_filename (str, optional): Defaults to "ExtrudeSplineShape.stp".
-        stl_filename (str, optional): Defaults to "ExtrudeSplineShape.stl".
+        stp_filename: Defaults to "ExtrudeSplineShape.stp".
+        stl_filename: Defaults to "ExtrudeSplineShape.stl".
     """
 
     def __init__(
         self,
-        distance,
-        stp_filename="ExtrudeSplineShape.stp",
-        stl_filename="ExtrudeSplineShape.stl",
+        distance: float,
+        stp_filename: Optional[str] = "ExtrudeSplineShape.stp",
+        stl_filename: Optional[str] = "ExtrudeSplineShape.stl",
         **kwargs
     ):
 

--- a/paramak/parametric_shapes/extruded_straight_shape.py
+++ b/paramak/parametric_shapes/extruded_straight_shape.py
@@ -1,4 +1,6 @@
 
+from typing import Optional
+
 from paramak import ExtrudeMixedShape
 
 
@@ -6,17 +8,17 @@ class ExtrudeStraightShape(ExtrudeMixedShape):
     """Extrudes a 3d CadQuery solid from points connected with straight lines.
 
     Args:
-        distance (float): the extrusion distance to use (cm units if used for
+        distance: the extrusion distance to use (cm units if used for
             neutronics)
-        stp_filename (str, optional): Defaults to "ExtrudeStraightShape.stp".
-        stl_filename (str, optional): Defaults to "ExtrudeStraightShape.stl".
+        stp_filename: Defaults to "ExtrudeStraightShape.stp".
+        stl_filename: Defaults to "ExtrudeStraightShape.stl".
     """
 
     def __init__(
         self,
-        distance,
-        stp_filename="ExtrudeStraightShape.stp",
-        stl_filename="ExtrudeStraightShape.stl",
+        distance: float,
+        stp_filename: Optional[str] = "ExtrudeStraightShape.stp",
+        stl_filename: Optional[str] = "ExtrudeStraightShape.stl",
         **kwargs
     ):
 

--- a/paramak/parametric_shapes/rotate_circle_shape.py
+++ b/paramak/parametric_shapes/rotate_circle_shape.py
@@ -1,4 +1,6 @@
 
+from typing import Optional
+
 import cadquery as cq
 from paramak import Shape
 
@@ -7,19 +9,19 @@ class RotateCircleShape(Shape):
     """Rotates a circular 3d CadQuery solid from a central point and a radius
 
     Args:
-        radius (float): radius of the shape
-        rotation_angle (float, optional): The rotation_angle to use when
-            revolving the solid (degrees). Defaults to 360.0.
-        stp_filename (str, optional):  Defaults to "RotateCircleShape.stp".
-        stl_filename (str, optional):  Defaults to "RotateCircleShape.stl".
+        radius: radius of the shape
+        rotation_angle: The rotation_angle to use when revolving the solid
+            (degrees). Defaults to 360.0.
+        stp_filename:  Defaults to "RotateCircleShape.stp".
+        stl_filename:  Defaults to "RotateCircleShape.stl".
     """
 
     def __init__(
         self,
-        radius,
-        rotation_angle=360.0,
-        stp_filename="RotateCircleShape.stp",
-        stl_filename="RotateCircleShape.stl",
+        radius: float,
+        rotation_angle: Optional[float] = 360.0,
+        stp_filename: Optional[str] = "RotateCircleShape.stp",
+        stl_filename: Optional[str] = "RotateCircleShape.stl",
         **kwargs
     ):
 

--- a/paramak/parametric_shapes/rotate_mixed_shape.py
+++ b/paramak/parametric_shapes/rotate_mixed_shape.py
@@ -1,4 +1,6 @@
 
+from typing import Optional
+
 from paramak import Shape
 
 
@@ -15,9 +17,9 @@ class RotateMixedShape(Shape):
 
     def __init__(
         self,
-        rotation_angle=360.0,
-        stp_filename="RotateMixedShape.stp",
-        stl_filename="RotateMixedShape.stl",
+        rotation_angle: Optional[float] = 360.0,
+        stp_filename: Optional[str] = "RotateMixedShape.stp",
+        stl_filename: Optional[str] = "RotateMixedShape.stl",
         **kwargs
     ):
 

--- a/paramak/parametric_shapes/rotate_mixed_shape.py
+++ b/paramak/parametric_shapes/rotate_mixed_shape.py
@@ -9,10 +9,10 @@ class RotateMixedShape(Shape):
     straight lines and splines.
 
     Args:
-        rotation_angle (float, optional): The rotation_angle to use when
-            revolving the solid (degrees). Defaults to 360.0.
-        stp_filename (str, optional):  Defaults to "RotateMixedShape.stp".
-        stl_filename (str, optional):  Defaults to "RotateMixedShape.stl".
+        rotation_angle: The rotation_angle to use when revolving the solid
+            (degrees). Defaults to 360.0.
+        stp_filename:  Defaults to "RotateMixedShape.stp".
+        stl_filename:  Defaults to "RotateMixedShape.stl".
     """
 
     def __init__(

--- a/paramak/parametric_shapes/rotate_spline_shape.py
+++ b/paramak/parametric_shapes/rotate_spline_shape.py
@@ -8,10 +8,10 @@ class RotateSplineShape(RotateMixedShape):
     """Rotates a 3d CadQuery solid from points connected with splines.
 
     Args:
-        rotation_angle (float, optional): The rotation_angle to use when
-            revolving the solid (degrees). Defaults to 360.0.
-        stp_filename (str, optional): Defaults to "RotateSplineShape.stp".
-        stl_filename (str, optional): Defaults to "RotateSplineShape.stl".
+        rotation_angle: The rotation_angle to use when revolving the solid.
+            Defaults to 360.0.
+        stp_filename: Defaults to "RotateSplineShape.stp".
+        stl_filename: Defaults to "RotateSplineShape.stl".
     """
 
     def __init__(

--- a/paramak/parametric_shapes/rotate_straight_shape.py
+++ b/paramak/parametric_shapes/rotate_straight_shape.py
@@ -9,10 +9,10 @@ class RotateStraightShape(RotateMixedShape):
     connections.
 
     Args:
-        rotation_angle (float): The rotation angle to use when revolving the
-            solid (degrees).
-        stp_filename (str, optional): Defaults to "RotateStraightShape.stp".
-        stl_filename (str, optional): Defaults to "RotateStraightShape.stl".
+        rotation_angle: The rotation angle to use when revolving the solid
+            (degrees).
+        stp_filename: Defaults to "RotateStraightShape.stp".
+        stl_filename: Defaults to "RotateStraightShape.stl".
     """
 
     def __init__(

--- a/paramak/parametric_shapes/rotate_straight_shape.py
+++ b/paramak/parametric_shapes/rotate_straight_shape.py
@@ -1,4 +1,6 @@
 
+from typing import Optional
+
 from paramak import RotateMixedShape
 
 
@@ -15,9 +17,9 @@ class RotateStraightShape(RotateMixedShape):
 
     def __init__(
         self,
-        rotation_angle=360.0,
-        stp_filename="RotateStraightShape.stp",
-        stl_filename="RotateStraightShape.stl",
+        rotation_angle: Optional[float] = 360.0,
+        stp_filename: Optional[str] = "RotateStraightShape.stp",
+        stl_filename: Optional[str] = "RotateStraightShape.stl",
         **kwargs
     ):
 

--- a/paramak/parametric_shapes/sweep_circle_shape.py
+++ b/paramak/parametric_shapes/sweep_circle_shape.py
@@ -11,19 +11,18 @@ class SweepCircleShape(Shape):
     the solid may occur.
 
     Args:
-        radius (float): Radius of 2D circle to be swept.
-        path_points (list of tuples each containing X (float), Z (float)): A
-            list of XY, YZ or XZ coordinates connected by spline connections
-            which define the path along which the 2D shape is swept.
-        workplane (str, optional): Workplane in which the circle to be swept
+        radius: Radius of 2D circle to be swept.
+        path_points: A list of XY, YZ or XZ coordinates connected by spline
+            connections which define the path along which the 2D shape is swept
+        workplane: Workplane in which the circle to be swept
             is defined. Defaults to "XY".
-        path_workplane (str, optional): Workplane in which the spline path is
+        path_workplane: Workplane in which the spline path is
             defined. Defaults to "XZ".
-        stp_filename (str, optional): Defaults to "SweepCircleShape.stp".
-        stl_filename (str, optional): Defaults to "SweepCircleShape.stl".
-        force_cross_section (bool, optional): If True, cross-section of solid
-            is forced to be shape defined by points in workplane at each
-            path_point. Defaults to False.
+        stp_filename: Defaults to "SweepCircleShape.stp".
+        stl_filename: Defaults to "SweepCircleShape.stl".
+        force_cross_section: If True, cross-section of solid is forced to be
+            shape defined by points in workplane at each path_point. Defaults
+            to False.
     """
 
     def __init__(

--- a/paramak/parametric_shapes/sweep_circle_shape.py
+++ b/paramak/parametric_shapes/sweep_circle_shape.py
@@ -1,4 +1,6 @@
 
+from typing import Optional, List, Tuple
+
 import cadquery as cq
 from paramak import Shape
 
@@ -26,13 +28,13 @@ class SweepCircleShape(Shape):
 
     def __init__(
         self,
-        radius,
-        path_points,
-        workplane="XY",
-        path_workplane="XZ",
-        stp_filename="SweepCircleShape.stp",
-        stl_filename="SweepCircleShape.stl",
-        force_cross_section=False,
+        radius: float,
+        path_points: List[Tuple[float, float]],
+        workplane: Optional[str] = "XY",
+        path_workplane: Optional[str] = "XZ",
+        stp_filename: Optional[str] = "SweepCircleShape.stp",
+        stl_filename: Optional[str] = "SweepCircleShape.stl",
+        force_cross_section: Optional[bool] = False,
         **kwargs
     ):
 
@@ -114,8 +116,11 @@ class SweepCircleShape(Shape):
 
             self.wire = wires
 
-            solid = wire.workplane(offset=self.path_points[-1][1] * factor).center(
-                self.path_points[-1][0], 0).circle(self.radius).sweep(path, multisection=True)
+            solid = wire.workplane(
+                offset=self.path_points[-1][1] * factor) \
+                .center(self.path_points[-1][0], 0) \
+                .circle(self.radius) \
+                .sweep(path, multisection=True)
 
         else:
 

--- a/paramak/parametric_shapes/sweep_mixed_shape.py
+++ b/paramak/parametric_shapes/sweep_mixed_shape.py
@@ -1,4 +1,6 @@
 
+from typing import Optional, List, Tuple
+
 import cadquery as cq
 from paramak import Shape
 
@@ -9,15 +11,15 @@ class SweepMixedShape(Shape):
     solid. Note, some variation in cross-section of the solid may occur.
 
     Args:
-        path_points (list of tuples each containing X (float), Z (float)): A
-            list of XY, YZ or XZ coordinates connected by spline connections
-            which define the path along which the 2D shape is swept.
-        workplane (str, optional): Workplane in which the 2D shape to be swept
-            is defined. Defaults to "XY".
-        path_workplane (str, optional): Workplane in which the spline path is
-            defined. Defaults to "XZ".
-        stp_filename (str, optional): Defaults to "SweepMixedShape.stp".
-        stl_filename (str, optional): Defaults to "SweepMixedShape.stl".
+        path_points: A list of XY, YZ or XZ coordinates connected by spline
+            connections which define the path along which the 2D shape is
+            swept.
+        workplane: Workplane in which the 2D shape to be swept is defined.
+            Defaults to "XY".
+        path_workplane: Workplane in which the spline path is defined. Defaults
+            to "XZ".
+        stp_filename: Defaults to "SweepMixedShape.stp".
+        stl_filename: Defaults to "SweepMixedShape.stl".
         force_cross_section (bool, optional): If True, cross-section of solid
             is forced to be shape defined by points in workplane at each
             path_point. Defaults to False.
@@ -25,12 +27,12 @@ class SweepMixedShape(Shape):
 
     def __init__(
         self,
-        path_points,
-        workplane="XY",
-        path_workplane="XZ",
-        stp_filename="SweepMixedShape.stp",
-        stl_filename="SweepMixedShape.stl",
-        force_cross_section=False,
+        path_points: List[Tuple[float, float]],
+        workplane: Optional[str] = "XY",
+        path_workplane: Optional[str] = "XZ",
+        stp_filename: Optional[str] = "SweepMixedShape.stp",
+        stl_filename: Optional[str] = "SweepMixedShape.stl",
+        force_cross_section: Optional[bool] = False,
         **kwargs
     ):
 

--- a/paramak/parametric_shapes/sweep_spline_shape.py
+++ b/paramak/parametric_shapes/sweep_spline_shape.py
@@ -1,4 +1,6 @@
 
+from typing import List, Tuple
+
 from paramak import SweepMixedShape
 
 
@@ -8,15 +10,15 @@ class SweepSplineShape(SweepMixedShape):
     variation in the cross-section of the solid may occur.
 
     Args:
-        path_points (list of tuples each containing X (float), Z (float)): A
-            list of XY, YZ or XZ coordinates connected by spline connections
-            which define the path along which the 2D shape is swept.
-        workplane (str, optional): Workplane in which the 2D shape to be swept
-            is defined. Defaults to "XY".
-        path_workplane (str, optional): Workplane in which the spline path is
-            defined. Defaults to "XZ".
-        stp_filename (str, optional): Defaults to "SweepSplineShape.stp".
-        stl_filename (str, optional): Defaults to "SweepSplineShape.stl".
+        path_points: A list of XY, YZ or XZ coordinates connected by spline
+            connections which define the path along which the 2D shape is
+            swept.
+        workplane: Workplane in which the 2D shape to be swept is defined.
+            Defaults to "XY".
+        path_workplane: Workplane in which the spline path is defined. Defaults
+            to "XZ".
+        stp_filename: Defaults to "SweepSplineShape.stp".
+        stl_filename: Defaults to "SweepSplineShape.stl".
         force_cross_section (bool, optional): If True, cross-setion of solid
             is forced to be shape defined by points in workplane at each
             path_point. Defaults to False.
@@ -24,12 +26,12 @@ class SweepSplineShape(SweepMixedShape):
 
     def __init__(
         self,
-        path_points,
-        workplane="XY",
-        path_workplane="XZ",
-        stp_filename="SweepSplineShape.stp",
-        stl_filename="SweepSplineShape.stl",
-        force_cross_section=False,
+        path_points: List[Tuple[float, float, str]],
+        workplane: str = "XY",
+        path_workplane: str = "XZ",
+        stp_filename: str = "SweepSplineShape.stp",
+        stl_filename: str = "SweepSplineShape.stl",
+        force_cross_section: bool = False,
         **kwargs
     ):
 

--- a/paramak/parametric_shapes/sweep_spline_shape.py
+++ b/paramak/parametric_shapes/sweep_spline_shape.py
@@ -1,5 +1,5 @@
 
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from paramak import SweepMixedShape
 
@@ -26,12 +26,12 @@ class SweepSplineShape(SweepMixedShape):
 
     def __init__(
         self,
-        path_points: List[Tuple[float, float, str]],
-        workplane: str = "XY",
-        path_workplane: str = "XZ",
-        stp_filename: str = "SweepSplineShape.stp",
-        stl_filename: str = "SweepSplineShape.stl",
-        force_cross_section: bool = False,
+        path_points: List[Tuple[float, float]],
+        workplane: Optional[str] = "XY",
+        path_workplane: Optional[str] = "XZ",
+        stp_filename: Optional[str] = "SweepSplineShape.stp",
+        stl_filename: Optional[str] = "SweepSplineShape.stl",
+        force_cross_section: Optional[bool] = False,
         **kwargs
     ):
 

--- a/paramak/parametric_shapes/sweep_straight_shape.py
+++ b/paramak/parametric_shapes/sweep_straight_shape.py
@@ -27,8 +27,8 @@ class SweepStraightShape(SweepMixedShape):
     def __init__(
         self,
         path_points: List[Tuple[float, float]],
-        workplane: str = "XY",
-        path_workplane: str = "XZ",
+        workplane: Optional[str] = "XY",
+        path_workplane: Optional[str] = "XZ",
         stp_filename: Optional[str] = "SweepStraightShape.stp",
         stl_filename: Optional[str] = "SweepStraightShape.stl",
         force_cross_section: Optional[bool] = False,

--- a/paramak/parametric_shapes/sweep_straight_shape.py
+++ b/paramak/parametric_shapes/sweep_straight_shape.py
@@ -10,18 +10,17 @@ class SweepStraightShape(SweepMixedShape):
     variation in the cross-section of the solid may occur.
 
     Args:
-        path_points (list of tuples each containing X (float), Z (float)): A
-            list of XY, YZ or XZ coordinates connected by spline connections
-            which define the path along which the 2D shape is swept.
-        workplane (str, optional): Workplane in which the 2D shape to be swept
-            is defined. Defaults to "XY".
-        path_workplane (str, optional): Workplane in which the spline path is
-            defined. Defaults to "XZ".
-        stp_filename (str, optional): Defaults to "SweepStraightShape.stp".
-        stl_filename (str, optional): Defaults to "SweepStraightShape.stl".
-        force_cross_section (bool, optional): If True, cross-section of solid
-            is forced to be shape defined by points in workplane at each
-            path_point. Defaults to False.
+        path_points: A list of XY, YZ or XZ coordinates connected by spline
+            connections which define the path along which the 2D shape is swept
+        workplane: Workplane in which the 2D shape to be swept is defined.
+            Defaults to "XY".
+        path_workplane: Workplane in which the spline path is defined. Defaults
+            to "XZ".
+        stp_filename: Defaults to "SweepStraightShape.stp".
+        stl_filename: Defaults to "SweepStraightShape.stl".
+        force_cross_section: If True, cross-section of solid is forced to be
+            shape defined by points in workplane at each path_point. Defaults
+            to False.
     """
 
     def __init__(

--- a/paramak/parametric_shapes/sweep_straight_shape.py
+++ b/paramak/parametric_shapes/sweep_straight_shape.py
@@ -1,4 +1,6 @@
 
+from typing import Optional, List, Tuple
+
 from paramak import SweepMixedShape
 
 
@@ -24,12 +26,12 @@ class SweepStraightShape(SweepMixedShape):
 
     def __init__(
         self,
-        path_points,
-        workplane="XY",
-        path_workplane="XZ",
-        stp_filename="SweepStraightShape.stp",
-        stl_filename="SweepStraightShape.stl",
-        force_cross_section=False,
+        path_points: List[Tuple[float, float]],
+        workplane: str = "XY",
+        path_workplane: str = "XZ",
+        stp_filename: Optional[str] = "SweepStraightShape.stp",
+        stl_filename: Optional[str] = "SweepStraightShape.stl",
+        force_cross_section: Optional[bool] = False,
         **kwargs
     ):
 


### PR DESCRIPTION
## Proposed changes

I am keen to add type hinting to all 12 of the parametric shapes but wanted to check with others if this is a good idea.

So I made a example PR that implements type hinting on one parametric shape and removes the types from the docstring.

If this is acceptable then I can roll this out for all the other 11 shapes

Let me know what you think @RemDelaporteMathurin @billingsley-john 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [x] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
