### PR TITLE
added options to svg export

### DIFF
--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -13,5 +13,5 @@ jobs:
    - uses: actions/checkout@v1
    - name: Build and test with Docker
      run: |
-       docker build -t paramak --build-arg include_neutronics=true --build-arg cq_version=master --build-arg compile_cores=2 .
+       docker build -t paramak --build-arg include_neutronics=true --build-arg cq_version=2.1 --build-arg compile_cores=2 .
        docker run --rm paramak  /bin/bash -c "cd .. && bash run_tests.sh && curl -s https://codecov.io/bash | bash"

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ coverage.xml
 *.vtk
 *.jpg
 *.xcf
+*.gif
 
 # sphinx built documetation
 docs/build/

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ common reactor components.
 </p>
 
 <p align="center">
-<img src="https://user-images.githubusercontent.com/8583900/107028956-29e46c80-67a6-11eb-9d22-37d7f17c014b.gif" width="200">
-<img src="https://user-images.githubusercontent.com/8583900/107030664-e2131480-67a8-11eb-84bb-59656e9e7722.gif" width="200">
+<img src="https://user-images.githubusercontent.com/8583900/107028956-29e46c80-67a6-11eb-9d22-37d7f17c014b.gif" width="350">
+<img src="https://user-images.githubusercontent.com/8583900/107030664-e2131480-67a8-11eb-84bb-59656e9e7722.gif" width="350">
 </p>
 
 ## Selection Of Parametric Components

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ common reactor components.
 </p>
 
 <p align="center">
-<img src="https://user-images.githubusercontent.com/8583900/107028956-29e46c80-67a6-11eb-9d22-37d7f17c014b.gif" width="350">
-<img src="https://user-images.githubusercontent.com/8583900/107030664-e2131480-67a8-11eb-84bb-59656e9e7722.gif" width="350">
+<img src="https://user-images.githubusercontent.com/8583900/107028956-29e46c80-67a6-11eb-9d22-37d7f17c014b.gif" width="300">
+<img src="https://user-images.githubusercontent.com/8583900/107030664-e2131480-67a8-11eb-84bb-59656e9e7722.gif" width="300">
 </p>
 
 ## Selection Of Parametric Components

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ common reactor components.
 </p>
 
 <p align="center">
-<img src="https://user-images.githubusercontent.com/8583900/88866536-e57a8180-d202-11ea-8e3f-2662973c6f69.gif" width="600">
-<img src="https://user-images.githubusercontent.com/8583900/86237379-90136c00-bb93-11ea-80fb-54e2dab74819.gif" width="150">
+<img src="https://user-images.githubusercontent.com/8583900/107028956-29e46c80-67a6-11eb-9d22-37d7f17c014b.gif" width="600">
+<img src="https://user-images.githubusercontent.com/8583900/107030664-e2131480-67a8-11eb-84bb-59656e9e7722.gif" width="600">
 </p>
 
 ## Selection Of Parametric Components

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ common reactor components.
 </p>
 
 <p align="center">
-<img src="https://user-images.githubusercontent.com/8583900/107028956-29e46c80-67a6-11eb-9d22-37d7f17c014b.gif" width="300">
+<img src="https://user-images.githubusercontent.com/8583900/107040396-155ca000-67b7-11eb-8b99-4aa9bf8a8655.gif" width="300">
 <img src="https://user-images.githubusercontent.com/8583900/107030664-e2131480-67a8-11eb-84bb-59656e9e7722.gif" width="300">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ common reactor components.
 </p>
 
 <p align="center">
-<img src="https://user-images.githubusercontent.com/8583900/107028956-29e46c80-67a6-11eb-9d22-37d7f17c014b.gif" width="600">
-<img src="https://user-images.githubusercontent.com/8583900/107030664-e2131480-67a8-11eb-84bb-59656e9e7722.gif" width="600">
+<img src="https://user-images.githubusercontent.com/8583900/107028956-29e46c80-67a6-11eb-9d22-37d7f17c014b.gif" width="200">
+<img src="https://user-images.githubusercontent.com/8583900/107030664-e2131480-67a8-11eb-84bb-59656e9e7722.gif" width="200">
 </p>
 
 ## Selection Of Parametric Components

--- a/examples/example_parametric_reactors/make_animation.py
+++ b/examples/example_parametric_reactors/make_animation.py
@@ -51,12 +51,13 @@ def rotate_single_reactor(number_of_images=10):
 
         my_reactor.export_svg(
             filename="rotation_" + str(i).zfill(4) + ".svg",
-            projectionDir=(x_angle, 1.1, z_angle)
+            projectionDir=(x_angle, 1.1, z_angle),
+            showHidden=False
         )
 
         print("made", str(i+1), "models out of", str(number_of_images))
 
-    os.system("convert -delay 40 output_for_rotated_svg/*.svg rotated.gif")
+    os.system("convert -delay 40 rotation_*.svg rotated.gif")
 
     print("animation file made as saved as rotated.gif")
 
@@ -79,13 +80,13 @@ def make_random_reactors(number_of_images=10):
             firstwall_radial_thickness=5,
             blanket_radial_thickness=np.random.uniform(10, 200),
             blanket_rear_wall_radial_thickness=10,
-            elongation=np.random.uniform(1.2, 1.7),
+            elongation=np.random.uniform(1.3, 1.7),
             triangularity=np.random.uniform(0.3, 0.55),
             number_of_tf_coils=16,
             rotation_angle=180,
             pf_coil_radial_thicknesses=[50, 50, 50, 50],
-            pf_coil_vertical_thicknesses=[50, 50, 50, 50],
-            pf_coil_to_rear_blanket_radial_gap=50,
+            pf_coil_vertical_thicknesses=[30, 30, 30, 30],
+            pf_coil_to_rear_blanket_radial_gap=20,
             pf_coil_to_tf_coil_radial_gap=50,
             outboard_tf_coil_radial_thickness=100,
             outboard_tf_coil_poloidal_thickness=50,
@@ -93,12 +94,12 @@ def make_random_reactors(number_of_images=10):
 
         my_reactor.export_svg(
             filename="random_" + str(i).zfill(4) + ".svg",
-            strokeWidth=6  # slightly thicker strokewidth than the default
+            showHidden=False
         )
 
         print("made", str(i+1), "models out of", str(number_of_images))
 
-    os.system("convert -delay 40 output_for_random_svg/*.svg randoms.gif")
+    os.system("convert -delay 40 random_*.svg randoms.gif")
 
     print("animation file made as saved as randoms.gif")
 

--- a/examples/example_parametric_reactors/make_animation.py
+++ b/examples/example_parametric_reactors/make_animation.py
@@ -9,13 +9,12 @@ import paramak
 from scipy.interpolate import interp1d
 
 
-def rotate_single_reactor(number_of_images=10):
+def rotate_single_reactor(number_of_images=100):
     """Makes a single reactor and exports and svg image with different view
     angles. Combines the svg images into a gif animation."""
 
     # allows the projection angle for the svg to be found via interpolation
-    z_angle_finder = interp1d([0, number_of_images], [2, 15])
-    x_angle_finder = interp1d([0, number_of_images], [-2, -3])
+    angle_finder = interp1d([0, number_of_images], [2.4021, 6.])
 
     my_reactor = paramak.SubmersionTokamak(
         inner_bore_radial_thickness=30,
@@ -44,25 +43,29 @@ def rotate_single_reactor(number_of_images=10):
 
     for i in range(number_of_images):
 
-        # finds the z angle to use for the roation
-        z_angle = z_angle_finder(i)
-        x_angle = x_angle_finder(i)
-        print('projectionDir=', x_angle, 1.1, z_angle)
+        # uses the rotation angle (in radians) to find new x, y points
+        x, y = paramak.utils.rotate([0, 0], [1, 0], angle_finder(i))
+        projectionDir = (x, y, 0)
 
         my_reactor.export_svg(
             filename="rotation_" + str(i).zfill(4) + ".svg",
-            projectionDir=(x_angle, 1.1, z_angle),
-            showHidden=False
+            projectionDir=projectionDir,
+            showHidden=False,
+            height=200,
+            width=300,
+            marginTop=27,
+            marginLeft=35,
+            strokeWidth=3.5
         )
 
         print("made", str(i + 1), "models out of", str(number_of_images))
 
-    os.system("convert -delay 40 rotation_*.svg rotated.gif")
+    os.system("convert -delay 15 rotation_*.svg rotated.gif")
 
     print("animation file made as saved as rotated.gif")
 
 
-def make_random_reactors(number_of_images=10):
+def make_random_reactors(number_of_images=11):
     """Makes a series of random sized reactors and exports an svg image for
     each one. Combines the svg images into a gif animation."""
 
@@ -106,4 +109,4 @@ def make_random_reactors(number_of_images=10):
 
 if __name__ == "__main__":
     rotate_single_reactor()
-    make_random_reactors()
+    # make_random_reactors()

--- a/examples/example_parametric_reactors/make_animation.py
+++ b/examples/example_parametric_reactors/make_animation.py
@@ -1,57 +1,108 @@
-__doc__ = """ Creates a series of images of a ball reactor images and
-combines them into gif animations using the command line tool convert,
- part of the imagemagick suite """
+__doc__ = """ Creates a series of images of a ball reactor images and combines
+them into gif animations using the command line tool convert, you will need to
+have imagemagick installed to convert the svg images to a gif animation """
 
-import argparse
 import os
-import uuid
 
 import numpy as np
 import paramak
-from tqdm import tqdm
+from scipy.interpolate import interp1d
 
-parser = argparse.ArgumentParser()
-parser.add_argument("-n", "--number_of_models", type=int, default=10)
-args = parser.parse_args()
 
-for i in tqdm(range(args.number_of_models)):
+def rotate_single_reactor(number_of_images=10):
+    """Makes a single reactor and exports and svg image with different view
+    angles. Combines the svg images into a gif animation."""
 
-    my_reactor = paramak.BallReactor(
-        inner_bore_radial_thickness=50,
-        inboard_tf_leg_radial_thickness=np.random.uniform(20, 50),
-        center_column_shield_radial_thickness=np.random.uniform(20, 60),
-        divertor_radial_thickness=50,
+    # allows the projection angle for the svg to be found via interpolation
+    z_angle_finder = interp1d([0, number_of_images], [2, 15])
+    x_angle_finder = interp1d([0, number_of_images], [-2, -3])
+
+    my_reactor = paramak.SubmersionTokamak(
+        inner_bore_radial_thickness=30,
+        inboard_tf_leg_radial_thickness=30,
+        center_column_shield_radial_thickness=30,
+        divertor_radial_thickness=80,
         inner_plasma_gap_radial_thickness=50,
-        plasma_radial_thickness=np.random.uniform(20, 200),
+        plasma_radial_thickness=200,
         outer_plasma_gap_radial_thickness=50,
-        firstwall_radial_thickness=5,
-        blanket_radial_thickness=np.random.uniform(10, 200),
-        blanket_rear_wall_radial_thickness=10,
-        elongation=np.random.uniform(1.2, 1.7),
-        triangularity=np.random.uniform(0.3, 0.55),
+        firstwall_radial_thickness=30,
+        blanket_rear_wall_radial_thickness=30,
         number_of_tf_coils=16,
         rotation_angle=180,
-        pf_coil_radial_thicknesses=[50, 50, 50, 50],
-        pf_coil_vertical_thicknesses=[50, 50, 50, 50],
-        pf_coil_to_rear_blanket_radial_gap=50,
+        support_radial_thickness=90,
+        inboard_blanket_radial_thickness=30,
+        outboard_blanket_radial_thickness=30,
+        elongation=2.00,
+        triangularity=0.50,
+        pf_coil_radial_thicknesses=[30, 30, 30, 30],
+        pf_coil_vertical_thicknesses=[30, 30, 30, 30],
         pf_coil_to_tf_coil_radial_gap=50,
-        outboard_tf_coil_radial_thickness=100,
-        outboard_tf_coil_poloidal_thickness=50,
+        outboard_tf_coil_radial_thickness=30,
+        outboard_tf_coil_poloidal_thickness=30,
+        tf_coil_to_rear_blanket_radial_gap=20,
     )
 
-    my_reactor.export_2d_image(
-        filename="output_for_animation_2d/" + str(uuid.uuid4()) + ".png"
-    )
-    my_reactor.export_svg(
-        filename="output_for_animation_svg/" + str(uuid.uuid4()) + ".svg"
-    )
+    for i in range(number_of_images):
 
-    print(str(args.number_of_models), "models made")
+        # finds the z angle to use for the roation
+        z_angle = z_angle_finder(i)
+        x_angle = x_angle_finder(i)
+        print('projectionDir=', x_angle, 1.1, z_angle)
 
-os.system("convert -delay 40 output_for_animation_2d/*.png 2d.gif")
+        my_reactor.export_svg(
+            filename="rotation_" + str(i).zfill(4) + ".svg",
+            projectionDir=(x_angle, 1.1, z_angle)
+        )
 
-os.system("convert -delay 40 output_for_animation_3d/*.png 3d.gif")
+        print("made", str(i+1), "models out of", str(number_of_images))
 
-os.system("convert -delay 40 output_for_animation_svg/*.svg 3d_svg.gif")
+    os.system("convert -delay 40 output_for_rotated_svg/*.svg rotated.gif")
 
-print("animation file made 2d.gif, 3d.gif and 3d_svg.gif")
+    print("animation file made as saved as rotated.gif")
+
+
+def make_random_reactors(number_of_images=10):
+    """Makes a series of random sized reactors and exports an svg image for
+    each one. Combines the svg images into a gif animation."""
+
+    # makes a series of reactor models
+    for i in range(number_of_images):
+
+        my_reactor = paramak.BallReactor(
+            inner_bore_radial_thickness=50,
+            inboard_tf_leg_radial_thickness=np.random.uniform(20, 50),
+            center_column_shield_radial_thickness=np.random.uniform(20, 60),
+            divertor_radial_thickness=50,
+            inner_plasma_gap_radial_thickness=50,
+            plasma_radial_thickness=np.random.uniform(20, 200),
+            outer_plasma_gap_radial_thickness=50,
+            firstwall_radial_thickness=5,
+            blanket_radial_thickness=np.random.uniform(10, 200),
+            blanket_rear_wall_radial_thickness=10,
+            elongation=np.random.uniform(1.2, 1.7),
+            triangularity=np.random.uniform(0.3, 0.55),
+            number_of_tf_coils=16,
+            rotation_angle=180,
+            pf_coil_radial_thicknesses=[50, 50, 50, 50],
+            pf_coil_vertical_thicknesses=[50, 50, 50, 50],
+            pf_coil_to_rear_blanket_radial_gap=50,
+            pf_coil_to_tf_coil_radial_gap=50,
+            outboard_tf_coil_radial_thickness=100,
+            outboard_tf_coil_poloidal_thickness=50,
+        )
+
+        my_reactor.export_svg(
+            filename="random_" + str(i).zfill(4) + ".svg",
+            strokeWidth=6  # slightly thicker strokewidth than the default
+        )
+
+        print("made", str(i+1), "models out of", str(number_of_images))
+
+    os.system("convert -delay 40 output_for_random_svg/*.svg randoms.gif")
+
+    print("animation file made as saved as randoms.gif")
+
+
+if __name__ == "__main__":
+    rotate_single_reactor()
+    make_random_reactors()

--- a/examples/example_parametric_shapes/make_CAD_from_points.py
+++ b/examples/example_parametric_shapes/make_CAD_from_points.py
@@ -16,6 +16,7 @@ def main():
         points=[(400, 100), (400, 200), (600, 200), (600, 100)]
     )
     rotated_straights.export_stp("rotated_straights.stp")
+    rotated_straights.export_svg("rotated_straights.svg")
     rotated_straights.export_html("rotated_straights.html")
 
     # this makes a banana shape and rotates it to make a solid
@@ -33,6 +34,7 @@ def main():
         ]
     )
     rotated_spline.export_stp("rotated_spline.stp")
+    rotated_spline.export_svg("rotated_spline.svg")
     rotated_spline.export_html("rotated_spline.html")
 
     # this makes a shape with straight, spline and circular edges and rotates
@@ -50,6 +52,7 @@ def main():
         ]
     )
     rotated_mixed.export_stp("rotated_mixed.stp")
+    rotated_mixed.export_svg("rotated_mixed.svg")
     rotated_mixed.export_html("rotated_mixed.html")
 
     # this makes a circular shape and rotates it to make a solid
@@ -60,6 +63,7 @@ def main():
         workplane="XZ"
     )
     rotated_circle.export_stp("rotated_circle.stp")
+    rotated_circle.export_svg("rotated_circle.svg")
     rotated_circle.export_html("rotated_circle.html")
 
     # extrude examples
@@ -78,6 +82,7 @@ def main():
         ]
     )
     extruded_straight.export_stp("extruded_straight.stp")
+    extruded_straight.export_svg("extruded_straight.svg")
     extruded_straight.export_html("extruded_straight.html")
 
     # this makes a banana shape and rotates it to make a solid
@@ -95,6 +100,7 @@ def main():
         ]
     )
     extruded_spline.export_stp("extruded_spline.stp")
+    extruded_spline.export_svg("extruded_spline.svg")
     extruded_spline.export_html("extruded_spline.html")
 
     # this makes a banana shape straight top and bottom edges and extrudes it
@@ -112,6 +118,7 @@ def main():
         ],
     )
     extruded_mixed.export_stp("extruded_mixed.stp")
+    extruded_mixed.export_svg("extruded_mixed.svg")
     extruded_mixed.export_html("extruded_mixed.html")
 
     # this makes a circular shape and extrudes it to make a solid
@@ -121,6 +128,7 @@ def main():
         distance=200
     )
     extruded_circle.export_stp("extruded_circle.stp")
+    extruded_circle.export_svg("extruded_circle.svg")
     extruded_circle.export_html("extruded_circle.html")
 
     # sweep examples
@@ -147,6 +155,7 @@ def main():
         path_workplane="XZ"
     )
     sweep_straight.export_stp("sweep_straight.stp")
+    sweep_straight.export_svg("sweep_straight.svg")
     sweep_straight.export_html("sweep_straight.html")
 
     # this makes a banana shape with spline edges and sweeps it along a spline
@@ -173,6 +182,7 @@ def main():
         path_workplane="XZ"
     )
     sweep_spline.export_stp("sweep_spline.stp")
+    sweep_spline.export_svg("sweep_spline.svg")
     sweep_spline.export_html("sweep_spline.html")
 
     # this makes a shape with straight, spline and circular edges and sweeps
@@ -198,6 +208,7 @@ def main():
         path_workplane="XZ"
     )
     sweep_mixed.export_stp("sweep_mixed.stp")
+    sweep_mixed.export_svg("sweep_mixed.svg")
     sweep_mixed.export_html("sweep_mixed.html")
 
     # this makes a circular shape and sweeps it to make a solid
@@ -214,6 +225,7 @@ def main():
         path_workplane="XZ"
     )
     sweep_circle.export_stp("sweep_circle.stp")
+    sweep_circle.export_svg("sweep_circle.svg")
     sweep_circle.export_html("sweep_circle.html")
 
 

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -2,6 +2,7 @@
 import json
 from collections.abc import Iterable
 from pathlib import Path
+from typing import Tuple
 
 import cadquery as cq
 import matplotlib.pyplot as plt
@@ -478,13 +479,48 @@ class Reactor:
                 Path(output_folder) / Path(entry.stp_filename))
         return filenames
 
-    def export_svg(self, filename: str = 'reactor.svg') -> str:
+    def export_svg(
+            self,
+            filename: str = 'reactor.svg',
+            projectionDir: Tuple[float, float, float] = (-1.75, 1.1, 5),
+            width: float = 1000,
+            height: float = 800,
+            marginLeft: float = 120,
+            marginTop: float = 100,
+            strokeWidth: float = None,
+            strokeColor: Tuple[int, int, int] = (0, 0, 0),
+            hiddenColor: Tuple[int, int, int] = (100, 100, 100),
+            showHidden: bool = True,
+        ) -> str:
         """Exports an svg file for the Reactor.solid. If the filename provided
         doesn't end with .svg it will be added.
 
         Args:
-            filename (str): the filename of the svg file to be exported.
-                Defaults to "reactor.svg".
+            filename: the filename of the svg file to be exported. Defaults to
+                "reactor.svg".
+            projectionDir: The direction vector to view the geometry from
+                (x, y, z). Defaults to (-1.75, 1.1, 5)
+            width: the width of the svg image produced in pixels. Defaults to
+                1000
+            height: the height of the svg image produced in pixels. Defaults to
+                800
+            marginLeft: the number of pixels between the left edge of the image
+                and the start of the geometry.
+            marginTop: the number of pixels between the top edge of the image
+                and the start of the geometry.
+            strokeWidth: the width of the lines used to draw the geometry.
+                Defaults to None which automatically selects an suitable width.
+            strokeColor: the color of the lines used to draw the geometry in 
+                RGB format with each value between 0 and 255. Defaults to
+                (0, 0, 0) which is black.
+            hiddenColor: the color of the lines used to draw the geometry in 
+                RGB format with each value between 0 and 255. Defaults to
+               (100, 100, 100) which is light grey.
+            showHidden: If the edges obscured by geometry should be included in
+                the diagram. Defaults to True.
+
+        Returns:
+            str: the svg filename created      
         """
 
         path_filename = Path(filename)
@@ -494,8 +530,24 @@ class Reactor:
 
         path_filename.parents[0].mkdir(parents=True, exist_ok=True)
 
-        with open(path_filename, "w") as out_file:
-            exporters.exportShape(self.solid, "SVG", out_file)
+        opt = {
+            "width": width,
+            "height": height,
+            "marginLeft": marginLeft,
+            "marginTop": marginTop,
+            "showAxes": False,
+            "projectionDir": projectionDir,
+            "strokeColor": strokeColor,
+            "hiddenColor": hiddenColor,
+            "showHidden": showHidden
+        }
+
+        if strokeWidth is not None:
+            opt["strokeWidth"] = strokeWidth
+
+        exporters.export(self.solid, str(path_filename), exportType='SVG',
+                         opt=opt)
+
         print("Saved file as ", path_filename)
 
         return str(path_filename)

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -147,23 +147,25 @@ class Reactor:
         list_of_cq_vals = []
 
         for shape_or_compound in self.shapes_and_components:
-            if isinstance(shape_or_compound.solid, (cq.occ_impl.shapes.Shape,
-                          cq.occ_impl.shapes.Compound)):
+            if isinstance(
+                shape_or_compound.solid,
+                (cq.occ_impl.shapes.Shape,
+                 cq.occ_impl.shapes.Compound)):
                 for solid in shape_or_compound.solid.Solids():
                     list_of_cq_vals.append(solid)
             else:
                 list_of_cq_vals.append(shape_or_compound.solid.val())
 
-        compound=cq.Compound.makeCompound(list_of_cq_vals)
+        compound = cq.Compound.makeCompound(list_of_cq_vals)
 
         return compound
 
     @ solid.setter
     def solid(self, value):
-        self._solid=value
+        self._solid = value
 
-    def neutronics_description(self, include_plasma: bool=False,
-                               include_graveyard: bool=True
+    def neutronics_description(self, include_plasma: bool = False,
+                               include_graveyard: bool = True
                                ):
         """A description of the reactor containing material tags, stp filenames,
         and tet mesh instructions. This is used for neutronics simulations which
@@ -178,7 +180,7 @@ class Reactor:
             dictionary: a dictionary of materials and filenames for the reactor
         """
 
-        neutronics_description=[]
+        neutronics_description = []
 
         for entry in self.shapes_and_components:
 
@@ -215,9 +217,9 @@ class Reactor:
 
     def export_neutronics_description(
             self,
-            filename: str="manifest.json",
-            include_plasma: bool=False,
-            include_graveyard: bool=True) -> str:
+            filename: str = "manifest.json",
+            include_plasma: bool = False,
+            include_graveyard: bool = True) -> str:
         """
         Saves Reactor.neutronics_description to a json file. The resulting json
         file contains a list of dictionaries. Each dictionary entry comprises
@@ -243,10 +245,10 @@ class Reactor:
                 included. Defaults to True as this is needed for DAGMC models.
         """
 
-        path_filename=Path(filename)
+        path_filename = Path(filename)
 
         if path_filename.suffix != ".json":
-            path_filename=path_filename.with_suffix(".json")
+            path_filename = path_filename.with_suffix(".json")
 
         path_filename.parents[0].mkdir(parents=True, exist_ok=True)
 
@@ -266,9 +268,9 @@ class Reactor:
 
     def export_stp(
             self,
-            output_folder: str="",
-            graveyard_offset: float=100,
-            mode: str='solid') -> list:
+            output_folder: str = "",
+            graveyard_offset: float = 100,
+            mode: str = 'solid') -> list:
         """Writes stp files (CAD geometry) for each Shape object in the reactor
         and the graveyard.
 
@@ -291,7 +293,7 @@ class Reactor:
                 self.stp_filenames,
             )
 
-        filenames=[]
+        filenames = []
         for entry in self.shapes_and_components:
             if entry.stp_filename is None:
                 raise ValueError(
@@ -318,9 +320,9 @@ class Reactor:
 
     def export_stl(
             self,
-            output_folder: str="",
-            graveyard_offset: float=100,
-            tolerance: float=0.001) -> list:
+            output_folder: str = "",
+            graveyard_offset: float = 100,
+            tolerance: float = 0.001) -> list:
         """Writes stl files (CAD geometry) for each Shape object in the reactor
 
         Args:
@@ -341,7 +343,7 @@ class Reactor:
                 self.stl_filenames,
             )
 
-        filenames=[]
+        filenames = []
         for entry in self.shapes_and_components:
             print("entry.stl_filename", entry.stl_filename)
             if entry.stl_filename is None:
@@ -373,10 +375,10 @@ class Reactor:
 
     def export_h5m(
             self,
-            filename: str='dagmc.h5m',
-            skip_graveyard: bool=False,
-            tolerance: float=0.001,
-            graveyard_offset: float=100) -> str:
+            filename: str = 'dagmc.h5m',
+            skip_graveyard: bool = False,
+            tolerance: float = 0.001,
+            graveyard_offset: float = 100) -> str:
         """Converts stl files into DAGMC compatible h5m file using PyMOAB. The
         DAGMC file produced has not been imprinted and merged unlike the other
         supported method which uses Trelis to produce an imprinted and merged
@@ -397,22 +399,22 @@ class Reactor:
             filename: output h5m filename
         """
 
-        path_filename=Path(filename)
+        path_filename = Path(filename)
 
         if path_filename.suffix != ".h5m":
-            path_filename=path_filename.with_suffix(".h5m")
+            path_filename = path_filename.with_suffix(".h5m")
 
         path_filename.parents[0].mkdir(parents=True, exist_ok=True)
 
-        moab_core, moab_tags=define_moab_core_and_tags()
+        moab_core, moab_tags = define_moab_core_and_tags()
 
-        surface_id=1
-        volume_id=1
+        surface_id = 1
+        volume_id = 1
 
         for item in self.shapes_and_components:
 
             item.export_stl(item.stl_filename, tolerance=tolerance)
-            moab_core=add_stl_to_moab_core(
+            moab_core = add_stl_to_moab_core(
                 moab_core,
                 surface_id,
                 volume_id,
@@ -425,9 +427,9 @@ class Reactor:
         if skip_graveyard is False:
             self.make_graveyard(graveyard_offset=graveyard_offset)
             self.graveyard.export_stl(self.graveyard.stl_filename)
-            volume_id=2
-            surface_id=2
-            moab_core=add_stl_to_moab_core(
+            volume_id = 2
+            surface_id = 2
+            moab_core = add_stl_to_moab_core(
                 moab_core,
                 surface_id,
                 volume_id,
@@ -436,9 +438,9 @@ class Reactor:
                 self.graveyard.stl_filename
             )
 
-        all_sets=moab_core.get_entities_by_handle(0)
+        all_sets = moab_core.get_entities_by_handle(0)
 
-        file_set=moab_core.create_meshset()
+        file_set = moab_core.create_meshset()
 
         moab_core.add_entities(file_set, all_sets)
 
@@ -446,7 +448,7 @@ class Reactor:
 
         return str(path_filename)
 
-    def export_physical_groups(self, output_folder: str="") -> list:
+    def export_physical_groups(self, output_folder: str = "") -> list:
         """Exports several JSON files containing a look up table which is
         useful for identifying faces and volumes. The output file names are
         generated from .stp_filename properties.
@@ -461,7 +463,7 @@ class Reactor:
         Returns:
             list: list of output file names
         """
-        filenames=[]
+        filenames = []
         for entry in self.shapes_and_components:
             if entry.stp_filename is None:
                 raise ValueError(
@@ -476,16 +478,16 @@ class Reactor:
 
     def export_svg(
         self,
-        filename: str='reactor.svg',
-        projectionDir: Tuple[float, float, float]=(-1.75, 1.1, 5),
-        width: float=1000,
-        height: float=800,
-        marginLeft: float=120,
-        marginTop: float=100,
-        strokeWidth: float=None,
-        strokeColor: Tuple[int, int, int]=(0, 0, 0),
-        hiddenColor: Tuple[int, int, int]=(100, 100, 100),
-        showHidden: bool=True,
+        filename: str = 'reactor.svg',
+        projectionDir: Tuple[float, float, float] = (-1.75, 1.1, 5),
+        width: float = 1000,
+        height: float = 800,
+        marginLeft: float = 120,
+        marginTop: float = 100,
+        strokeWidth: float = None,
+        strokeColor: Tuple[int, int, int] = (0, 0, 0),
+        hiddenColor: Tuple[int, int, int] = (100, 100, 100),
+        showHidden: bool = True,
     ) -> str:
         """Exports an svg file for the Reactor.solid. If the filename provided
         doesn't end with .svg it will be added.
@@ -518,14 +520,14 @@ class Reactor:
             str: the svg filename created
         """
 
-        path_filename=Path(filename)
+        path_filename = Path(filename)
 
         if path_filename.suffix != ".svg":
-            path_filename=path_filename.with_suffix(".svg")
+            path_filename = path_filename.with_suffix(".svg")
 
         path_filename.parents[0].mkdir(parents=True, exist_ok=True)
 
-        opt={
+        opt = {
             "width": width,
             "height": height,
             "marginLeft": marginLeft,
@@ -538,7 +540,7 @@ class Reactor:
         }
 
         if strokeWidth is not None:
-            opt["strokeWidth"]=strokeWidth
+            opt["strokeWidth"] = strokeWidth
 
         exporters.export(self.solid, str(path_filename), exportType='SVG',
                          opt=opt)
@@ -549,8 +551,8 @@ class Reactor:
 
     def export_graveyard(
             self,
-            graveyard_offset: float=100,
-            filename: str="Graveyard.stp"):
+            graveyard_offset: float = 100,
+            filename: str = "Graveyard.stp"):
         """Writes an stp file (CAD geometry) for the reactor graveyard. This
         is needed for DAGMC simulations. This method also calls
         Reactor.make_graveyard with the offset.
@@ -566,11 +568,11 @@ class Reactor:
         """
 
         self.make_graveyard(graveyard_offset=graveyard_offset)
-        new_filename=self.graveyard.export_stp(Path(filename))
+        new_filename = self.graveyard.export_stp(Path(filename))
 
         return new_filename
 
-    def make_graveyard(self, graveyard_offset: float=100):
+    def make_graveyard(self, graveyard_offset: float = 100):
         """Creates a graveyard volume (bounding box) that encapsulates all
         volumes. This is required by DAGMC when performing neutronics
         simulations.
@@ -585,13 +587,13 @@ class Reactor:
             to as a graveyard in DAGMC
         """
 
-        self.graveyard_offset=graveyard_offset
+        self.graveyard_offset = graveyard_offset
 
         for component in self.shapes_and_components:
             if component.solid is None:
                 component.create_solid()
 
-        graveyard_shape=paramak.HollowCube(
+        graveyard_shape = paramak.HollowCube(
             length=self.largest_dimension * 2 + graveyard_offset * 2,
             name="Graveyard",
             material_tag="Graveyard",
@@ -599,17 +601,17 @@ class Reactor:
             stl_filename="Graveyard.stl",
         )
 
-        self.graveyard=graveyard_shape
+        self.graveyard = graveyard_shape
 
         return graveyard_shape
 
     def export_2d_image(
             self,
             filename="2d_slice.png",
-            xmin: float=0.0,
-            xmax: float=900.0,
-            ymin: float=-600.0,
-            ymax: float=600.0) -> str:
+            xmin: float = 0.0,
+            xmax: float = 900.0,
+            ymin: float = -600.0,
+            ymax: float = 600.0) -> str:
         """Creates a 2D slice image (png) of the reactor.
 
         Args:
@@ -619,18 +621,18 @@ class Reactor:
             str: png filename created
         """
 
-        path_filename=Path(filename)
+        path_filename = Path(filename)
 
         if path_filename.suffix != ".png":
-            path_filename=path_filename.with_suffix(".png")
+            path_filename = path_filename.with_suffix(".png")
 
         path_filename.parents[0].mkdir(parents=True, exist_ok=True)
 
-        fig, ax=plt.subplots()
+        fig, ax = plt.subplots()
 
         # creates indvidual patches for each Shape which are combined together
         for entry in self.shapes_and_components:
-            patch=entry._create_patch()
+            patch = entry._create_patch()
             ax.add_collection(patch)
 
         ax.axis("equal")
@@ -664,15 +666,15 @@ class Reactor:
 
         # accesses the Shape wires for each Shape and builds up a list of
         # traces
-        all_wires=[]
+        all_wires = []
         for entry in self.shapes_and_components:
             if not isinstance(entry.wire, list):
-                list_of_wires=[entry.wire]
+                list_of_wires = [entry.wire]
             else:
-                list_of_wires=entry.wire
-            all_wires=all_wires + list_of_wires
+                list_of_wires = entry.wire
+            all_wires = all_wires + list_of_wires
 
-        fig=paramak.utils.export_wire_to_html(
+        fig = paramak.utils.export_wire_to_html(
             wires=all_wires,
             filename=filename,
             view_plane=view_plane,

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -148,7 +148,7 @@ class Reactor:
 
         for shape_or_compound in self.shapes_and_components:
             if isinstance(shape_or_compound.solid, (cq.occ_impl.shapes.Shape,
-                    cq.occ_impl.shapes.Compound),
+                    cq.occ_impl.shapes.Compound):
                 for solid in shape_or_compound.solid.Solids():
                     list_of_cq_vals.append(solid)
             else:

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -147,9 +147,8 @@ class Reactor:
         list_of_cq_vals = []
 
         for shape_or_compound in self.shapes_and_components:
-            if isinstance(
-                    shape_or_compound.solid,
-                    cq.occ_impl.shapes.Compound):
+            if isinstance(shape_or_compound.solid, (cq.occ_impl.shapes.Shape,
+                    cq.occ_impl.shapes.Compound),
                 for solid in shape_or_compound.solid.Solids():
                     list_of_cq_vals.append(solid)
             else:

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -141,8 +141,7 @@ class Reactor:
     @property
     def solid(self):
         """This combines all the parametric shapes and compents in the reactor
-        object and rotates the viewing angle so that .solid operations in
-        jupyter notebook.
+        object.
         """
 
         list_of_cq_vals = []
@@ -158,9 +157,6 @@ class Reactor:
 
         compound = cq.Compound.makeCompound(list_of_cq_vals)
 
-        compound = compound.rotate(
-            startVector=(0, 1, 0), endVector=(0, 0, 1), angleDegrees=180
-        )
         return compound
 
     @solid.setter

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -148,7 +148,7 @@ class Reactor:
 
         for shape_or_compound in self.shapes_and_components:
             if isinstance(shape_or_compound.solid, (cq.occ_impl.shapes.Shape,
-                    cq.occ_impl.shapes.Compound):
+                    cq.occ_impl.shapes.Compound)):
                 for solid in shape_or_compound.solid.Solids():
                     list_of_cq_vals.append(solid)
             else:

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -148,7 +148,7 @@ class Reactor:
 
         for shape_or_compound in self.shapes_and_components:
             if isinstance(shape_or_compound.solid, (cq.occ_impl.shapes.Shape,
-                    cq.occ_impl.shapes.Compound)):
+                          cq.occ_impl.shapes.Compound)):
                 for solid in shape_or_compound.solid.Solids():
                     list_of_cq_vals.append(solid)
             else:

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -2,7 +2,7 @@
 import json
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple, List
 
 import cadquery as cq
 import matplotlib.pyplot as plt
@@ -148,9 +148,8 @@ class Reactor:
 
         for shape_or_compound in self.shapes_and_components:
             if isinstance(
-                shape_or_compound.solid,
-                (cq.occ_impl.shapes.Shape,
-                 cq.occ_impl.shapes.Compound)):
+                    shape_or_compound.solid,
+                    (cq.occ_impl.shapes.Shape, cq.occ_impl.shapes.Compound)):
                 for solid in shape_or_compound.solid.Solids():
                     list_of_cq_vals.append(solid)
             else:
@@ -164,17 +163,18 @@ class Reactor:
     def solid(self, value):
         self._solid = value
 
-    def neutronics_description(self, include_plasma: bool = False,
-                               include_graveyard: bool = True
-                               ):
+    def neutronics_description(
+            self,
+            include_plasma: Optional[bool] = False,
+            include_graveyard: Optional[bool] = True) -> dict:
         """A description of the reactor containing material tags, stp filenames,
-        and tet mesh instructions. This is used for neutronics simulations which
-        require linkage between volumes, materials and identification of which
-        volumes to tet mesh. The plasma geometry is not included by default as
-        it is typically not included in neutronics simulations. The reason for
-        this is that the low number density results in minimal interaction with
-        neutrons. However, it can be added if the include_plasma argument is set
-        to True.
+        and tet mesh instructions. This is used for neutronics simulations
+        which require linkage between volumes, materials and identification of
+        which volumes to tet mesh. The plasma geometry is not included by
+        default as it is typically not included in neutronics simulations. The
+        reason for this is that the low number density results in minimal
+        interaction with neutrons. However, it can be added if the
+        include_plasma argument is set to True.
 
         Returns:
             dictionary: a dictionary of materials and filenames for the reactor
@@ -217,9 +217,9 @@ class Reactor:
 
     def export_neutronics_description(
             self,
-            filename: str = "manifest.json",
-            include_plasma: bool = False,
-            include_graveyard: bool = True) -> str:
+            filename: Optional[str] = "manifest.json",
+            include_plasma: Optional[bool] = False,
+            include_graveyard: Optional[bool] = True) -> str:
         """
         Saves Reactor.neutronics_description to a json file. The resulting json
         file contains a list of dictionaries. Each dictionary entry comprises
@@ -268,9 +268,9 @@ class Reactor:
 
     def export_stp(
             self,
-            output_folder: str = "",
-            graveyard_offset: float = 100,
-            mode: str = 'solid') -> list:
+            output_folder: Optional[str] = "",
+            graveyard_offset: Optional[float] = 100,
+            mode: Optional[str] = 'solid') -> List[str]:
         """Writes stp files (CAD geometry) for each Shape object in the reactor
         and the graveyard.
 
@@ -320,9 +320,9 @@ class Reactor:
 
     def export_stl(
             self,
-            output_folder: str = "",
-            graveyard_offset: float = 100,
-            tolerance: float = 0.001) -> list:
+            output_folder: Optional[str] = "",
+            graveyard_offset: Optional[float] = 100,
+            tolerance: Optional[float] = 0.001) -> List[str]:
         """Writes stl files (CAD geometry) for each Shape object in the reactor
 
         Args:
@@ -375,10 +375,10 @@ class Reactor:
 
     def export_h5m(
             self,
-            filename: str = 'dagmc.h5m',
-            skip_graveyard: bool = False,
-            tolerance: float = 0.001,
-            graveyard_offset: float = 100) -> str:
+            filename: Optional[str] = 'dagmc.h5m',
+            skip_graveyard: Optional[bool] = False,
+            tolerance: Optional[float] = 0.001,
+            graveyard_offset: Optional[float] = 100) -> str:
         """Converts stl files into DAGMC compatible h5m file using PyMOAB. The
         DAGMC file produced has not been imprinted and merged unlike the other
         supported method which uses Trelis to produce an imprinted and merged
@@ -448,7 +448,9 @@ class Reactor:
 
         return str(path_filename)
 
-    def export_physical_groups(self, output_folder: str = "") -> list:
+    def export_physical_groups(
+            self,
+            output_folder: Optional[str] = "") -> List[str]:
         """Exports several JSON files containing a look up table which is
         useful for identifying faces and volumes. The output file names are
         generated from .stp_filename properties.
@@ -478,17 +480,16 @@ class Reactor:
 
     def export_svg(
         self,
-        filename: str = 'reactor.svg',
+        filename: Optional[str] = 'reactor.svg',
         projectionDir: Tuple[float, float, float] = (-1.75, 1.1, 5),
-        width: float = 1000,
-        height: float = 800,
-        marginLeft: float = 120,
-        marginTop: float = 100,
-        strokeWidth: float = None,
-        strokeColor: Tuple[int, int, int] = (0, 0, 0),
-        hiddenColor: Tuple[int, int, int] = (100, 100, 100),
-        showHidden: bool = True,
-    ) -> str:
+        width: Optional[float] = 1000,
+        height: Optional[float] = 800,
+        marginLeft: Optional[float] = 120,
+        marginTop: Optional[float] = 100,
+        strokeWidth: Optional[float] = None,
+        strokeColor: Optional[Tuple[int, int, int]] = (0, 0, 0),
+        hiddenColor: Optional[Tuple[int, int, int]] = (100, 100, 100),
+        showHidden: Optional[bool] = True) -> str:
         """Exports an svg file for the Reactor.solid. If the filename provided
         doesn't end with .svg it will be added.
 
@@ -551,8 +552,8 @@ class Reactor:
 
     def export_graveyard(
             self,
-            graveyard_offset: float = 100,
-            filename: str = "Graveyard.stp"):
+            graveyard_offset: Optional[float] = 100,
+            filename: Optional[str] = "Graveyard.stp") -> str:
         """Writes an stp file (CAD geometry) for the reactor graveyard. This
         is needed for DAGMC simulations. This method also calls
         Reactor.make_graveyard with the offset.
@@ -572,7 +573,9 @@ class Reactor:
 
         return new_filename
 
-    def make_graveyard(self, graveyard_offset: float = 100):
+    def make_graveyard(
+            self,
+            graveyard_offset: Optional[float] = 100) -> paramak.Shape:
         """Creates a graveyard volume (bounding box) that encapsulates all
         volumes. This is required by DAGMC when performing neutronics
         simulations.
@@ -607,11 +610,11 @@ class Reactor:
 
     def export_2d_image(
             self,
-            filename="2d_slice.png",
-            xmin: float = 0.0,
-            xmax: float = 900.0,
-            ymin: float = -600.0,
-            ymax: float = 600.0) -> str:
+            filename: Optional[str] = "2d_slice.png",
+            xmin: Optional[float] = 0.0,
+            xmax: Optional[float] = 900.0,
+            ymin: Optional[float] = -600.0,
+            ymax: Optional[float] = 600.0) -> str:
         """Creates a 2D slice image (png) of the reactor.
 
         Args:
@@ -647,7 +650,10 @@ class Reactor:
 
         return str(path_filename)
 
-    def export_html(self, filename="reactor.html", view_plane='RZ'):
+    def export_html(
+            self,
+            filename: Optional[str] = "reactor.html",
+            view_plane: Optional[str] = 'RZ'):
         """Creates a html graph representation of the points for the Shape
         objects that make up the reactor. Shapes are colored by their .color
         property. Shapes are also labelled by their .name. If filename provided

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -479,17 +479,17 @@ class Reactor:
         return filenames
 
     def export_svg(
-        self,
-        filename: Optional[str] = 'reactor.svg',
-        projectionDir: Tuple[float, float, float] = (-1.75, 1.1, 5),
-        width: Optional[float] = 1000,
-        height: Optional[float] = 800,
-        marginLeft: Optional[float] = 120,
-        marginTop: Optional[float] = 100,
-        strokeWidth: Optional[float] = None,
-        strokeColor: Optional[Tuple[int, int, int]] = (0, 0, 0),
-        hiddenColor: Optional[Tuple[int, int, int]] = (100, 100, 100),
-        showHidden: Optional[bool] = True) -> str:
+            self,
+            filename: Optional[str] = 'reactor.svg',
+            projectionDir: Tuple[float, float, float] = (-1.75, 1.1, 5),
+            width: Optional[float] = 1000,
+            height: Optional[float] = 800,
+            marginLeft: Optional[float] = 120,
+            marginTop: Optional[float] = 100,
+            strokeWidth: Optional[float] = None,
+            strokeColor: Optional[Tuple[int, int, int]] = (0, 0, 0),
+            hiddenColor: Optional[Tuple[int, int, int]] = (100, 100, 100),
+            showHidden: Optional[bool] = True) -> str:
         """Exports an svg file for the Reactor.solid. If the filename provided
         doesn't end with .svg it will be added.
 

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -87,9 +87,9 @@ class Shape:
         surface_reflectivity: Optional[bool] = False,
         physical_groups=None,
         # TODO defining Shape types as paramak.Shape results in circular import
-        cut = None,
-        intersect = None,
-        union = None,
+        cut=None,
+        intersect=None,
+        union=None,
     ):
 
         self.connection_type = connection_type
@@ -679,7 +679,8 @@ class Shape:
         return solid
 
     def get_rotation_axis(self):
-        # TODO add return type hinting -> Tuple[List[Tuple[int, int, int], Tuple[int, int, int]], str]
+        # TODO add return type hinting -> Tuple[List[Tuple[int, int, int],
+        # Tuple[int, int, int]], str]
         """Returns the rotation axis for a given shape. If self.rotation_axis
         is None, the rotation axis will be computed from self.workplane (or
         from self.path_workplane if applicable). If self.rotation_axis is an
@@ -849,17 +850,17 @@ class Shape:
         return str(path_filename)
 
     def export_svg(
-        self,
-        filename: Optional[str] = 'shape.svg',
-        projectionDir: Tuple[float, float, float] = (-1.75, 1.1, 5),
-        width: Optional[float] = 800,
-        height: Optional[float] = 800,
-        marginLeft: Optional[float] = 100,
-        marginTop: Optional[float] = 100,
-        strokeWidth: Optional[float] = None,
-        strokeColor: Optional[Tuple[int, int, int]] = (0, 0, 0),
-        hiddenColor: Optional[Tuple[int, int, int]] = (100, 100, 100),
-        showHidden: Optional[bool] = True) -> str:
+            self,
+            filename: Optional[str] = 'shape.svg',
+            projectionDir: Tuple[float, float, float] = (-1.75, 1.1, 5),
+            width: Optional[float] = 800,
+            height: Optional[float] = 800,
+            marginLeft: Optional[float] = 100,
+            marginTop: Optional[float] = 100,
+            strokeWidth: Optional[float] = None,
+            strokeColor: Optional[Tuple[int, int, int]] = (0, 0, 0),
+            hiddenColor: Optional[Tuple[int, int, int]] = (100, 100, 100),
+            showHidden: Optional[bool] = True) -> str:
         """Exports an svg file for the Reactor.solid. If the filename provided
         doesn't end with .svg it will be added.
 

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -4,7 +4,7 @@ import numbers
 import warnings
 from collections.abc import Iterable
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, Optional, Union
 
 import cadquery as cq
 import matplotlib.pyplot as plt
@@ -33,9 +33,9 @@ class Shape:
             Defaults to "mixed".
         name (str, optional): the name of the shape, used in the graph legend
             by export_html. Defaults to None.
-        color ((float, float, float [, float]), optional): The color to use when exporting as html
-            graphs or png images. Can be in RGB or RGBA format with floats
-            between 0 and 1. Defaults to (0.5, 0.5, 0.5).
+        color ((float, float, float [, float]), optional): The color to use
+            when exporting as html graphs or png images. Can be in RGB or RGBA
+            format with floats between 0 and 1. Defaults to (0.5, 0.5, 0.5).
         material_tag (str, optional): the material name to use when exporting
             the neutronics description. Defaults to None.
         stp_filename (str, optional): the filename used when saving stp files.
@@ -74,21 +74,22 @@ class Shape:
     def __init__(
         self,
         points: list = None,
-        connection_type="mixed",
-        name=None,
-        color=(0.5, 0.5, 0.5),
-        material_tag: str = None,
-        stp_filename: str = None,
-        stl_filename: str = None,
-        azimuth_placement_angle=0.0,
-        workplane: str = "XZ",
-        rotation_axis=None,
-        tet_mesh: str = None,
-        surface_reflectivity: bool = False,
+        connection_type: Optional[str] = "mixed",
+        name: Optional[str] = None,
+        color: Optional[Tuple[float, float, float]] = (0.5, 0.5, 0.5),
+        material_tag: Optional[str] = None,
+        stp_filename: Optional[str] = None,
+        stl_filename: Optional[str] = None,
+        azimuth_placement_angle: Optional[Union[float, List[float]]] = 0.0,
+        workplane: Optional[str] = "XZ",
+        rotation_axis: Optional[str] = None,
+        tet_mesh: Optional[str] = None,
+        surface_reflectivity: Optional[bool] = False,
         physical_groups=None,
-        cut=None,
-        intersect=None,
-        union=None,
+        # TODO defining Shape types as paramak.Shape results in circular import
+        cut = None,
+        intersect = None,
+        union = None,
     ):
 
         self.connection_type = connection_type
@@ -547,7 +548,7 @@ class Shape:
             raise ValueError(msg)
         self._azimuth_placement_angle = value
 
-    def create_solid(self):
+    def create_solid(self) -> cq.Workplane:
         solid = None
         if self.points is not None:
             # obtains the first two values of the points list
@@ -655,7 +656,9 @@ class Shape:
 
         return solid
 
-    def rotate_solid(self, solid):
+    def rotate_solid(
+            self,
+            solid: Optional[cq.Workplane]) -> cq.Workplane:
         # Checks if the azimuth_placement_angle is a list of angles
         if isinstance(self.azimuth_placement_angle, Iterable):
             azimuth_placement_angles = self.azimuth_placement_angle
@@ -676,6 +679,7 @@ class Shape:
         return solid
 
     def get_rotation_axis(self):
+        # TODO add return type hinting -> Tuple[List[Tuple[int, int, int], Tuple[int, int, int]], str]
         """Returns the rotation axis for a given shape. If self.rotation_axis
         is None, the rotation axis will be computed from self.workplane (or
         from self.path_workplane if applicable). If self.rotation_axis is an
@@ -713,7 +717,7 @@ class Shape:
                 workplane = self.workplane
             return rotation_axis[workplane[1]], workplane[1]
 
-    def create_limits(self):
+    def create_limits(self) -> Tuple[float, float, float, float]:
         """Finds the x,y,z limits (min and max) of the points that make up the
         face of the shape. Note the Shape may extend beyond this boundary if
         splines are used to connect points.
@@ -739,7 +743,10 @@ class Shape:
 
         return self.x_min, self.x_max, self.z_min, self.z_max
 
-    def export_stl(self, filename: str, tolerance: float = 0.001) -> str:
+    def export_stl(
+            self,
+            filename: str,
+            tolerance: Optional[float] = 0.001) -> str:
         """Exports an stl file for the Shape.solid. If the provided filename
             doesn't end with .stl it will be added
 
@@ -763,9 +770,9 @@ class Shape:
 
     def export_stp(
             self,
-            filename=None,
-            units='mm',
-            mode: str = 'solid') -> str:
+            filename: Optional[str] = None,
+            units: Optional[str] = 'mm',
+            mode: Optional[str] = 'solid') -> str:
         """Exports an stp file for the Shape.solid. If the filename provided
             doesn't end with .stp or .step then .stp will be added. If a
             filename is not provided and the shape's stp_filename property is
@@ -843,17 +850,16 @@ class Shape:
 
     def export_svg(
         self,
-        filename: str = 'shape.svg',
+        filename: Optional[str] = 'shape.svg',
         projectionDir: Tuple[float, float, float] = (-1.75, 1.1, 5),
-        width: float = 800,
-        height: float = 800,
-        marginLeft: float = 100,
-        marginTop: float = 100,
-        strokeWidth: float = None,
-        strokeColor: Tuple[int, int, int] = (0, 0, 0),
-        hiddenColor: Tuple[int, int, int] = (100, 100, 100),
-        showHidden: bool = True,
-    ) -> str:
+        width: Optional[float] = 800,
+        height: Optional[float] = 800,
+        marginLeft: Optional[float] = 100,
+        marginTop: Optional[float] = 100,
+        strokeWidth: Optional[float] = None,
+        strokeColor: Optional[Tuple[int, int, int]] = (0, 0, 0),
+        hiddenColor: Optional[Tuple[int, int, int]] = (100, 100, 100),
+        showHidden: Optional[bool] = True) -> str:
         """Exports an svg file for the Reactor.solid. If the filename provided
         doesn't end with .svg it will be added.
 
@@ -916,10 +922,10 @@ class Shape:
 
     def export_html(
             self,
-            filename: str = "shape.html",
-            facet_splines: bool = True,
-            facet_circles: bool = True,
-            tolerance: float = 1e-3,
+            filename: Optional[str] = "shape.html",
+            facet_splines: Optional[bool] = True,
+            facet_circles: Optional[bool] = True,
+            tolerance: Optional[float] = 1e-3,
     ):
         """Creates a html graph representation of the points and connections
         for the Shape object. Shapes are colored by their .color property.
@@ -985,8 +991,12 @@ class Shape:
         return fig
 
     def export_2d_image(
-            self, filename: str = 'shape.png', xmin: float = 0.,
-            xmax: float = 900., ymin: float = -600., ymax: float = 600.):
+            self,
+            filename: Optional[str] = 'shape.png',
+            xmin: Optional[float] = 0.,
+            xmax: Optional[float] = 900.,
+            ymin: Optional[float] = -600.,
+            ymax: Optional[float] = 600.):
         """Exports a 2d image (png) of the reactor. Components are colored by
         their Shape.color property. If filename provided doesn't end with .png
         then .png will be added.
@@ -1093,7 +1103,7 @@ class Shape:
 
         return neutronics_description
 
-    def perform_boolean_operations(self, solid, **kwargs):
+    def perform_boolean_operations(self, solid: cq.Workplane, **kwargs):
         """Performs boolean cut, intersect and union operations if shapes are
         provided"""
 
@@ -1118,7 +1128,9 @@ class Shape:
 
         return solid
 
-    def make_graveyard(self, graveyard_offset: int = 100):
+    def make_graveyard(
+            self,
+            graveyard_offset: Optional[int] = 100) -> cq.Workplane:
         """Creates a graveyard volume (bounding box) that encapsulates all
         volumes. This is required by DAGMC when performing neutronics
         simulations.
@@ -1152,10 +1164,10 @@ class Shape:
 
     def export_h5m(
             self,
-            filename: str = 'dagmc.h5m',
-            skip_graveyard: bool = False,
-            tolerance: float = 0.001,
-            graveyard_offset: float = 100) -> str:
+            filename: Optional[str] = 'dagmc.h5m',
+            skip_graveyard: Optional[bool] = False,
+            tolerance: Optional[float] = 0.001,
+            graveyard_offset: Optional[float] = 100) -> str:
         """Converts stl files into DAGMC compatible h5m file using PyMOAB. The
         DAGMC file produced has not been imprinted and merged unlike the other
         supported method which uses Trelis to produce an imprinted and merged
@@ -1222,8 +1234,8 @@ class Shape:
 
     def export_graveyard(
             self,
-            graveyard_offset: float = 100,
-            filename: str = "Graveyard.stp") -> str:
+            graveyard_offset: Optional[float] = 100,
+            filename: Optional[str] = "Graveyard.stp") -> str:
         """Writes an stp file (CAD geometry) for the reactor graveyard. This
         is needed for DAGMC simulations. This method also calls
         Reactor.make_graveyard with the offset.

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -841,12 +841,48 @@ class Shape:
 
         return str(path_filename)
 
-    def export_svg(self, filename: str) -> str:
-        """Exports an svg file for the Shape.solid. If the provided filename
+    def export_svg(
+            self,
+            filename: str = 'shape.svg',
+            projectionDir: Tuple[float, float, float] = (-1.75, 1.1, 5),
+            width: float = 800,
+            height: float = 800,
+            marginLeft: float = 100,
+            marginTop: float = 100,
+            strokeWidth: float = None,
+            strokeColor: Tuple[int, int, int] = (0, 0, 0),
+            hiddenColor: Tuple[int, int, int] = (100, 100, 100),
+            showHidden: bool = True,
+        ) -> str:
+        """Exports an svg file for the Reactor.solid. If the filename provided
         doesn't end with .svg it will be added.
 
         Args:
-            filename (str): the filename of the svg file to be exported
+            filename: the filename of the svg file to be exported. Defaults to
+                "reactor.svg".
+            projectionDir: The direction vector to view the geometry from
+                (x, y, z). Defaults to (-1.75, 1.1, 5)
+            width: the width of the svg image produced in pixels. Defaults to
+                1000
+            height: the height of the svg image produced in pixels. Defaults to
+                800
+            marginLeft: the number of pixels between the left edge of the image
+                and the start of the geometry.
+            marginTop: the number of pixels between the top edge of the image
+                and the start of the geometry.
+            strokeWidth: the width of the lines used to draw the geometry.
+                Defaults to None which automatically selects an suitable width.
+            strokeColor: the color of the lines used to draw the geometry in 
+                RGB format with each value between 0 and 255. Defaults to
+                (0, 0, 0) which is black.
+            hiddenColor: the color of the lines used to draw the geometry in 
+                RGB format with each value between 0 and 255. Defaults to
+               (100, 100, 100) which is light grey.
+            showHidden: If the edges obscured by geometry should be included in
+                the diagram. Defaults to True.
+
+        Returns:
+            str: the svg filename created      
         """
 
         path_filename = Path(filename)
@@ -856,11 +892,28 @@ class Shape:
 
         path_filename.parents[0].mkdir(parents=True, exist_ok=True)
 
-        with open(path_filename, "w") as out_file:
-            exporters.exportShape(self.solid, "SVG", out_file)
+        opt = {
+            "width": width,
+            "height": height,
+            "marginLeft": marginLeft,
+            "marginTop": marginTop,
+            "showAxes": False,
+            "projectionDir": projectionDir,
+            "strokeColor": strokeColor,
+            "hiddenColor": hiddenColor,
+            "showHidden": showHidden
+        }
+
+        if strokeWidth is not None:
+            opt["strokeWidth"] = strokeWidth
+
+        exporters.export(self.solid, str(path_filename), exportType='SVG',
+                         opt=opt)
+
         print("Saved file as ", path_filename)
 
         return str(path_filename)
+
 
     def export_html(
             self,

--- a/tests/test_example_reactors.py
+++ b/tests/test_example_reactors.py
@@ -5,13 +5,30 @@ import unittest
 from pathlib import Path
 
 from examples.example_parametric_reactors import (
-    ball_reactor, ball_reactor_single_null, submersion_reactor_single_null,
-    htc_reactor)
+    ball_reactor, ball_reactor_single_null, htc_reactor, make_animation,
+    submersion_reactor_single_null)
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'examples'))
 
 
 class TestExampleReactors(unittest.TestCase):
+
+    def test_make_animations(self):
+        """Runs the example to check the output files are produced"""
+        output_filenames = [
+            "random_0000.svg",
+            "random_0001.svg",
+            "rotation_0000.svg",
+            "rotation_0001.svg",
+        ]
+        for output_filename in output_filenames:
+            os.system("rm " + output_filename)
+        make_animation.rotate_single_reactor(2)
+        make_animation.make_random_reactors(2)
+        for output_filename in output_filenames:
+            assert Path(output_filename).exists() is True
+            os.system("rm " + output_filename)
+
     def test_make_parametric_htc_rector(self):
         """Runs the example to check the output files are produced"""
         output_filenames = [


### PR DESCRIPTION
## Proposed changes

This PR updates the export svg methods so that they allow new export options such as view angle and image width.

The animation examples script has also been updated to make use of this improved feature.

Ideally the gif made for the rotation should have their last and first frame blend into each other but I've not quite got the angles x,y,z correct

This makes use of quite a new feature in CQ so the docker image usedin circle ci might need rebuilding for this to pass

![3d_svg](https://user-images.githubusercontent.com/8583900/106968068-17374c80-6740-11eb-9f0d-9e9355f7fd55.gif)

![rotated_z](https://user-images.githubusercontent.com/8583900/106972215-4d78ca00-6748-11eb-8165-37a56b629c0a.gif)


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
