### PR TITLE
updated stp exporter to new cq method

### DIFF
--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -807,7 +807,7 @@ class Shape:
         else:
             raise ValueError("The mode argument for export_stp \
                 only accepts 'solid' or 'wire'", self)
-  
+
         if units == 'cm':
             _replace(
                 path_filename,

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -800,15 +800,14 @@ class Shape:
         elif self.stp_filename is not None:
             path_filename = Path(self.stp_filename)
 
-        with open(path_filename, "w") as out_file:
-            if mode == 'solid':
-                exporters.exportShape(self.solid, "STEP", out_file)
-            elif mode == 'wire':
-                exporters.exportShape(self.wire, "STEP", out_file)
-            else:
-                raise ValueError("The mode argument for export_stp \
-                    only accepts 'solid' or 'wire'", self)
-
+        if mode == 'solid':
+            exporters.export(self.solid, str(path_filename), exportType='STEP')
+        elif mode == 'wire':
+            exporters.export(self.wire, str(path_filename), exportType='STEP')
+        else:
+            raise ValueError("The mode argument for export_stp \
+                only accepts 'solid' or 'wire'", self)
+  
         if units == 'cm':
             _replace(
                 path_filename,


### PR DESCRIPTION
## Proposed changes

This removes the opening of a file and use of exporters.exportShape and replaces it with exporters.export when exporting a stp file as discussed in #82 

The former method is now depreciated.

```angular_tolerance```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
