### PR TITLE
added openmp threads option

### DIFF
--- a/paramak/parametric_neutronics/neutronics_model.py
+++ b/paramak/parametric_neutronics/neutronics_model.py
@@ -592,7 +592,7 @@ class NeutronicsModel():
 
     def simulate(self, verbose: bool = True, method: str = None,
                  cell_tally_results_filename: str = 'results.json',
-                 openmp_threads: int = None):
+                 threads: int = None):
         """Run the OpenMC simulation. Deletes exisiting simulation output
         (summary.h5) if files exists.
 
@@ -603,7 +603,7 @@ class NeutronicsModel():
             method (str): The method to use when making the imprinted and
                 merged geometry. Options are "ppp", "trelis", "pymoab".
                 Defaults to pymoab.
-            openmp_threads (int, optional): Sets the number of OpenMP threads
+            threads (int, optional): Sets the number of OpenMP threads
                 used for the simulation. None takes all available threads by 
                 default. Defaults to None.
 
@@ -625,7 +625,7 @@ class NeutronicsModel():
         os.system('rm tallies.xml')
 
         self.statepoint_filename = self.model.run(
-            output=verbose, threads=openmp_threads
+            output=verbose, threads=threads
         )
         self.results = get_neutronics_results_from_statepoint_file(
             statepoint_filename=self.statepoint_filename,

--- a/paramak/parametric_neutronics/neutronics_model.py
+++ b/paramak/parametric_neutronics/neutronics_model.py
@@ -603,6 +603,9 @@ class NeutronicsModel():
             method (str): The method to use when making the imprinted and
                 merged geometry. Options are "ppp", "trelis", "pymoab".
                 Defaults to pymoab.
+            openmp_threads (int, optional): Sets the number of OpenMP threads
+                used for the simulation. None means all available threads are
+                used. Defaults to None.
 
         Returns:
             dict: the simulation output filename

--- a/paramak/parametric_neutronics/neutronics_model.py
+++ b/paramak/parametric_neutronics/neutronics_model.py
@@ -604,8 +604,8 @@ class NeutronicsModel():
                 merged geometry. Options are "ppp", "trelis", "pymoab".
                 Defaults to pymoab.
             openmp_threads (int, optional): Sets the number of OpenMP threads
-                used for the simulation. None means all available threads are
-                used. Defaults to None.
+                used for the simulation. None takes all threads by default.
+                Defaults to None.
 
         Returns:
             dict: the simulation output filename

--- a/paramak/parametric_neutronics/neutronics_model.py
+++ b/paramak/parametric_neutronics/neutronics_model.py
@@ -604,8 +604,8 @@ class NeutronicsModel():
                 merged geometry. Options are "ppp", "trelis", "pymoab".
                 Defaults to pymoab.
             openmp_threads (int, optional): Sets the number of OpenMP threads
-                used for the simulation. None takes all threads by default.
-                Defaults to None.
+                used for the simulation. None takes all available threads by 
+                default. Defaults to None.
 
         Returns:
             dict: the simulation output filename

--- a/paramak/parametric_neutronics/neutronics_model.py
+++ b/paramak/parametric_neutronics/neutronics_model.py
@@ -591,7 +591,8 @@ class NeutronicsModel():
                 self.tallies.append(tally)
 
     def simulate(self, verbose: bool = True, method: str = None,
-                 cell_tally_results_filename: str = 'results.json'):
+                 cell_tally_results_filename: str = 'results.json',
+                 openmp_threads: int = None):
         """Run the OpenMC simulation. Deletes exisiting simulation output
         (summary.h5) if files exists.
 
@@ -620,7 +621,9 @@ class NeutronicsModel():
         os.system('rm settings.xml')
         os.system('rm tallies.xml')
 
-        self.statepoint_filename = self.model.run(output=verbose)
+        self.statepoint_filename = self.model.run(
+            output=verbose, threads=openmp_threads
+        )
         self.results = get_neutronics_results_from_statepoint_file(
             statepoint_filename=self.statepoint_filename,
             fusion_power=self.fusion_power


### PR DESCRIPTION
## Proposed changes

PR which adds an optional openmp_threads argument to .simulate() to control the number of threads OpenMC uses during a simulation.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
