### PR TITLE
added method = trelis-gui option

### DIFF
--- a/paramak/parametric_neutronics/make_faceteted_neutronics_model.py
+++ b/paramak/parametric_neutronics/make_faceteted_neutronics_model.py
@@ -6,7 +6,7 @@ import os
 # file is required that specfies a the stp filenames and the materials names to
 # assign. The name of the manifest file is manifest.json by default but can be
 # specified using aprepro arguments. Other optional aprepro arguments are
-# faceting_tolerance and merge_tolerance which default to 1e-1 and 1e-4 by
+# faceting_tolerance and merge_tolerance which default to 1e-3 and 1e-4 by
 # default
 
 # To using this script with Trelis it can be run in batch mode
@@ -195,7 +195,7 @@ for var_name in aprepro_vars:
 if "faceting_tolerance" in aprepro_vars:
     faceting_tolerance = str(cubit.get_aprepro_value_as_string("faceting_tolerance"))
 else:
-    faceting_tolerance = str(1.0e-1)
+    faceting_tolerance = str(1.0e-3)
 
 if "merge_tolerance" in aprepro_vars:
     merge_tolerance = str(cubit.get_aprepro_value_as_string("merge_tolerance"))

--- a/paramak/parametric_neutronics/neutronics_model.py
+++ b/paramak/parametric_neutronics/neutronics_model.py
@@ -77,7 +77,7 @@ class NeutronicsModel():
         merge_tolerance (float): the tolerance to use when merging surfaces.
             Defaults to 1e-4.
         faceting_tolerance (float): the tolerance to use when faceting surfaces.
-            Defaults to 1e-1.
+            Defaults to 1e-3.
         mesh_2D_resolution (tuple of ints): The 3D mesh resolution in the height
             and width directions. The larger the resolution the finer the mesh
             and more computational intensity is required to converge each mesh
@@ -99,7 +99,7 @@ class NeutronicsModel():
         simulation_batches: int = 100,
         simulation_particles_per_batch: int = 10000,
         max_lost_particles: int = 10,
-        faceting_tolerance: float = 1e-1,
+        faceting_tolerance: float = 1e-3,
         merge_tolerance: float = 1e-4,
         mesh_2D_resolution: float = (400, 400),
         mesh_3D_resolution: float = (100, 100, 100),
@@ -318,11 +318,11 @@ class NeutronicsModel():
 
         Arguments:
             method: (str): The method to use when making the imprinted and
-                merged geometry. Options are "ppp", "trelis", "pymoab" and
-                None.  Defaults to None.
+                merged geometry. Options are "ppp", "trelis", "trelis-gui",
+                "pymoab" and None. Defaults to None.
         """
 
-        if method in ['ppp', 'trelis', 'pymoab']:
+        if method in ['ppp', 'trelis', 'trelis-gui', 'pymoab']:
             os.system('rm dagmc_not_watertight.h5m')
             os.system('rm dagmc.h5m')
         elif method is None and Path('dagmc.h5m').is_file():
@@ -330,7 +330,8 @@ class NeutronicsModel():
         else:
             raise ValueError(
                 "the method using in create_neutronics_geometry \
-                should be either ppp, trelis, pymoab or None.", method)
+                should be either ppp, trelis, trelis-gui, pymoab or None.",
+                method)
 
         if method == 'ppp':
 
@@ -358,7 +359,7 @@ class NeutronicsModel():
             #         occ_faceter/bin folder is in the path directory")
             # self._make_watertight()
 
-        elif method == 'trelis':
+        elif method.startswith('trelis'):
             self.geometry.export_stp()
             self.geometry.export_neutronics_description()
 
@@ -371,8 +372,12 @@ class NeutronicsModel():
                 raise FileNotFoundError(
                     "The make_faceteted_neutronics_model.py was \
                     not found in the directory")
-            os.system("trelis -batch -nographics make_faceteted_neutronics_model.py \"faceting_tolerance='" +
-                      str(self.faceting_tolerance) + "'\" \"merge_tolerance='" + str(self.merge_tolerance) + "'\"")
+            if method == 'trelis-gui':
+                os.system("trelis make_faceteted_neutronics_model.py \"faceting_tolerance='" +
+                        str(self.faceting_tolerance) + "'\" \"merge_tolerance='" + str(self.merge_tolerance) + "'\"")
+            else:
+                os.system("trelis -batch -nographics make_faceteted_neutronics_model.py \"faceting_tolerance='" +
+                        str(self.faceting_tolerance) + "'\" \"merge_tolerance='" + str(self.merge_tolerance) + "'\"")
 
             if not Path("dagmc_not_watertight.h5m").is_file():
                 raise FileNotFoundError(
@@ -409,8 +414,8 @@ class NeutronicsModel():
 
         Arguments:
             method: (str): The method to use when making the imprinted and
-                merged geometry. Options are "ppp", "trelis", "pymoab".
-                Defaults to None.
+                merged geometry. Options are "ppp", "trelis", "trelis-gui",
+                "pymoab". Defaults to None.
         """
 
         self.create_materials()

--- a/paramak/parametric_neutronics/neutronics_model.py
+++ b/paramak/parametric_neutronics/neutronics_model.py
@@ -373,11 +373,11 @@ class NeutronicsModel():
                     "The make_faceteted_neutronics_model.py was \
                     not found in the directory")
             if method == 'trelis-gui':
-                os.system("trelis make_faceteted_neutronics_model.py \"faceting_tolerance='" +
-                        str(self.faceting_tolerance) + "'\" \"merge_tolerance='" + str(self.merge_tolerance) + "'\"")
+                os.system("trelis make_faceteted_neutronics_model.py \"faceting_tolerance='" + str(
+                    self.faceting_tolerance) + "'\" \"merge_tolerance='" + str(self.merge_tolerance) + "'\"")
             else:
                 os.system("trelis -batch -nographics make_faceteted_neutronics_model.py \"faceting_tolerance='" +
-                        str(self.faceting_tolerance) + "'\" \"merge_tolerance='" + str(self.merge_tolerance) + "'\"")
+                          str(self.faceting_tolerance) + "'\" \"merge_tolerance='" + str(self.merge_tolerance) + "'\"")
 
             if not Path("dagmc_not_watertight.h5m").is_file():
                 raise FileNotFoundError(


### PR DESCRIPTION
## Proposed changes

While the paramak is setup for automation it is sometimes desirable to view the trelis model and visually check it for imperfections.

This PR adds another option to the methods available called ```trelis-gui``` which runs trelis without the --batch mode. This means trelis gui will pop up and make the DAGMC geometry with the user able to observe the group naming and other aspects

The trelis-gui will stay open till the user closes it. Most of the time the user will have to hide the graveyard to make the geometry visable.

![Screenshot from 2021-02-23 15-59-53](https://user-images.githubusercontent.com/8583900/108870700-40852300-75f0-11eb-9fc2-a93c666b9c9d.png)


## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
