### PR TITLE
added method to convert circle edges to spline edges

### DIFF
--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -1271,7 +1271,7 @@ class Shape:
 
         return new_filename
 
-    def convert_all_circle_points_to_splines(
+    def convert_all_circle_connections_to_splines(
             self,
             tolerance: Optional[float] = 0.1
     ) -> List[Tuple[float, float, str]]:
@@ -1299,7 +1299,7 @@ class Shape:
                 p1 = self.points[counter + 1][:2]
                 p2 = self.points[counter + 2][:2]
 
-                points = paramak.utils.convert_single_circle_to_spline(
+                points = paramak.utils.convert_circle_to_spline(
                     p0, p1, p2, tolerance=tolerance
                 )
 

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -1270,3 +1270,44 @@ class Shape:
         new_filename = self.graveyard.export_stp(Path(filename))
 
         return new_filename
+
+    def make_circle_edge(self, p0, p1, p2, tolerance=0.1):
+
+        solid = cq.Workplane(self.workplane).center(0, 0)
+        solid = solid.moveTo(p0[0], p0[1]).threePointArc(p1, p2)
+        edge = solid.vals()[0]
+
+        new_edge = paramak.utils._transform_curve(edge, tolerance=tolerance)
+
+        points = paramak.utils.extract_points_from_edges(
+            edges=new_edge,
+            # view_plane=view_plane
+        )
+        points_with_connections = []
+        for point in points[:-1]:
+            print('         ',(point[0], point[1], 'spline'))
+            points_with_connections.append((point[0], point[1], 'spline'))
+
+        return points_with_connections
+
+    def convert_circle_edges_to_splines(self, tolerance=0.1):
+
+        new_points = []
+        counter = 0
+        while counter < len(self.points):
+
+            if self.points[counter][2] == 'circle':
+                p0 = self.points[counter][:2]
+                p1 = self.points[counter+1][:2]
+                p2 = self.points[counter+2][:2]
+
+                points = self.make_circle_edge(p0, p1, p2, tolerance=tolerance)
+
+                new_points = new_points + points
+                new_points.append(self.points[counter+2])
+                counter = counter+3
+            else:
+                new_points.append(self.points[counter])
+                counter = counter+1
+        self.points = new_points[:-1]
+        return new_points[:-1]

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -1271,26 +1271,24 @@ class Shape:
 
         return new_filename
 
-    def make_circle_edge(self, p0, p1, p2, tolerance=0.1):
+    def convert_all_circle_points_to_splines(
+            self,
+            tolerance: Optional[float] = 0.1
+            ) -> List[Tuple[float, float, str]]:
+        """Replaces circle edges in Shape.points with spline edges. The spline
+        control coordinates are obtained by faceting the circle edge with the
+        provided tolerance. The Shape.points will be updated to exclude the
+        circle points and include the new spline points. This method works best
+        when the connection before and after the circle is s straight
+        connection type. This method is useful when converting the stp file
+        into other formats due to errors in the conversion of circle edges.
 
-        solid = cq.Workplane(self.workplane).center(0, 0)
-        solid = solid.moveTo(p0[0], p0[1]).threePointArc(p1, p2)
-        edge = solid.vals()[0]
+        Args:
+            tolerance: the precision of the faceting.
 
-        new_edge = paramak.utils._transform_curve(edge, tolerance=tolerance)
-
-        points = paramak.utils.extract_points_from_edges(
-            edges=new_edge,
-            # view_plane=view_plane
-        )
-        points_with_connections = []
-        for point in points[:-1]:
-            print('         ',(point[0], point[1], 'spline'))
-            points_with_connections.append((point[0], point[1], 'spline'))
-
-        return points_with_connections
-
-    def convert_circle_edges_to_splines(self, tolerance=0.1):
+        Returns:
+            The new points with spline connections
+        """
 
         new_points = []
         counter = 0
@@ -1301,7 +1299,9 @@ class Shape:
                 p1 = self.points[counter+1][:2]
                 p2 = self.points[counter+2][:2]
 
-                points = self.make_circle_edge(p0, p1, p2, tolerance=tolerance)
+                points = paramak.utils.convert_single_circle_to_spline(
+                    p0, p1, p2, tolerance=tolerance
+                )
 
                 new_points = new_points + points
                 new_points.append(self.points[counter+2])

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -1285,7 +1285,7 @@ class Shape:
         )
         points_with_connections = []
         for point in points[:-1]:
-            print('         ',(point[0], point[1], 'spline'))
+            print('         ', (point[0], point[1], 'spline'))
             points_with_connections.append((point[0], point[1], 'spline'))
 
         return points_with_connections
@@ -1298,16 +1298,16 @@ class Shape:
 
             if self.points[counter][2] == 'circle':
                 p0 = self.points[counter][:2]
-                p1 = self.points[counter+1][:2]
-                p2 = self.points[counter+2][:2]
+                p1 = self.points[counter + 1][:2]
+                p2 = self.points[counter + 2][:2]
 
                 points = self.make_circle_edge(p0, p1, p2, tolerance=tolerance)
 
                 new_points = new_points + points
-                new_points.append(self.points[counter+2])
-                counter = counter+3
+                new_points.append(self.points[counter + 2])
+                counter = counter + 3
             else:
                 new_points.append(self.points[counter])
-                counter = counter+1
+                counter = counter + 1
         self.points = new_points[:-1]
         return new_points[:-1]

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -1274,7 +1274,7 @@ class Shape:
     def convert_all_circle_points_to_splines(
             self,
             tolerance: Optional[float] = 0.1
-            ) -> List[Tuple[float, float, str]]:
+    ) -> List[Tuple[float, float, str]]:
         """Replaces circle edges in Shape.points with spline edges. The spline
         control coordinates are obtained by faceting the circle edge with the
         provided tolerance. The Shape.points will be updated to exclude the

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -1303,7 +1303,10 @@ class Shape:
                     p0, p1, p2, tolerance=tolerance
                 )
 
-                new_points = new_points + points
+                # the last point needs to have the connection type of p2
+                for point in points[:-1]:
+                    new_points.append((point[0], point[1], 'spline'))
+
                 new_points.append(self.points[counter + 2])
                 counter = counter + 3
             else:

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -1295,12 +1295,12 @@ class Shape:
         while counter < len(self.points):
 
             if self.points[counter][2] == 'circle':
-                p0 = self.points[counter][:2]
-                p1 = self.points[counter + 1][:2]
-                p2 = self.points[counter + 2][:2]
+                p_0 = self.points[counter][:2]
+                p_1 = self.points[counter + 1][:2]
+                p_2 = self.points[counter + 2][:2]
 
                 points = paramak.utils.convert_circle_to_spline(
-                    p0, p1, p2, tolerance=tolerance
+                    p_0, p_1, p_2, tolerance=tolerance
                 )
 
                 # the last point needs to have the connection type of p2

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -659,7 +659,7 @@ def convert_single_circle_to_spline(
         p1: Tuple[float, float],
         p2: Tuple[float, float],
         tolerance: Optional[float] = 0.1
-        ) -> List[Tuple[float, float, str]]:
+) -> List[Tuple[float, float, str]]:
     """Converts three points on the edge of a circle into a series of points
     on the edge of the circle. This is done by creating a circle edge from the
     the points provided (p0, p1, p2), facets the circle with the provided

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -686,18 +686,15 @@ def convert_circle_to_spline(
         edges=new_edge,
         view_plane='XZ'
     )
-    points_with_connections = []
-    for point in points:
-        points_with_connections.append((point[0], point[1]))
 
-    return points_with_connections
+    return points
 
 
 class FaceAreaSelector(cq.Selector):
     """A custom CadQuery selector the selects faces based on their area with a
     tolerance. The following useage example will fillet the faces of an extrude
-    shape with an area of 0.5. paramak.ExtrudeStraightShape(points=[(1,1),(2,1),
-    (2,2)], distance=5).solid.faces(FaceAreaSelector(0.5)).fillet(0.1)
+    shape with an area of 0.5. paramak.ExtrudeStraightShape(points=[(1,1),
+    (2,1), (2,2)], distance=5).solid.faces(FaceAreaSelector(0.5)).fillet(0.1)
 
     Args:
         area (float): The area of the surface to select.

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -663,8 +663,7 @@ def convert_circle_to_spline(
     """Converts three points on the edge of a circle into a series of points
     on the edge of the circle. This is done by creating a circle edge from the
     the points provided (p0, p1, p2), facets the circle with the provided
-    tolerance to extracts the points on the faceted edge and returns them with
-    spline connections.
+    tolerance to extracts the points on the faceted edge and returns them.
 
     Args:
         p0: coordinates of the first point
@@ -673,7 +672,7 @@ def convert_circle_to_spline(
         tolerance: the precision of the faceting.
 
     Returns:
-        The new points with spline connections
+        The new points
     """
 
     # work plane is arbitrarily selected and has no impact of function
@@ -688,8 +687,8 @@ def convert_circle_to_spline(
         view_plane='XZ'
     )
     points_with_connections = []
-    for point in points[:-1]:
-        points_with_connections.append((point[0], point[1], 'spline'))
+    for point in points:
+        points_with_connections.append((point[0], point[1]))
 
     return points_with_connections
 

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -17,7 +17,7 @@ from OCP.GCPnts import GCPnts_QuasiUniformDeflection
 import paramak
 
 
-def _transform_curve(edge, tolerance: float = 1e-3):
+def transform_curve(edge, tolerance: float = 1e-3):
     """Converts a curved edge into a series of straight lines (facetets) with
     the provided tolerance.
 
@@ -80,7 +80,7 @@ def facet_wire(
 
     for edge in iterable_of_wires:
         if edge.geomType() in types_to_facet:
-            edges.extend(_transform_curve(edge, tolerance=tolerance).Edges())
+            edges.extend(transform_curve(edge, tolerance=tolerance).Edges())
         else:
             edges.append(edge)
 
@@ -655,20 +655,20 @@ def export_wire_to_html(
 
 
 def convert_circle_to_spline(
-        p0: Tuple[float, float],
-        p1: Tuple[float, float],
-        p2: Tuple[float, float],
+        p_0: Tuple[float, float],
+        p_1: Tuple[float, float],
+        p_2: Tuple[float, float],
         tolerance: Optional[float] = 0.1
 ) -> List[Tuple[float, float, str]]:
     """Converts three points on the edge of a circle into a series of points
     on the edge of the circle. This is done by creating a circle edge from the
-    the points provided (p0, p1, p2), facets the circle with the provided
+    the points provided (p_0, p_1, p_2), facets the circle with the provided
     tolerance to extracts the points on the faceted edge and returns them.
 
     Args:
-        p0: coordinates of the first point
-        p1: coordinates of the second point
-        p2: coordinates of the third point
+        p_0: coordinates of the first point
+        p_1: coordinates of the second point
+        p_2: coordinates of the third point
         tolerance: the precision of the faceting.
 
     Returns:
@@ -677,10 +677,10 @@ def convert_circle_to_spline(
 
     # work plane is arbitrarily selected and has no impact of function
     solid = cq.Workplane('XZ').center(0, 0)
-    solid = solid.moveTo(p0[0], p0[1]).threePointArc(p1, p2)
+    solid = solid.moveTo(p_0[0], p_0[1]).threePointArc(p_1, p_2)
     edge = solid.vals()[0]
 
-    new_edge = paramak.utils._transform_curve(edge, tolerance=tolerance)
+    new_edge = paramak.utils.transform_curve(edge, tolerance=tolerance)
 
     points = paramak.utils.extract_points_from_edges(
         edges=new_edge,

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -654,7 +654,7 @@ def export_wire_to_html(
     return fig
 
 
-def convert_single_circle_to_spline(
+def convert_circle_to_spline(
         p0: Tuple[float, float],
         p1: Tuple[float, float],
         p2: Tuple[float, float],
@@ -677,7 +677,7 @@ def convert_single_circle_to_spline(
     """
 
     # work plane is arbitrarily selected and has no impact of function
-    solid = cq.Workplane('XY').center(0, 0)
+    solid = cq.Workplane('XZ').center(0, 0)
     solid = solid.moveTo(p0[0], p0[1]).threePointArc(p1, p2)
     edge = solid.vals()[0]
 
@@ -685,7 +685,7 @@ def convert_single_circle_to_spline(
 
     points = paramak.utils.extract_points_from_edges(
         edges=new_edge,
-        # view_plane=view_plane
+        view_plane='XZ'
     )
     points_with_connections = []
     for point in points[:-1]:

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -10,6 +10,33 @@ import pytest
 
 class TestShape(unittest.TestCase):
 
+    def setUp(self):
+        
+        self.test_rotate_mixed_shape = paramak.RotateMixedShape(
+            rotation_angle=180,
+            points=[
+                (100, 0, "straight"),
+                (200, 0, "circle"),
+                (250, 50, "circle"),
+                (200, 100, "straight"),
+                (150, 100, "straight"),
+                (140, 75, "straight"),
+                (110, 45, "straight"),
+            ]
+        )
+        self.test_extrude_mixed_shape = paramak.ExtrudeMixedShape(
+            distance=10,
+            points=[
+                (100, 0, "straight"),
+                (200, 0, "circle"),
+                (250, 50, "circle"),
+                (200, 100, "straight"),
+                (150, 100, "straight"),
+                (140, 75, "straight"),
+                (110, 45, "straight"),
+            ]
+        )
+
     def test_shape_default_properties(self):
         """Creates a Shape object and checks that the points attribute has
         a default of None."""
@@ -558,34 +585,7 @@ class TestShape(unittest.TestCase):
         for i in range(len(incorrect_values)):
             self.assertRaises(ValueError, set_value)
 
-    def test_convert_single_circle_to_spline(self):
-        """Tests the conversion of 3 points on a circle into points on a spline
-        curve."""
-
-        new_points = paramak.utils.convert_single_circle_to_spline(
-            p0=(200, 0),
-            p1=(250, 50),
-            p2=(200, 100),
-            tolerance=0.2
-        )
-
-        connections = [connection[2] for connection in new_points]
-
-        assert len(set(connections)) == 1
-        assert connections[0] == 'spline'
-
-        new_points = paramak.utils.convert_single_circle_to_spline(
-            p0=(200, 0),
-            p1=(250, 50),
-            p2=(200, 100),
-            tolerance=0.1
-        )
-
-        connections_lower_tol = [connection[2] for connection in new_points]
-
-        assert len(connections_lower_tol) > len(connections)
-
-    def test_convert_all_circle_points_to_splines(self):
+    def test_convert_all_circle_points_change_to_splines(self):
         """creates a ExtrudeMixedShape with two circular edges and converts
         them to spline edges. Checks the new edges have been correctly
         replaced with splines"""
@@ -603,7 +603,7 @@ class TestShape(unittest.TestCase):
             ]
         )
         assert len(rotated_mixed.points) == 8
-        rotated_mixed.convert_all_circle_points_to_splines()
+        rotated_mixed.convert_all_circle_connections_to_splines()
         assert len(rotated_mixed.points) > 8
         assert rotated_mixed.points[0][2] == 'straight'
         assert rotated_mixed.points[1][0] == 200
@@ -617,6 +617,28 @@ class TestShape(unittest.TestCase):
         assert rotated_mixed.points[-1][1] == 0
         assert rotated_mixed.points[-2][2] == 'spline'
         assert rotated_mixed.points[-3][2] == 'spline'
+
+    def test_convert_circles_to_splines_volume_RotateMixedShape(self):
+        """creates a RotateMixedShape with a circular edge and converts the
+        edge to a spline edges. Checks the new shape has appoximatly the same
+        volume as the orignal shape (with circles)"""
+
+        original_volume = self.test_rotate_mixed_shape.volume
+        self.test_rotate_mixed_shape.convert_all_circle_connections_to_splines()
+        new_volume = self.test_rotate_mixed_shape.volume
+
+        assert pytest.approx(new_volume, rel=0.00001) == original_volume
+
+    def test_convert_circles_to_splines_volume_ExtrudeMixedShape(self):
+        """creates a ExtrudeMixedShape with a circular edge and converts the
+        edge to a spline edges. Checks the new shape has appoximatly the same
+        volume as the orignal shape (with circles)"""
+
+        original_volume = self.test_extrude_mixed_shape.volume
+        self.test_extrude_mixed_shape.convert_all_circle_connections_to_splines()
+        new_volume = self.test_extrude_mixed_shape.volume
+
+        assert pytest.approx(new_volume, rel=0.00001) == original_volume
 
 
 if __name__ == "__main__":

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -11,7 +11,7 @@ import pytest
 class TestShape(unittest.TestCase):
 
     def setUp(self):
-        
+
         self.test_rotate_mixed_shape = paramak.RotateMixedShape(
             rotation_angle=180,
             points=[

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -13,7 +13,7 @@ class TestShape(unittest.TestCase):
     def setUp(self):
         
         self.test_rotate_mixed_shape = paramak.RotateMixedShape(
-            rotation_angle=180,
+            rotation_angle=1,
             points=[
                 (100, 0, "straight"),
                 (200, 0, "circle"),
@@ -25,7 +25,7 @@ class TestShape(unittest.TestCase):
             ]
         )
         self.test_extrude_mixed_shape = paramak.ExtrudeMixedShape(
-            distance=10,
+            distance=1,
             points=[
                 (100, 0, "straight"),
                 (200, 0, "circle"),
@@ -627,7 +627,7 @@ class TestShape(unittest.TestCase):
         self.test_rotate_mixed_shape.convert_all_circle_connections_to_splines()
         new_volume = self.test_rotate_mixed_shape.volume
 
-        assert pytest.approx(new_volume, rel=0.00001) == original_volume
+        assert pytest.approx(new_volume, rel=0.000001) == original_volume
 
     def test_convert_circles_to_splines_volume_ExtrudeMixedShape(self):
         """creates a ExtrudeMixedShape with a circular edge and converts the
@@ -638,7 +638,7 @@ class TestShape(unittest.TestCase):
         self.test_extrude_mixed_shape.convert_all_circle_connections_to_splines()
         new_volume = self.test_extrude_mixed_shape.volume
 
-        assert pytest.approx(new_volume, rel=0.00001) == original_volume
+        assert pytest.approx(new_volume, rel=0.000001) == original_volume
 
 
 if __name__ == "__main__":

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -585,61 +585,6 @@ class TestShape(unittest.TestCase):
         for i in range(len(incorrect_values)):
             self.assertRaises(ValueError, set_value)
 
-    def test_convert_all_circle_points_change_to_splines(self):
-        """creates a ExtrudeMixedShape with two circular edges and converts
-        them to spline edges. Checks the new edges have been correctly
-        replaced with splines"""
-
-        rotated_mixed = paramak.RotateMixedShape(
-            rotation_angle=180,
-            points=[
-                (100, 0, "straight"),
-                (200, 0, "circle"),
-                (250, 50, "circle"),
-                (200, 100, "straight"),
-                (150, 100, "straight"),
-                (140, 75, "circle"),
-                (110, 45, "circle"),
-            ]
-        )
-        assert len(rotated_mixed.points) == 8
-        rotated_mixed.convert_all_circle_connections_to_splines()
-        assert len(rotated_mixed.points) > 8
-        assert rotated_mixed.points[0][2] == 'straight'
-        assert rotated_mixed.points[1][0] == 200
-        assert rotated_mixed.points[1][1] == 0
-        assert rotated_mixed.points[1][2] == 'spline'
-        assert rotated_mixed.points[2][2] == 'spline'
-
-        # last point is the same as the first point
-        assert rotated_mixed.points[-1][2] == 'straight'
-        assert rotated_mixed.points[-1][0] == 100
-        assert rotated_mixed.points[-1][1] == 0
-        assert rotated_mixed.points[-2][2] == 'spline'
-        assert rotated_mixed.points[-3][2] == 'spline'
-
-    def test_convert_circles_to_splines_volume_RotateMixedShape(self):
-        """creates a RotateMixedShape with a circular edge and converts the
-        edge to a spline edges. Checks the new shape has appoximatly the same
-        volume as the orignal shape (with circles)"""
-
-        original_volume = self.test_rotate_mixed_shape.volume
-        self.test_rotate_mixed_shape.convert_all_circle_connections_to_splines()
-        new_volume = self.test_rotate_mixed_shape.volume
-
-        assert pytest.approx(new_volume, rel=0.000001) == original_volume
-
-    def test_convert_circles_to_splines_volume_ExtrudeMixedShape(self):
-        """creates a ExtrudeMixedShape with a circular edge and converts the
-        edge to a spline edges. Checks the new shape has appoximatly the same
-        volume as the orignal shape (with circles)"""
-
-        original_volume = self.test_extrude_mixed_shape.volume
-        self.test_extrude_mixed_shape.convert_all_circle_connections_to_splines()
-        new_volume = self.test_extrude_mixed_shape.volume
-
-        assert pytest.approx(new_volume, rel=0.000001) == original_volume
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parametric_shapes/test_ExtrudeMixedShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeMixedShape.py
@@ -195,7 +195,8 @@ class TestExtrudeMixedShape(unittest.TestCase):
         assert self.test_shape_2.points[-4] == (150, 100, "straight")
         assert self.test_shape_2.points[-5] == (200, 100, "straight")
 
-        for point in self.test_shape_2.points[1:len(self.test_shape_2.points)-5]:
+        for point in self.test_shape_2.points[1:len(
+                self.test_shape_2.points) - 5]:
             assert point[2] == 'spline'
 
     def test_convert_circles_to_splines_volume(self):

--- a/tests/test_parametric_shapes/test_ExtrudeMixedShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeMixedShape.py
@@ -16,6 +16,32 @@ class TestExtrudeMixedShape(unittest.TestCase):
             distance=50
         )
 
+        self.test_shape_2 = ExtrudeMixedShape(
+            distance=1,
+            points=[
+                (100, 0, "straight"),
+                (200, 0, "circle"),
+                (250, 50, "circle"),
+                (200, 100, "straight"),
+                (150, 100, "straight"),
+                (140, 75, "straight"),
+                (110, 45, "straight"),
+            ]
+        )
+
+        self.test_shape_3 = ExtrudeMixedShape(
+            distance=180,
+            points=[
+                (100, 0, "straight"),
+                (200, 0, "circle"),
+                (250, 50, "circle"),
+                (200, 100, "straight"),
+                (150, 100, "straight"),
+                (140, 75, "circle"),
+                (110, 45, "circle"),
+            ]
+        )
+
     def test_default_parameters(self):
         """Checks that the default parameters of an ExtrudeMixedShape are correct."""
 
@@ -150,6 +176,44 @@ class TestExtrudeMixedShape(unittest.TestCase):
             Path("test_solid2.stp").stat().st_size
 
         os.system("rm test_solid.stp test_solid2.stp test_wire.stp")
+
+    def test_convert_all_circle_points_change_to_splines(self):
+        """creates a ExtrudeMixedShape with one circular edges and converts
+        them to spline edges. Checks the new edges have been correctly
+        replaced with splines"""
+
+        assert len(self.test_shape_2.points) == 8
+        self.test_shape_2.convert_all_circle_connections_to_splines()
+        assert len(self.test_shape_2.points) > 8
+        assert self.test_shape_2.points[0] == (100, 0, "straight")
+        assert self.test_shape_2.points[1] == (200, 0, 'spline')
+
+        # last point is the same as the first point
+        assert self.test_shape_2.points[-1] == (100, 0, "straight")
+        assert self.test_shape_2.points[-2] == (110, 45, "straight")
+        assert self.test_shape_2.points[-3] == (140, 75, "straight")
+        assert self.test_shape_2.points[-4] == (150, 100, "straight")
+        assert self.test_shape_2.points[-5] == (200, 100, "straight")
+
+        for point in self.test_shape_2.points[1:len(self.test_shape_2.points)-5]:
+            assert point[2] == 'spline'
+
+    def test_convert_circles_to_splines_volume(self):
+        """creates a RotateMixedShape with a circular edge and converts the
+        edge to a spline edges. Checks the new shape has appoximatly the same
+        volume as the orignal shape (with circles)"""
+
+        original_volume = self.test_shape_2.volume
+        self.test_shape_2.convert_all_circle_connections_to_splines()
+        new_volume = self.test_shape_2.volume
+
+        assert pytest.approx(new_volume, rel=0.000001) == original_volume
+
+        original_volume = self.test_shape_3.volume
+        self.test_shape_3.convert_all_circle_connections_to_splines()
+        new_volume = self.test_shape_3.volume
+
+        assert pytest.approx(new_volume, rel=0.000001) == original_volume
 
 
 if __name__ == "__main__":

--- a/tests/test_parametric_shapes/test_RotateMixedShape.py
+++ b/tests/test_parametric_shapes/test_RotateMixedShape.py
@@ -15,6 +15,32 @@ class TestRotateMixedShape(unittest.TestCase):
                     (70, 50, "circle"), (60, 25, "circle"), (70, 0, "straight")]
         )
 
+        self.test_shape_2 = RotateMixedShape(
+            rotation_angle=1,
+            points=[
+                (100, 0, "straight"),
+                (200, 0, "circle"),
+                (250, 50, "circle"),
+                (200, 100, "straight"),
+                (150, 100, "straight"),
+                (140, 75, "straight"),
+                (110, 45, "straight"),
+            ]
+        )
+
+        self.test_shape_3 = RotateMixedShape(
+            rotation_angle=180,
+            points=[
+                (100, 0, "straight"),
+                (200, 0, "circle"),
+                (250, 50, "circle"),
+                (200, 100, "straight"),
+                (150, 100, "straight"),
+                (140, 75, "circle"),
+                (110, 45, "circle"),
+            ]
+        )
+
     def test_export_2d_image(self):
         """Creates a RotateMixedShape object and checks that a png file of the
         object with the correct suffix can be exported using the
@@ -125,7 +151,7 @@ class TestRotateMixedShape(unittest.TestCase):
             """Checks ValueError is raised when an incorrect number of
             connections is specified."""
 
-            test_shape = RotateMixedShape(
+            RotateMixedShape(
                 points=[(0, 200, "straight"), (200, 100), (0, 0, "spline")]
             )
 
@@ -214,6 +240,40 @@ class TestRotateMixedShape(unittest.TestCase):
             Path("test_solid2.stp").stat().st_size
 
         os.system("rm test_solid.stp test_solid2.stp test_wire.stp")
+
+    def test_convert_all_circle_points_change_to_splines(self):
+        """creates a RotateMixedShape with two circular edges and converts
+        them to spline edges. Checks the new edges have been correctly
+        replaced with splines"""
+
+        assert len(self.test_shape_3.points) == 8
+        self.test_shape_3.convert_all_circle_connections_to_splines()
+        assert len(self.test_shape_3.points) > 8
+        assert self.test_shape_3.points[0] == (100, 0, "straight")
+        assert self.test_shape_3.points[1][2] == 'spline'
+        assert self.test_shape_3.points[2][2] == 'spline'
+
+        # last point is the same as the first point
+        assert self.test_shape_3.points[-1] == (100, 0, "straight")
+        assert self.test_shape_3.points[-2][2] == 'spline'
+        assert self.test_shape_3.points[-3][2] == 'spline'
+
+    def test_convert_circles_to_splines_volume(self):
+        """creates a RotateMixedShape with a circular edge and converts the
+        edge to a spline edges. Checks the new shape has appoximatly the same
+        volume as the orignal shape (with circles)"""
+
+        original_volume = self.test_shape_2.volume
+        self.test_shape_2.convert_all_circle_connections_to_splines()
+        new_volume = self.test_shape_2.volume
+
+        assert pytest.approx(new_volume, rel=0.000001) == original_volume
+
+        original_volume = self.test_shape_3.volume
+        self.test_shape_3.convert_all_circle_connections_to_splines()
+        new_volume = self.test_shape_3.volume
+
+        assert pytest.approx(new_volume, rel=0.00001) == original_volume
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,33 @@ import plotly.graph_objects as go
 
 class TestUtilityFunctions(unittest.TestCase):
 
+    def test_convert_circle_to_spline(self):
+        """Tests the conversion of 3 points on a circle into points on a spline
+        curve."""
+
+        new_points = paramak.utils.convert_circle_to_spline(
+            p0=(200, 0),
+            p1=(250, 50),
+            p2=(200, 100),
+            tolerance=0.2
+        )
+
+        connections = [connection[2] for connection in new_points]
+
+        assert len(set(connections)) == 1
+        assert connections[0] == 'spline'
+
+        new_points = paramak.utils.convert_circle_to_spline(
+            p0=(200, 0),
+            p1=(250, 50),
+            p2=(200, 100),
+            tolerance=0.1
+        )
+
+        connections_lower_tol = [connection[2] for connection in new_points]
+
+        assert len(connections_lower_tol) > len(connections)
+
     def test_extract_points_from_edges(self):
         """Extracts points from edges and checks the list returned is the
         correct len and contains the correct types"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,9 +18,9 @@ class TestUtilityFunctions(unittest.TestCase):
         curve."""
 
         new_points = paramak.utils.convert_circle_to_spline(
-            p0=(200., 0.),
-            p1=(250., 50.),
-            p2=(200., 100.),
+            p_0=(200., 0.),
+            p_1=(250., 50.),
+            p_2=(200., 100.),
             tolerance=0.2
         )
 
@@ -31,9 +31,9 @@ class TestUtilityFunctions(unittest.TestCase):
         assert pytest.approx(new_points[-1][1], abs=0.0000000000001) == 100
 
         new_points_more_details = paramak.utils.convert_circle_to_spline(
-            p0=(200, 0),
-            p1=(250, 50),
-            p2=(200, 100),
+            p_0=(200, 0),
+            p_1=(250, 50),
+            p_2=(200, 100),
             tolerance=0.1
         )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,6 +25,10 @@ class TestUtilityFunctions(unittest.TestCase):
 
         connections = [connection[2] for connection in new_points]
 
+        assert new_points[0][0] == 200
+        assert new_points[0][1] == 0
+        assert new_points[-1][0] == 200
+        assert new_points[-1][1] == 100
         assert len(set(connections)) == 1
         assert connections[0] == 'spline'
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,14 @@
 
 import unittest
-from cadquery.cq import Workplane
 
 import numpy as np
 import paramak
-from paramak.utils import (EdgeLengthSelector, FaceAreaSelector,
-                           find_center_point_of_circle, plotly_trace,
-                           extract_points_from_edges, facet_wire)
 import plotly.graph_objects as go
+import pytest
+from cadquery.cq import Workplane
+from paramak.utils import (EdgeLengthSelector, FaceAreaSelector,
+                           extract_points_from_edges, facet_wire,
+                           find_center_point_of_circle, plotly_trace)
 
 
 class TestUtilityFunctions(unittest.TestCase):
@@ -17,31 +18,26 @@ class TestUtilityFunctions(unittest.TestCase):
         curve."""
 
         new_points = paramak.utils.convert_circle_to_spline(
-            p0=(200, 0),
-            p1=(250, 50),
-            p2=(200, 100),
+            p0=(200., 0.),
+            p1=(250., 50.),
+            p2=(200., 100.),
             tolerance=0.2
         )
 
-        connections = [connection[2] for connection in new_points]
+        # these points can change from 200. to values like 200.00000000000009
+        assert pytest.approx(new_points[0][0], abs=0.0000000000001) == 200
+        assert pytest.approx(new_points[0][1], abs=0.0000000000001) == 0
+        assert pytest.approx(new_points[-1][0], abs=0.0000000000001) == 200
+        assert pytest.approx(new_points[-1][1], abs=0.0000000000001) == 100
 
-        assert new_points[0][0] == 200
-        assert new_points[0][1] == 0
-        assert new_points[-1][0] == 200
-        assert new_points[-1][1] == 100
-        assert len(set(connections)) == 1
-        assert connections[0] == 'spline'
-
-        new_points = paramak.utils.convert_circle_to_spline(
+        new_points_more_details = paramak.utils.convert_circle_to_spline(
             p0=(200, 0),
             p1=(250, 50),
             p2=(200, 100),
             tolerance=0.1
         )
 
-        connections_lower_tol = [connection[2] for connection in new_points]
-
-        assert len(connections_lower_tol) > len(connections)
+        assert len(new_points_more_details) > len(new_points)
 
     def test_extract_points_from_edges(self):
         """Extracts points from edges and checks the list returned is the


### PR DESCRIPTION
## Proposed changes

as described in issue #737 circle edges can cause problems when importing the stp files into trelis.

This PR provides the user with a method of replacing the circles with spines of specified tolerance.

TODO

- [x] adding tests
- [x] adding docstrings
- [x] perhaps move from shape.py to mixed shapes or utils


## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [x] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
