### PR TITLE
added new method of performing ordered boolean operations

### DIFF
--- a/paramak/parametric_components/blanket_poloidal_segment.py
+++ b/paramak/parametric_components/blanket_poloidal_segment.py
@@ -129,7 +129,7 @@ class BlanketFPPoloidalSegments(BlanketFP):
             cutting_shape = RotateStraightShape(
                 rotation_angle=self.rotation_angle,
                 azimuth_placement_angle=self.azimuth_placement_angle,
-                union=[])
+                boolean_operations={"union"=[]})
             # add points to the shape to avoid void solid
             cutting_shape.points = [
                 (self.major_radius,
@@ -188,7 +188,7 @@ class BlanketFPPoloidalSegments(BlanketFP):
                         angle=np.pi / 2)]
                 cutter.points = points_cutter
                 # add cutter to global cutting shape
-                cutting_shape.union.append(cutter)
+                cutting_shape.boolean_operations["cut"].append(cutter)
 
             self.segments_cutters = cutting_shape
 

--- a/paramak/parametric_components/blanket_poloidal_segment.py
+++ b/paramak/parametric_components/blanket_poloidal_segment.py
@@ -129,7 +129,7 @@ class BlanketFPPoloidalSegments(BlanketFP):
             cutting_shape = RotateStraightShape(
                 rotation_angle=self.rotation_angle,
                 azimuth_placement_angle=self.azimuth_placement_angle,
-                boolean_operations={"union": []})
+                boolean_operations={"cut": []})
             # add points to the shape to avoid void solid
             cutting_shape.points = [
                 (self.major_radius,
@@ -188,7 +188,7 @@ class BlanketFPPoloidalSegments(BlanketFP):
                         angle=np.pi / 2)]
                 cutter.points = points_cutter
                 # add cutter to global cutting shape
-                cutting_shape.boolean_operations["cut"].append(cutter)
+                cutting_shape.boolean_operations["union"].append(cutter)
 
             self.segments_cutters = cutting_shape
 

--- a/paramak/parametric_components/blanket_poloidal_segment.py
+++ b/paramak/parametric_components/blanket_poloidal_segment.py
@@ -129,7 +129,7 @@ class BlanketFPPoloidalSegments(BlanketFP):
             cutting_shape = RotateStraightShape(
                 rotation_angle=self.rotation_angle,
                 azimuth_placement_angle=self.azimuth_placement_angle,
-                boolean_operations={"union"=[]})
+                boolean_operations={"union": []})
             # add points to the shape to avoid void solid
             cutting_shape.points = [
                 (self.major_radius,

--- a/paramak/parametric_components/blanket_poloidal_segment.py
+++ b/paramak/parametric_components/blanket_poloidal_segment.py
@@ -129,7 +129,7 @@ class BlanketFPPoloidalSegments(BlanketFP):
             cutting_shape = RotateStraightShape(
                 rotation_angle=self.rotation_angle,
                 azimuth_placement_angle=self.azimuth_placement_angle,
-                boolean_operations={"cut": []})
+                boolean_operations={"union": []})
             # add points to the shape to avoid void solid
             cutting_shape.points = [
                 (self.major_radius,

--- a/paramak/parametric_components/inboard_firstwall_fccs.py
+++ b/paramak/parametric_components/inboard_firstwall_fccs.py
@@ -159,10 +159,10 @@ class InboardFirstwallFCCS(RotateMixedShape):
                 self.boolean_operations["cut"] = self.central_column_shield
             else:
                 if isinstance(self.boolean_operations["cut"], Iterable):
-                    self.boolean_operations["cut"] = [*self.boolean_operations["cut"], self.central_column_shield]
+                    self.boolean_operations["cut"] = [
+                        *self.boolean_operations["cut"], self.central_column_shield]
                 else:
-                    self.boolean_operations["cut"] [*[self.boolean_operations["cut"]], self.central_column_shield]
-            
+                    self.boolean_operations["cut"][*[self.boolean_operations["cut"]], self.central_column_shield]
 
         # add to cut attribute
         # if self.cut is None:

--- a/paramak/parametric_components/inboard_firstwall_fccs.py
+++ b/paramak/parametric_components/inboard_firstwall_fccs.py
@@ -156,11 +156,10 @@ class InboardFirstwallFCCS(RotateMixedShape):
             self.boolean_operations = {"cut": self.central_column_shield}
         elif "cut" not in self.boolean_operations:
             self.boolean_operations["cut"] = self.central_column_shield
+        elif isinstance(self.boolean_operations["cut"], Iterable):
+            self.boolean_operations["cut"] = [*self.boolean_operations["cut"], self.central_column_shield]
         else:
-            if isinstance(self.boolean_operations["cut"], Iterable):
-                self.boolean_operations["cut"] = [*self.boolean_operations["cut"], self.central_column_shield]
-            else:
-                self.boolean_operations["cut"] = [*[self.boolean_operations["cut"]], self.central_column_shield]
+            self.boolean_operations["cut"] = [*[self.boolean_operations["cut"]], self.central_column_shield]
 
 
         # add to cut attribute

--- a/paramak/parametric_components/inboard_firstwall_fccs.py
+++ b/paramak/parametric_components/inboard_firstwall_fccs.py
@@ -152,10 +152,22 @@ class InboardFirstwallFCCS(RotateMixedShape):
         points = firstwall.points[:-1]  # remove last point
         self.points = points
 
-        # add to cut attribute
-        if self.cut is None:
-            self.cut = self.central_column_shield
-        elif isinstance(self.cut, Iterable):
-            self.cut = [*self.cut, self.central_column_shield]
+        if self.boolean_operations is None:
+            self.boolean_operations = {"cut": self.central_column_shield}
         else:
-            self.cut = [*[self.cut], self.central_column_shield]
+            if "cut" not in self.boolean_operations:
+                self.boolean_operations["cut"] = self.central_column_shield
+            else:
+                if isinstance(self.boolean_operations["cut"], Iterable):
+                    self.boolean_operations["cut"] = [*self.boolean_operations["cut"], self.central_column_shield]
+                else:
+                    self.boolean_operations["cut"] [*[self.boolean_operations["cut"]], self.central_column_shield]
+            
+
+        # add to cut attribute
+        # if self.cut is None:
+        #     self.cut = self.central_column_shield
+        # elif isinstance(self.cut, Iterable):
+        #     self.cut = [*self.cut, self.central_column_shield]
+        # else:
+        #     self.cut = [*[self.cut], self.central_column_shield]

--- a/paramak/parametric_components/inboard_firstwall_fccs.py
+++ b/paramak/parametric_components/inboard_firstwall_fccs.py
@@ -158,10 +158,11 @@ class InboardFirstwallFCCS(RotateMixedShape):
             self.boolean_operations["cut"] = self.central_column_shield
         else:
             if isinstance(self.boolean_operations["cut"], Iterable):
-                self.boolean_operations["cut"] = [*self.boolean_operations["cut"], self.central_column_shield]
+                self.boolean_operations["cut"] = [
+                    *self.boolean_operations["cut"], self.central_column_shield]
             else:
-                self.boolean_operations["cut"] = [*[self.boolean_operations["cut"]], self.central_column_shield]
-
+                self.boolean_operations["cut"] = [
+                    *[self.boolean_operations["cut"]], self.central_column_shield]
 
         # add to cut attribute
         # if self.cut is None:

--- a/paramak/parametric_components/inboard_firstwall_fccs.py
+++ b/paramak/parametric_components/inboard_firstwall_fccs.py
@@ -154,14 +154,13 @@ class InboardFirstwallFCCS(RotateMixedShape):
 
         if self.boolean_operations is None:
             self.boolean_operations = {"cut": self.central_column_shield}
+        elif "cut" not in self.boolean_operations:
+            self.boolean_operations["cut"] = self.central_column_shield
         else:
-            if "cut" not in self.boolean_operations:
-                self.boolean_operations["cut"] = self.central_column_shield
+            if isinstance(self.boolean_operations["cut"], Iterable):
+                self.boolean_operations["cut"] = [*self.boolean_operations["cut"], self.central_column_shield]
             else:
-                if isinstance(self.boolean_operations["cut"], Iterable):
-                    self.boolean_operations["cut"] = [*self.boolean_operations["cut"], self.central_column_shield]
-                else:
-                    self.boolean_operations["cut"] [*[self.boolean_operations["cut"]], self.central_column_shield]
+                self.boolean_operations["cut"] = [*[self.boolean_operations["cut"]], self.central_column_shield]
             
 
         # add to cut attribute

--- a/paramak/parametric_components/inboard_firstwall_fccs.py
+++ b/paramak/parametric_components/inboard_firstwall_fccs.py
@@ -157,9 +157,12 @@ class InboardFirstwallFCCS(RotateMixedShape):
         elif "cut" not in self.boolean_operations:
             self.boolean_operations["cut"] = self.central_column_shield
         elif isinstance(self.boolean_operations["cut"], Iterable):
-            self.boolean_operations["cut"] = [*self.boolean_operations["cut"], self.central_column_shield]
+            self.boolean_operations["cut"] = [
+                *self.boolean_operations["cut"],
+                self.central_column_shield]
         else:
-            self.boolean_operations["cut"] = [*[self.boolean_operations["cut"]], self.central_column_shield]
+            self.boolean_operations["cut"] = [
+                *[self.boolean_operations["cut"]], self.central_column_shield]
 
         # add to cut attribute
         # if self.cut is None:

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -406,7 +406,7 @@ class BallReactor(paramak.Reactor):
             material_tag="blanket_mat",
             stp_filename="blanket.stp",
             stl_filename="blanket.stl",
-            boolean_operations={"cut": [self_center_column_cutter]}
+            boolean_operations={"cut": [self._center_column_cutter]}
         )
 
         self._blanket_rear_wall = paramak.BlanketFP(
@@ -421,7 +421,7 @@ class BallReactor(paramak.Reactor):
             material_tag="blanket_rear_wall_mat",
             stp_filename="blanket_rear_wall.stp",
             stl_filename="blanket_rear_wall.stl",
-            boolean_operations={"cut": [self_center_column_cutter]}
+            boolean_operations={"cut": [self._center_column_cutter]}
         )
 
         return [self._firstwall, self._blanket, self._blanket_rear_wall]
@@ -455,7 +455,7 @@ class BallReactor(paramak.Reactor):
                 (self._divertor_end_radius, divertor_height_top),
                 (self._divertor_start_radius, divertor_height_top)
             ],
-            intersect=self._blanket_fw_rear_wall_envelope,
+            boolean_operations={"intersect": self._blanket_fw_rear_wall_envelope},
             stp_filename="divertor.stp",
             stl_filename="divertor.stl",
             name="divertor",

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -392,7 +392,7 @@ class BallReactor(paramak.Reactor):
             material_tag="firstwall_mat",
             stp_filename="firstwall.stp",
             stl_filename="firstwall.stl",
-            cut=[self._center_column_cutter]
+            boolean_operations={"cut": [self._center_column_cutter]}
         )
 
         self._blanket = paramak.BlanketFP(
@@ -406,7 +406,7 @@ class BallReactor(paramak.Reactor):
             material_tag="blanket_mat",
             stp_filename="blanket.stp",
             stl_filename="blanket.stl",
-            cut=[self._center_column_cutter])
+            boolean_operations={"cut": [self_center_column_cutter]}
 
         self._blanket_rear_wall = paramak.BlanketFP(
             plasma=self._plasma,
@@ -420,7 +420,7 @@ class BallReactor(paramak.Reactor):
             material_tag="blanket_rear_wall_mat",
             stp_filename="blanket_rear_wall.stp",
             stl_filename="blanket_rear_wall.stl",
-            cut=[self._center_column_cutter],
+            boolean_operations={"cut": [self_center_column_cutter]}
         )
 
         return [self._firstwall, self._blanket, self._blanket_rear_wall]
@@ -466,7 +466,7 @@ class BallReactor(paramak.Reactor):
                 self._firstwall,
                 self._blanket,
                 self._blanket_rear_wall]:
-            component.cut.append(self._divertor)
+            component.boolean_operations["cut"].append(self._divertor)
 
         return self._divertor
 

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -409,7 +409,7 @@ class BallReactor(paramak.Reactor):
             boolean_operations={"cut": [self_center_column_cutter]}
         )
 
-        self._blanket_rear_wall=paramak.BlanketFP(
+        self._blanket_rear_wall = paramak.BlanketFP(
             plasma=self._plasma,
             thickness=self.blanket_rear_wall_radial_thickness,
             offset_from_plasma=[e + self.firstwall_radial_thickness
@@ -428,7 +428,7 @@ class BallReactor(paramak.Reactor):
 
     def _make_divertor(self):
         # # used as an intersect when making the divertor
-        self._blanket_fw_rear_wall_envelope=paramak.BlanketFP(
+        self._blanket_fw_rear_wall_envelope = paramak.BlanketFP(
             plasma=self._plasma,
             thickness=self.firstwall_radial_thickness +
             self.blanket_radial_thickness +
@@ -439,16 +439,16 @@ class BallReactor(paramak.Reactor):
             rotation_angle=self.rotation_angle,
         )
 
-        divertor_height=self._blanket_rear_wall_end_height * 2
+        divertor_height = self._blanket_rear_wall_end_height * 2
 
-        divertor_height_top=divertor_height
-        divertor_height_bottom=-divertor_height
+        divertor_height_top = divertor_height
+        divertor_height_bottom = -divertor_height
 
         if self.divertor_position == "lower":
-            divertor_height_top=0
+            divertor_height_top = 0
         elif self.divertor_position == "upper":
-            divertor_height_bottom=0
-        self._divertor=paramak.RotateStraightShape(
+            divertor_height_bottom = 0
+        self._divertor = paramak.RotateStraightShape(
             points=[
                 (self._divertor_start_radius, divertor_height_bottom),
                 (self._divertor_end_radius, divertor_height_bottom),
@@ -472,12 +472,12 @@ class BallReactor(paramak.Reactor):
         return self._divertor
 
     def _make_pf_coils(self):
-        list_of_components=[]
+        list_of_components = []
         if (self.pf_coil_vertical_thicknesses,
                 self.pf_coil_radial_thicknesses,
                 self.pf_coil_to_rear_blanket_radial_gap) != (None, None, None):
 
-            self._pf_coil=paramak.PoloidalFieldCoilSet(
+            self._pf_coil = paramak.PoloidalFieldCoilSet(
                 heights=self.pf_coil_vertical_thicknesses,
                 widths=self.pf_coil_radial_thicknesses,
                 center_points=self._pf_coils_xy_values,
@@ -488,7 +488,7 @@ class BallReactor(paramak.Reactor):
                 material_tag="pf_coil_mat",
             )
 
-            self._pf_coils_casing=paramak.PoloidalFieldCoilCaseSetFC(
+            self._pf_coils_casing = paramak.PoloidalFieldCoilCaseSetFC(
                 pf_coils=self._pf_coil,
                 casing_thicknesses=self.pf_coil_case_thickness,
                 rotation_angle=self.rotation_angle,
@@ -498,15 +498,15 @@ class BallReactor(paramak.Reactor):
                 material_tag="pf_coil_case_mat",
             )
 
-            list_of_components=[self._pf_coils_casing, self._pf_coil]
+            list_of_components = [self._pf_coils_casing, self._pf_coil]
         return list_of_components
 
     def _make_tf_coils(self):
-        comp=[]
+        comp = []
         if (self.pf_coil_to_tf_coil_radial_gap,
                 self.outboard_tf_coil_radial_thickness) != (None, None):
 
-            self._tf_coil=paramak.ToroidalFieldCoilRectangle(
+            self._tf_coil = paramak.ToroidalFieldCoilRectangle(
                 with_inner_leg=False,
                 horizontal_start_point=(
                     self._inboard_tf_coils_start_radius,
@@ -522,5 +522,5 @@ class BallReactor(paramak.Reactor):
                 stl_filename="tf_coil.stl",
                 rotation_angle=self.rotation_angle
             )
-            comp=[self._tf_coil]
+            comp = [self._tf_coil]
         return comp

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -408,7 +408,7 @@ class BallReactor(paramak.Reactor):
             stl_filename="blanket.stl",
             boolean_operations={"cut": [self_center_column_cutter]}
 
-        self._blanket_rear_wall = paramak.BlanketFP(
+        self._blanket_rear_wall=paramak.BlanketFP(
             plasma=self._plasma,
             thickness=self.blanket_rear_wall_radial_thickness,
             offset_from_plasma=[e + self.firstwall_radial_thickness
@@ -427,7 +427,7 @@ class BallReactor(paramak.Reactor):
 
     def _make_divertor(self):
         # # used as an intersect when making the divertor
-        self._blanket_fw_rear_wall_envelope = paramak.BlanketFP(
+        self._blanket_fw_rear_wall_envelope=paramak.BlanketFP(
             plasma=self._plasma,
             thickness=self.firstwall_radial_thickness +
             self.blanket_radial_thickness +
@@ -438,16 +438,16 @@ class BallReactor(paramak.Reactor):
             rotation_angle=self.rotation_angle,
         )
 
-        divertor_height = self._blanket_rear_wall_end_height * 2
+        divertor_height=self._blanket_rear_wall_end_height * 2
 
-        divertor_height_top = divertor_height
-        divertor_height_bottom = -divertor_height
+        divertor_height_top=divertor_height
+        divertor_height_bottom=-divertor_height
 
         if self.divertor_position == "lower":
-            divertor_height_top = 0
+            divertor_height_top=0
         elif self.divertor_position == "upper":
-            divertor_height_bottom = 0
-        self._divertor = paramak.RotateStraightShape(
+            divertor_height_bottom=0
+        self._divertor=paramak.RotateStraightShape(
             points=[
                 (self._divertor_start_radius, divertor_height_bottom),
                 (self._divertor_end_radius, divertor_height_bottom),
@@ -471,12 +471,12 @@ class BallReactor(paramak.Reactor):
         return self._divertor
 
     def _make_pf_coils(self):
-        list_of_components = []
+        list_of_components=[]
         if (self.pf_coil_vertical_thicknesses,
                 self.pf_coil_radial_thicknesses,
                 self.pf_coil_to_rear_blanket_radial_gap) != (None, None, None):
 
-            self._pf_coil = paramak.PoloidalFieldCoilSet(
+            self._pf_coil=paramak.PoloidalFieldCoilSet(
                 heights=self.pf_coil_vertical_thicknesses,
                 widths=self.pf_coil_radial_thicknesses,
                 center_points=self._pf_coils_xy_values,
@@ -487,7 +487,7 @@ class BallReactor(paramak.Reactor):
                 material_tag="pf_coil_mat",
             )
 
-            self._pf_coils_casing = paramak.PoloidalFieldCoilCaseSetFC(
+            self._pf_coils_casing=paramak.PoloidalFieldCoilCaseSetFC(
                 pf_coils=self._pf_coil,
                 casing_thicknesses=self.pf_coil_case_thickness,
                 rotation_angle=self.rotation_angle,
@@ -497,15 +497,15 @@ class BallReactor(paramak.Reactor):
                 material_tag="pf_coil_case_mat",
             )
 
-            list_of_components = [self._pf_coils_casing, self._pf_coil]
+            list_of_components=[self._pf_coils_casing, self._pf_coil]
         return list_of_components
 
     def _make_tf_coils(self):
-        comp = []
+        comp=[]
         if (self.pf_coil_to_tf_coil_radial_gap,
                 self.outboard_tf_coil_radial_thickness) != (None, None):
 
-            self._tf_coil = paramak.ToroidalFieldCoilRectangle(
+            self._tf_coil=paramak.ToroidalFieldCoilRectangle(
                 with_inner_leg=False,
                 horizontal_start_point=(
                     self._inboard_tf_coils_start_radius,
@@ -521,5 +521,5 @@ class BallReactor(paramak.Reactor):
                 stl_filename="tf_coil.stl",
                 rotation_angle=self.rotation_angle
             )
-            comp = [self._tf_coil]
+            comp=[self._tf_coil]
         return comp

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -407,6 +407,7 @@ class BallReactor(paramak.Reactor):
             stp_filename="blanket.stp",
             stl_filename="blanket.stl",
             boolean_operations={"cut": [self_center_column_cutter]}
+        )
 
         self._blanket_rear_wall = paramak.BlanketFP(
             plasma=self._plasma,

--- a/paramak/parametric_reactors/center_column_study_reactor.py
+++ b/paramak/parametric_reactors/center_column_study_reactor.py
@@ -268,12 +268,12 @@ class CenterColumnStudyReactor(paramak.Reactor):
             start_angle=-180,
             stop_angle=180,
             rotation_angle=self.rotation_angle,
-            cut=[self._center_column_cutter]
+            boolean_operations={"cut": [self._center_column_cutter]}
         )
         return self._blanket
 
     def _make_divertor(self):
-        self._blanket_enveloppe = paramak.BlanketFP(
+        self._blanket_envelope = paramak.BlanketFP(
             plasma=self._plasma,
             thickness=100.,
             offset_from_plasma=[
@@ -285,7 +285,7 @@ class CenterColumnStudyReactor(paramak.Reactor):
             start_angle=-180,
             stop_angle=180,
             rotation_angle=self.rotation_angle,
-            cut=[self._center_column_cutter]
+            boolean_operations={"cut": [self._center_column_cutter]}
         )
 
         self._divertor = paramak.CenterColumnShieldCylinder(
@@ -298,7 +298,7 @@ class CenterColumnStudyReactor(paramak.Reactor):
             stl_filename="divertor.stl",
             name="divertor",
             material_tag="divertor_mat",
-            intersect=self._blanket_enveloppe,
+            boolean_operations={"intersect": self._blanket_envelope}
         )
-        self._blanket.cut.append(self._divertor)
+        self._blanket.boolean_operations["cut"].append(self._divertor)
         return self._divertor

--- a/paramak/parametric_reactors/eu_demo_2015_reactor.py
+++ b/paramak/parametric_reactors/eu_demo_2015_reactor.py
@@ -83,7 +83,7 @@ class EuDemoFrom2015PaperDiagram(paramak.Reactor):
                 (375.4508992805756, 755, "straight"),
             ],
             distance=200,
-            cut=[vac_vessel_inner, vac_vessel],
+            boolean_operations={"cut": [vac_vessel_inner, vac_vessel]},
             # azimuth placement angle can't start at
             # zero nor end at 360 until #757 is solved
             azimuth_placement_angle=np.linspace(
@@ -220,7 +220,7 @@ class EuDemoFrom2015PaperDiagram(paramak.Reactor):
             ],
             rotation_angle=self.rotation_angle,
             # avoid overlap between VV and blanket divertor
-            union=[blanket, divertor]
+            boolean_operations={"union": [blanket, divertor]}
         )
         vac_vessel = paramak.RotateSplineShape(
             points=[
@@ -276,7 +276,7 @@ class EuDemoFrom2015PaperDiagram(paramak.Reactor):
                 (516.7486775621876, -175.64585325476332),
                 (516.7486775621876, -107.40944903301386),
             ],
-            cut=vac_vessel_inner,  # hollow shape
+            boolean_operations={"cut": vac_vessel_inner},
             rotation_angle=self.rotation_angle,
             stp_filename='vacvessel.stp',
             stl_filename='vacvessel.stl',

--- a/paramak/parametric_reactors/segmented_blanket_ball_reactor.py
+++ b/paramak/parametric_reactors/segmented_blanket_ball_reactor.py
@@ -76,7 +76,7 @@ class SegmentedBlanketBallReactor(paramak.BallReactor):
             2 * self.firstwall_radial_thickness,
             azimuth_placement_angle=azimuth_placement_angles)
 
-        self._blanket.cut = [self._center_column_cutter, thick_cutter]
+        self._blanket.boolean_operations = {"cut": [self._center_column_cutter, thick_cutter]}
 
         if self.blanket_fillet_radius != 0:
             # tried firstwall start radius here already
@@ -90,10 +90,10 @@ class SegmentedBlanketBallReactor(paramak.BallReactor):
                 paramak.EdgeLengthSelector(front_edge_length_b)).fillet(
                 self.blanket_fillet_radius)
         self._firstwall.thickness += self.blanket_radial_thickness
-        self._firstwall.cut = [
+        self._firstwall.boolean_operations = {"cut": [
             self._center_column_cutter,
             thin_cutter,
-            self._blanket]
+            self._blanket]}
 
         # TODO this segfaults at the moment but works as an opperation on the
         # reactor after construction in jupyter

--- a/paramak/parametric_reactors/segmented_blanket_ball_reactor.py
+++ b/paramak/parametric_reactors/segmented_blanket_ball_reactor.py
@@ -76,7 +76,8 @@ class SegmentedBlanketBallReactor(paramak.BallReactor):
             2 * self.firstwall_radial_thickness,
             azimuth_placement_angle=azimuth_placement_angles)
 
-        self._blanket.boolean_operations = {"cut": [self._center_column_cutter, thick_cutter]}
+        self._blanket.boolean_operations = {
+            "cut": [self._center_column_cutter, thick_cutter]}
 
         if self.blanket_fillet_radius != 0:
             # tried firstwall start radius here already

--- a/paramak/parametric_reactors/sparc_paper_2020.py
+++ b/paramak/parametric_reactors/sparc_paper_2020.py
@@ -294,7 +294,7 @@ class SparcFrom2020PaperDiagram(paramak.Reactor):
             ],
             rotation_angle=self.rotation_angle,
             stp_filename='inner_vessel.stp',
-            cut=[vac_vessel, vs_coils, antenna]
+            boolean_operations={"cut": [vac_vessel, vs_coils, antenna]}
         )
 
         return [antenna, vac_vessel, inner_vessel]

--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -496,8 +496,7 @@ class SubmersionTokamak(paramak.Reactor):
             material_tag="divertor_mat"
         )
 
-        self._firstwall.boolean_operations = {"union": self._inboard_firstwall,
-                                              "cut": self._divertor}
+        self._firstwall.boolean_operations["cut"] = self._divertor
         self._inboard_firstwall.boolean_operations = {"cut": self._divertor}
         return self._divertor
 
@@ -568,8 +567,7 @@ class SubmersionTokamak(paramak.Reactor):
             material_tag="supports_mat",
             boolean_operations={"intersect": blanket_enveloppe}
         )
-        self._blanket.boolean_operations = {"union": self._inboard_blanket,
-                                            "cut": self._supports}
+        self._blanket.boolean_operations["cut"] = self._supports
 
         return self._supports
 

--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -568,8 +568,8 @@ class SubmersionTokamak(paramak.Reactor):
             material_tag="supports_mat",
             boolean_operations={"intersect": blanket_enveloppe}
         )
-        self._blanket.boolean_operations={"union": self._inboard_blanket,
-                                          "cut": self._supports}
+        self._blanket.boolean_operations = {"union": self._inboard_blanket,
+                                            "cut": self._supports}
 
         return self._supports
 
@@ -632,7 +632,7 @@ class SubmersionTokamak(paramak.Reactor):
             name="outboard_rear_blanket_wall",
             material_tag="blanket_rear_wall_mat",
             boolean_operations={"union": [
-                self._outboard_rear_blanket_wall_upper, 
+                self._outboard_rear_blanket_wall_upper,
                 self._outboard_rear_blanket_wall_lower
             ]},
         )

--- a/paramak/parametric_reactors/submersion_reactor.py
+++ b/paramak/parametric_reactors/submersion_reactor.py
@@ -444,7 +444,7 @@ class SubmersionTokamak(paramak.Reactor):
             stl_filename="outboard_firstwall.stl",
             name="outboard_firstwall",
             material_tag="firstwall_mat",
-            union=self._inboard_firstwall,
+            boolean_operations={"union": self._inboard_firstwall}
         )
         return self._firstwall
 
@@ -469,7 +469,7 @@ class SubmersionTokamak(paramak.Reactor):
             stl_filename="outboard_firstwall.stl",
             name="outboard_firstwall",
             material_tag="firstwall_mat",
-            union=fw_enveloppe_inboard,
+            boolean_operations={"union": fw_enveloppe_inboard}
         )
         divertor_height = self._blanket_rear_wall_end_height
 
@@ -488,7 +488,7 @@ class SubmersionTokamak(paramak.Reactor):
                 (self._divertor_end_radius, divertor_height_top),
                 (self._divertor_start_radius, divertor_height_top)
             ],
-            intersect=fw_enveloppe,
+            boolean_operations={"intersect": fw_enveloppe},
             rotation_angle=self.rotation_angle,
             stp_filename="divertor.stp",
             stl_filename="divertor.stl",
@@ -496,8 +496,9 @@ class SubmersionTokamak(paramak.Reactor):
             material_tag="divertor_mat"
         )
 
-        self._firstwall.cut = self._divertor
-        self._inboard_firstwall.cut = self._divertor
+        self._firstwall.boolean_operations = {"union": self._inboard_firstwall,
+                                              "cut": self._divertor}
+        self._inboard_firstwall.boolean_operations = {"cut": self._divertor}
         return self._divertor
 
     def _make_blanket(self):
@@ -506,7 +507,7 @@ class SubmersionTokamak(paramak.Reactor):
             inner_radius=self._inboard_blanket_start_radius,
             outer_radius=max(self._inboard_firstwall.points)[0],
             rotation_angle=self.rotation_angle,
-            cut=self._inboard_firstwall,
+            boolean_operations={"cut": self._inboard_firstwall}
         )
 
         # this takes a single solid from a compound of solids by finding the
@@ -529,7 +530,7 @@ class SubmersionTokamak(paramak.Reactor):
             stl_filename="blanket.stl",
             name="blanket",
             material_tag="blanket_mat",
-            union=self._inboard_blanket,
+            boolean_operations={"union": self._inboard_blanket}
         )
         return self._blanket
 
@@ -542,7 +543,7 @@ class SubmersionTokamak(paramak.Reactor):
             + self.firstwall_radial_thickness,
             thickness=self.outboard_blanket_radial_thickness,
             rotation_angle=self.rotation_angle,
-            union=self._inboard_blanket,
+            boolean_operations={"union": self._inboard_blanket}
         )
         support_height = self._blanket_rear_wall_end_height
         support_height_top = support_height
@@ -565,9 +566,10 @@ class SubmersionTokamak(paramak.Reactor):
             stl_filename="supports.stl",
             name="supports",
             material_tag="supports_mat",
-            intersect=blanket_enveloppe,
+            boolean_operations={"intersect": blanket_enveloppe}
         )
-        self._blanket.cut = self._supports
+        self._blanket.boolean_operations={"union": self._inboard_blanket,
+                                          "cut": self._supports}
 
         return self._supports
 
@@ -629,9 +631,10 @@ class SubmersionTokamak(paramak.Reactor):
             stl_filename="outboard_rear_blanket_wall.stl",
             name="outboard_rear_blanket_wall",
             material_tag="blanket_rear_wall_mat",
-            union=[
-                self._outboard_rear_blanket_wall_upper,
-                self._outboard_rear_blanket_wall_lower],
+            boolean_operations={"union": [
+                self._outboard_rear_blanket_wall_upper, 
+                self._outboard_rear_blanket_wall_lower
+            ]},
         )
 
         return self._outboard_rear_blanket_wall

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -1135,7 +1135,7 @@ class Shape:
         if 'wedge_cut' in kwargs:
             if kwargs['wedge_cut'] is not None:
                 solid = cut_solid(solid, kwargs['wedge_cut'])
-        
+
         return solid
 
     def make_graveyard(

--- a/tests/test_parametric_components/test_InboardFirstwallFCCS.py
+++ b/tests/test_parametric_components/test_InboardFirstwallFCCS.py
@@ -146,7 +146,7 @@ class TestInboardFirstwallFCCS(unittest.TestCase):
             thickness=20,
             rotation_angle=180,
             azimuth_placement_angle=180,
-            union=b)
+            boolean_operations={"union": b})
         assert np.isclose(c.volume, 2 * b.volume)
 
     def test_azimuth_placement_angle(self):
@@ -171,7 +171,7 @@ class TestInboardFirstwallFCCS(unittest.TestCase):
             thickness=20,
             rotation_angle=180,
             azimuth_placement_angle=90,
-            cut=b)
+            boolean_operations={"cut": b})
         assert np.isclose(c.volume, 0.5 * b.volume)
 
     def test_cut_attribute(self):

--- a/tests/test_parametric_components/test_PoloidallySegmentedBlanketFP.py
+++ b/tests/test_parametric_components/test_PoloidallySegmentedBlanketFP.py
@@ -61,7 +61,7 @@ class TestBlanketFP(unittest.TestCase):
         blanket2 = paramak.BlanketFPPoloidalSegments(
             thickness=20, start_angle=0,
             stop_angle=180, rotation_angle=180,
-            cut=blanket1)
+            boolean_operations={"cut": blanket1})
 
         blanket1.nb_segments_limits = (4, 8)
         blanket2.nb_segments_limits = (3, 8)
@@ -76,7 +76,7 @@ class TestBlanketFP(unittest.TestCase):
         blanket2 = paramak.BlanketFPPoloidalSegments(
             thickness=20, start_angle=0,
             stop_angle=180, rotation_angle=180,
-            cut=blanket1)
+            boolean_operations={"cut": blanket1})
 
         blanket1.num_segments = 8
         blanket2.num_segments = 5
@@ -97,7 +97,7 @@ class TestBlanketFP(unittest.TestCase):
         blanket2 = paramak.BlanketFPPoloidalSegments(
             thickness=20, start_angle=0,
             stop_angle=180, rotation_angle=180,
-            cut=blanket1)
+            boolean_operations={"cut": blanket1})
         blanket2.segments_angles = [0, 25, 50, 90, 130, 150, 180]
         assert blanket2.volume != 0
 

--- a/tests/test_parametric_components/test_PortCutterRectangular.py
+++ b/tests/test_parametric_components/test_PortCutterRectangular.py
@@ -64,7 +64,7 @@ class TestPortCutterRectangular(unittest.TestCase):
             points=[(0, 0), (0, 50), (500, 50), (500, 0)],
             workplane="YZ",
         )
-        self.test_shape.cut = cutting_shape
+        self.test_shape.boolean_operations = {"cut": cutting_shape}
 
         assert self.test_shape.volume == pytest.approx(20 * 40 * 300 * 0.5)
 

--- a/tests/test_parametric_components/test_PortCutterRotated.py
+++ b/tests/test_parametric_components/test_PortCutterRotated.py
@@ -37,14 +37,14 @@ class TestPortCutterRotated(unittest.TestCase):
             height=500,
             inner_radius=200,
             outer_radius=300,
-            cut=small_ports
+            boolean_operations={"cut": small_ports}
         )
 
         vessel_with_large_ports = paramak.CenterColumnShieldCylinder(
             height=500,
             inner_radius=200,
             outer_radius=300,
-            cut=large_ports
+            boolean_operations={"cut": large_ports}
         )
 
         assert large_ports.volume > small_ports.volume

--- a/tests/test_parametric_components/test_VacuumVessel.py
+++ b/tests/test_parametric_components/test_VacuumVessel.py
@@ -44,6 +44,6 @@ class TestVacuumVessel(unittest.TestCase):
 
         pre_cut_volume = self.test_shape.volume
 
-        self.test_shape.cut = [cutter1, cutter2, cutter3, cutter4, cutter5]
+        self.test_shape.boolean_operations = {"cut": [cutter1, cutter2, cutter3, cutter4, cutter5]}
         assert self.test_shape.solid is not None
         assert self.test_shape.volume < pre_cut_volume

--- a/tests/test_parametric_components/test_VacuumVessel.py
+++ b/tests/test_parametric_components/test_VacuumVessel.py
@@ -44,6 +44,7 @@ class TestVacuumVessel(unittest.TestCase):
 
         pre_cut_volume = self.test_shape.volume
 
-        self.test_shape.boolean_operations = {"cut": [cutter1, cutter2, cutter3, cutter4, cutter5]}
+        self.test_shape.boolean_operations = {
+            "cut": [cutter1, cutter2, cutter3, cutter4, cutter5]}
         assert self.test_shape.solid is not None
         assert self.test_shape.volume < pre_cut_volume

--- a/tests/test_parametric_shapes/test_ExtrudeCircleShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeCircleShape.py
@@ -55,7 +55,7 @@ class TestExtrudeCircleShape(unittest.TestCase):
 
         shape_with_cut = ExtrudeCircleShape(
             points=[(30, 0)], radius=20, distance=40,
-            cut=self.test_shape
+            boolean_operations={"cut": self.test_shape}
         )
 
         assert shape_with_cut.volume == pytest.approx(
@@ -71,7 +71,7 @@ class TestExtrudeCircleShape(unittest.TestCase):
 
         intersected_shape = ExtrudeCircleShape(
             points=[(30, 0)], radius=10, distance=50,
-            intersect=[self.test_shape, intersect_shape]
+            boolean_operations={"intersect": [self.test_shape, intersect_shape]}
         )
 
         assert intersected_shape.volume == pytest.approx(math.pi * 5**2 * 30)

--- a/tests/test_parametric_shapes/test_ExtrudeCircleShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeCircleShape.py
@@ -70,9 +70,10 @@ class TestExtrudeCircleShape(unittest.TestCase):
             points=[(30, 0)], radius=5, distance=50)
 
         intersected_shape = ExtrudeCircleShape(
-            points=[(30, 0)], radius=10, distance=50,
-            boolean_operations={"intersect": [self.test_shape, intersect_shape]}
-        )
+            points=[
+                (30, 0)], radius=10, distance=50, boolean_operations={
+                "intersect": [
+                    self.test_shape, intersect_shape]})
 
         assert intersected_shape.volume == pytest.approx(math.pi * 5**2 * 30)
 

--- a/tests/test_parametric_shapes/test_ExtrudeMixedShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeMixedShape.py
@@ -103,7 +103,7 @@ class TestExtrudeMixedShape(unittest.TestCase):
                 (12, 12, "spline"),
                 (12, 3, "spline"),
             ],
-            cut=inner_shape,
+            boolean_operations={"cut": inner_shape},
             distance=30,
         )
 

--- a/tests/test_parametric_shapes/test_ExtrudeSplineShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeSplineShape.py
@@ -59,7 +59,8 @@ class TestExtrudeSplineShape(unittest.TestCase):
         )
 
         outer_shape_with_cut = ExtrudeSplineShape(
-            points=[(3, 3), (3, 12), (12, 12), (12, 3)], cut=inner_shape,
+            points=[(3, 3), (3, 12), (12, 12), (12, 3)], 
+            boolean_operations={"cut": inner_shape},
             distance=30,
         )
 

--- a/tests/test_parametric_shapes/test_ExtrudeSplineShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeSplineShape.py
@@ -59,7 +59,7 @@ class TestExtrudeSplineShape(unittest.TestCase):
         )
 
         outer_shape_with_cut = ExtrudeSplineShape(
-            points=[(3, 3), (3, 12), (12, 12), (12, 3)], 
+            points=[(3, 3), (3, 12), (12, 12), (12, 3)],
             boolean_operations={"cut": inner_shape},
             distance=30,
         )

--- a/tests/test_parametric_shapes/test_ExtrudeStraightShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeStraightShape.py
@@ -53,7 +53,7 @@ class TestExtrudeStraightShape(unittest.TestCase):
 
         shape_with_cut = ExtrudeStraightShape(
             points=[(0, 0), (0, 40), (40, 40), (40, 0)], distance=40,
-            cut=self.test_shape
+            boolean_operations={"cut": self.test_shape}
         )
 
         assert shape_with_cut.volume == pytest.approx(
@@ -66,7 +66,7 @@ class TestExtrudeStraightShape(unittest.TestCase):
 
         unioned_shape = ExtrudeStraightShape(
             points=[(0, 10), (0, 30), (20, 30), (20, 10)], distance=30,
-            union=self.test_shape
+            boolean_operations={"union": self.test_shape}
         )
         assert unioned_shape.volume == pytest.approx(30 * 20 * 30)
 
@@ -76,7 +76,7 @@ class TestExtrudeStraightShape(unittest.TestCase):
 
         intersected_shape = ExtrudeStraightShape(
             points=[(0, 10), (0, 30), (20, 30), (20, 10)], distance=30,
-            intersect=self.test_shape
+            boolean_operations={"intersect": self.test_shape}
         )
         assert intersected_shape.volume == pytest.approx(10 * 20 * 30)
 

--- a/tests/test_parametric_shapes/test_RotateCircleShape.py
+++ b/tests/test_parametric_shapes/test_RotateCircleShape.py
@@ -78,7 +78,7 @@ class TestRotateCircleShape(unittest.TestCase):
             points=[(60, 0)], radius=15
         )
         outer_shape_volume = outer_shape.volume
-        outer_shape.cut = self.test_shape
+        outer_shape.boolean_operations = {"cut": self.test_shape}
         assert outer_shape.volume == pytest.approx(
             outer_shape_volume - self.test_shape.volume
         )

--- a/tests/test_parametric_shapes/test_RotateMixedShape.py
+++ b/tests/test_parametric_shapes/test_RotateMixedShape.py
@@ -121,7 +121,7 @@ class TestRotateMixedShape(unittest.TestCase):
                 (500, 200, "straight"),
                 (500, 100, "straight"),
             ],
-            union=inner_box,
+            boolean_operations={"union": inner_box}
         )
 
         assert inner_box.volume + outer_box.volume == pytest.approx(
@@ -173,7 +173,7 @@ class TestRotateMixedShape(unittest.TestCase):
             ]
         )
         outer_shape_volume = outer_shape.volume
-        outer_shape.cut = self.test_shape
+        outer_shape.boolean_operations = {"cut": self.test_shape}
         assert outer_shape.volume == pytest.approx(
             outer_shape_volume - self.test_shape.volume
         )

--- a/tests/test_parametric_shapes/test_RotateSplineShape.py
+++ b/tests/test_parametric_shapes/test_RotateSplineShape.py
@@ -50,7 +50,7 @@ class TestRotateSplineShape(unittest.TestCase):
 
         outer_shape_with_cut = RotateSplineShape(
             points=[(3, 3), (3, 12), (12, 12), (12, 3)],
-            cut=inner_shape,
+            boolean_operations={"cut": inner_shape},
             rotation_angle=180,
         )
 

--- a/tests/test_parametric_shapes/test_RotateStraightShape.py
+++ b/tests/test_parametric_shapes/test_RotateStraightShape.py
@@ -63,7 +63,7 @@ class TestRotateStraightShape(unittest.TestCase):
 
         outer_box_and_inner_box = RotateStraightShape(
             points=[(200, 100), (200, 200), (500, 200), (500, 100)],
-            union=inner_box,
+            boolean_operations={"union": inner_box}
         )
 
         assert inner_box.volume + outer_box.volume == pytest.approx(
@@ -215,7 +215,7 @@ class TestRotateStraightShape(unittest.TestCase):
 
         shape_with_cut = RotateStraightShape(
             points=[(0, -5), (0, 25), (25, 25), (25, -5)],
-            cut=self.test_shape
+            boolean_operations={"cut": self.test_shape}
         )
 
         assert shape_with_cut.volume == pytest.approx(
@@ -240,7 +240,7 @@ class TestRotateStraightShape(unittest.TestCase):
 
         main_shape_with_cuts = RotateStraightShape(
             points=[(0, 0), (0, 200), (200, 200), (200, 0)],
-            cut=[shape_to_cut_1, shape_to_cut_2]
+            boolean_operations={"cut": [shape_to_cut_1, shape_to_cut_2]}
         )
 
         assert main_shape_with_cuts.volume == pytest.approx(


### PR DESCRIPTION
## Proposed changes

Starting PR which updates the method for performing boolean operations of cut, union and intersect. At the moment, the order in which these operations are performed is hard coded. This PR introduces a boolean_operations dictionary to shapes in which the boolean operations and their orders can be specified.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
