### PR TITLE
changed order of rotate_solid and compound creation

### DIFF
--- a/paramak/parametric_components/toroidal_field_coil_rectangle.py
+++ b/paramak/parametric_components/toroidal_field_coil_rectangle.py
@@ -140,6 +140,8 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
 
         solid = wire.extrude(distance=-self.distance / 2.0, both=True)
 
+        solid = self.rotate_solid(solid)
+
         if self.with_inner_leg is True:
             inner_leg_solid = cq.Workplane(self.workplane)
             inner_leg_solid = inner_leg_solid.polyline(
@@ -147,11 +149,12 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
             inner_leg_solid = inner_leg_solid.close().extrude(
                 distance=-self.distance / 2.0, both=True)
 
+            inner_leg_solid = self.rotate_solid(inner_leg_solid)
+
             solid = cq.Compound.makeCompound(
                 [a.val() for a in [inner_leg_solid, solid]]
             )
 
-        solid = self.rotate_solid(solid)
         cutting_wedge = calculate_wedge_cut(self)
         solid = self.perform_boolean_operations(solid, wedge_cut=cutting_wedge)
         self.solid = solid   # not necessarily required as set in boolean_operations

--- a/paramak/parametric_components/toroidal_field_coil_rectangle.py
+++ b/paramak/parametric_components/toroidal_field_coil_rectangle.py
@@ -142,6 +142,9 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
 
         solid = self.rotate_solid(solid)
 
+        cutting_wedge = calculate_wedge_cut(self)
+        solid = self.perform_boolean_operations(solid, wedge_cut=cutting_wedge)
+
         if self.with_inner_leg is True:
             inner_leg_solid = cq.Workplane(self.workplane)
             inner_leg_solid = inner_leg_solid.polyline(
@@ -150,13 +153,12 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
                 distance=-self.distance / 2.0, both=True)
 
             inner_leg_solid = self.rotate_solid(inner_leg_solid)
+            inner_leg_solid = self.perform_boolean_operations(inner_leg_solid, wedge_cut=cutting_wedge)
 
             solid = cq.Compound.makeCompound(
                 [a.val() for a in [inner_leg_solid, solid]]
             )
 
-        cutting_wedge = calculate_wedge_cut(self)
-        solid = self.perform_boolean_operations(solid, wedge_cut=cutting_wedge)
         self.solid = solid   # not necessarily required as set in boolean_operations
 
         return solid

--- a/paramak/parametric_components/toroidal_field_coil_rectangle.py
+++ b/paramak/parametric_components/toroidal_field_coil_rectangle.py
@@ -153,7 +153,8 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
                 distance=-self.distance / 2.0, both=True)
 
             inner_leg_solid = self.rotate_solid(inner_leg_solid)
-            inner_leg_solid = self.perform_boolean_operations(inner_leg_solid, wedge_cut=cutting_wedge)
+            inner_leg_solid = self.perform_boolean_operations(
+                inner_leg_solid, wedge_cut=cutting_wedge)
 
             solid = cq.Compound.makeCompound(
                 [a.val() for a in [inner_leg_solid, solid]]

--- a/tests/test_parametric_components/test_ToroidalFieldCoilRectangle.py
+++ b/tests/test_parametric_components/test_ToroidalFieldCoilRectangle.py
@@ -50,7 +50,6 @@ class TestToroidalFieldCoilRectangle(unittest.TestCase):
         )
         assert test_inner_leg.solid is not None
 
-
     def test_creation_with_inner_leg_with_overlap(self):
         """Creates tf coils with overlappting inner legs using the ToroidalFieldCoilRectangle
         parametric component and checks that a cadquery solid is created correctly."""
@@ -70,12 +69,12 @@ class TestToroidalFieldCoilRectangle(unittest.TestCase):
             points=[
                 (0, 700), (50, 700), (50, -700), (0, -700)
             ], distance=30,
-            azimuth_placement_angle = [0, 45, 90, 135, 180, 225, 270, 315]
+            azimuth_placement_angle=[0, 45, 90, 135, 180, 225, 270, 315]
         )
         inner_leg_volume = test_inner_leg.volume
 
-        assert with_inner_leg_volume == pytest.approx(without_inner_leg_volume + inner_leg_volume)
-        
+        assert with_inner_leg_volume == pytest.approx(
+            without_inner_leg_volume + inner_leg_volume)
 
     def test_creation_no_inner_leg(self):
         """Creates a tf coil with no inner leg using the ToroidalFieldCoilRectangle

--- a/tests/test_parametric_components/test_ToroidalFieldCoilRectangle.py
+++ b/tests/test_parametric_components/test_ToroidalFieldCoilRectangle.py
@@ -50,6 +50,33 @@ class TestToroidalFieldCoilRectangle(unittest.TestCase):
         )
         assert test_inner_leg.solid is not None
 
+
+    def test_creation_with_inner_leg_with_overlap(self):
+        """Creates tf coils with overlappting inner legs using the ToroidalFieldCoilRectangle
+        parametric component and checks that a cadquery solid is created correctly."""
+
+        self.test_shape.horizontal_start_point = (0, 700)
+        self.test_shape.number_of_coils = 8
+        assert self.test_shape.solid is not None
+
+        with_inner_leg_volume = self.test_shape.volume
+
+        self.test_shape.with_inner_leg = False
+        without_inner_leg_volume = self.test_shape.volume
+
+        assert self.test_shape.solid is not None
+
+        test_inner_leg = paramak.ExtrudeStraightShape(
+            points=[
+                (0, 700), (50, 700), (50, -700), (0, -700)
+            ], distance=30,
+            azimuth_placement_angle = [0, 45, 90, 135, 180, 225, 270, 315]
+        )
+        inner_leg_volume = test_inner_leg.volume
+
+        assert with_inner_leg_volume == pytest.approx(without_inner_leg_volume + inner_leg_volume)
+        
+
     def test_creation_no_inner_leg(self):
         """Creates a tf coil with no inner leg using the ToroidalFieldCoilRectangle
         parametric component and checks that a cadquery solid is created."""

--- a/tests/test_parametric_components/test_ToroidalFieldCoilRectangle.py
+++ b/tests/test_parametric_components/test_ToroidalFieldCoilRectangle.py
@@ -51,7 +51,7 @@ class TestToroidalFieldCoilRectangle(unittest.TestCase):
         assert test_inner_leg.solid is not None
 
     def test_creation_with_inner_leg_with_overlap(self):
-        """Creates tf coils with overlappting inner legs using the ToroidalFieldCoilRectangle
+        """Creates tf coils with overlapping inner legs using the ToroidalFieldCoilRectangle
         parametric component and checks that a cadquery solid is created correctly."""
 
         self.test_shape.horizontal_start_point = (0, 700)


### PR DESCRIPTION
## Proposed changes

PR to fix tf coil bug outlined in #780. Thanks @katie-taylor for raising the issue.
Previously, the outer tf coil and inboard leg were created separately and then made into a single compound before being passed to rotate_solid which placed a shape at each azimuth_placement_angle and unioned. CadQuery didn't like the compound being passed to rotate_solid.
Now, the outer tf coil and inboard leg are passed to rotate_solid separately to place at each azimuthal placement angle and a compound of their shapes created after.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
