### PR TITLE
added DAGMC bin folder to path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -191,6 +191,7 @@ RUN pip install -r requirements.txt
 
 ENV OPENMC_CROSS_SECTIONS=/root/nndc_hdf5/cross_sections.xml
 ENV PATH="/MOAB/build/bin:${PATH}"
+ENV PATH="/DAGMC/bin:${PATH}"
 
 RUN mkdir /home/paramak
 EXPOSE 8888


### PR DESCRIPTION
## Proposed changes

Just spotted another one missing from the path. DAGMC should be included in the path to allow make_watertight to be found

I keep finding these bugs as I add tests to the develop_combine_neutronics branch

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

