### PR TITLE
added option for single file export_stp

### DIFF
--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -541,8 +541,9 @@ class Reactor:
             if len(self.stp_filenames) != len(set(self.stp_filenames)):
                 print([item for item, count in collections.Counter(
                     self.stp_filenames).items() if count > 1])
-                raise ValueError("Set Reactor already contains shapes with the "
-                                "same stp_filename")
+                raise ValueError(
+                    "Set Reactor already contains shapes with the "
+                    "same stp_filename")
 
             filenames = []
             for entry in self.shapes_and_components:

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -580,24 +580,23 @@ class Reactor:
 
             return filenames
 
-        else:
+        # exports a single file for the whole model
+        assembly = cq.Assembly(name='reactor')
+        for entry in self.shapes_and_components:
+            if entry.color is None:
+                assembly.add(entry.solid)
+            else:
+                assembly.add(entry.solid, color=cq.Color(*entry.color))
 
-            assembly = cq.Assembly(name='reactor')
-            for entry in self.shapes_and_components:
-                if entry.color is None:
-                    assembly.add(entry.solid)
-                else:
-                    assembly.add(entry.solid, color=cq.Color(*entry.color))
+        assembly.save(filename, exportType='STEP')
 
-            assembly.save(filename, exportType='STEP')
+        if units == 'cm':
+            _replace(
+                filename,
+                'SI_UNIT(.MILLI.,.METRE.)',
+                'SI_UNIT(.CENTI.,.METRE.)')
 
-            if units == 'cm':
-                _replace(
-                    filename,
-                    'SI_UNIT(.MILLI.,.METRE.)',
-                    'SI_UNIT(.CENTI.,.METRE.)')
-
-            return [filename]
+        return [filename]
 
     def export_stl(
             self,

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -592,7 +592,7 @@ class Reactor:
 
             if units == 'cm':
                 _replace(
-                    path_filename,
+                    filename,
                     'SI_UNIT(.MILLI.,.METRE.)',
                     'SI_UNIT(.CENTI.,.METRE.)')
 

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -586,7 +586,7 @@ class Reactor:
                 if entry.color is None:
                     assembly.add(entry.solid)
                 else:
-                    assembly.add(entry.solid, color=cq.Color(*self.color))
+                    assembly.add(entry.solid, color=cq.Color(*entry.color))
 
             assembly.save(filename, exportType='STEP')
 

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -15,14 +15,20 @@ class TestReactor(unittest.TestCase):
         self.test_shape = paramak.RotateStraightShape(
             points=[(0, 0), (0, 20), (20, 20)])
 
+        self.test_shape2 = paramak.ExtrudeStraightShape(
+            points=[(100, 100), (50, 100), (50, 50)], distance = 20)
+
         self.test_reactor = paramak.Reactor([self.test_shape])
+
+        self.test_reactor_2 = paramak.Reactor([self.test_shape, self.test_shape2])
 
     def test_reactor_export_stp(self):
         """Exports the reactor as seperate files and as a single file"""
         os.system('rm *.stp')
-        self.test_shape.export_stp()
+        self.test_reactor_2.export_stp()
         assert Path('RotateStraightShape.stp').is_file()
-        self.test_shape.export_stp(filename='single_file.stp')
+        assert Path('ExtrudeStraightShape.stp').is_file()
+        self.test_reactor_2.export_stp(filename='single_file.stp')
         assert Path('single_file.stp').is_file()
 
     def test_reactor_export_html_from_str_input(self):

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -17,6 +17,14 @@ class TestReactor(unittest.TestCase):
 
         self.test_reactor = paramak.Reactor([self.test_shape])
 
+    def test_reactor_export_stp(self):
+        """Exports the reactor as seperate files and as a single file"""
+        os.system('rm *.stp')
+        self.test_shape.export_stp()
+        assert Path('RotateStraightShape.stp').is_file()
+        self.test_shape.export_stp(filename='single_file.stp')
+        assert Path('single_file.stp').is_file()
+
     def test_reactor_export_html_from_str_input(self):
         """when the .solid is called it constructs the geometry. This should be
         possible even whe the shapes_and_components passed to reactor is just a

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -28,7 +28,7 @@ class TestReactor(unittest.TestCase):
         self.test_reactor_2.export_stp()
         assert Path('RotateStraightShape.stp').is_file()
         assert Path('ExtrudeStraightShape.stp').is_file()
-        self.test_reactor_2.export_stp(filename='single_file.stp')
+        self.test_reactor_2.export_stp(filename='single_file.stp', units='cm')
         assert Path('single_file.stp').is_file()
 
     def test_reactor_export_html_from_str_input(self):

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -16,11 +16,12 @@ class TestReactor(unittest.TestCase):
             points=[(0, 0), (0, 20), (20, 20)])
 
         self.test_shape2 = paramak.ExtrudeStraightShape(
-            points=[(100, 100), (50, 100), (50, 50)], distance = 20)
+            points=[(100, 100), (50, 100), (50, 50)], distance=20)
 
         self.test_reactor = paramak.Reactor([self.test_shape])
 
-        self.test_reactor_2 = paramak.Reactor([self.test_shape, self.test_shape2])
+        self.test_reactor_2 = paramak.Reactor(
+            [self.test_shape, self.test_shape2])
 
     def test_reactor_export_stp(self):
         """Exports the reactor as seperate files and as a single file"""


### PR DESCRIPTION
## Proposed changes

This adds a filename option to the Reactor.export_stp so that the whole reactor can be exported as a single stp file instead of seperate parts. As requested in issue #818

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
