### PR TITLE
added missing material tags

### DIFF
--- a/paramak/parametric_reactors/eu_demo_2015_reactor.py
+++ b/paramak/parametric_reactors/eu_demo_2015_reactor.py
@@ -93,6 +93,7 @@ class EuDemoFrom2015PaperDiagram(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stp_filename="tf_coil_casing.stp",
             stl_filename="tf_coil_casing.stl",
+            material_tag="tf_coil_casing_mat",
             color=(1., 1., 0.498),
         )
 
@@ -136,6 +137,7 @@ class EuDemoFrom2015PaperDiagram(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stp_filename="blanket.stp",
             stl_filename="blanket.stl",
+            material_tag="blanket_mat",
             color=(0., 1., 0.498),
         )
 
@@ -171,6 +173,7 @@ class EuDemoFrom2015PaperDiagram(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stp_filename="divertor.stp",
             stl_filename="divertor.stl",
+            material_tag="divertor_mat",
             color=(1., 0.667, 0.),
         )
 
@@ -225,7 +228,10 @@ class EuDemoFrom2015PaperDiagram(paramak.Reactor):
             ],
             rotation_angle=self.rotation_angle,
             # avoid overlap between VV and blanket divertor
-            union=[blanket, divertor]
+            union=[blanket, divertor],
+            material_tag="vacuum_vessel_inner_mat",
+            stp_filename='vacvesselinner.stp',
+            stl_filename='vacvesselinner.stl',
         )
         vac_vessel = paramak.RotateSplineShape(
             points=[
@@ -285,6 +291,7 @@ class EuDemoFrom2015PaperDiagram(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stp_filename='vacvessel.stp',
             stl_filename='vacvessel.stl',
+            material_tag="vacuum_vessel_mat",
             color=(0., 1., 1.),
         )
 
@@ -343,6 +350,7 @@ class EuDemoFrom2015PaperDiagram(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stl_filename='outboard_pf_coils.stl',
             stp_filename='outboard_pf_coils.stp',
+            material_tag='outboard_pf_coils_mat',
         )
 
         pf_coils_1 = paramak.RotateStraightShape(
@@ -355,6 +363,7 @@ class EuDemoFrom2015PaperDiagram(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stl_filename='pf_coils_1.stl',
             stp_filename='pf_coils_1.stp',
+            material_tag='pf_coils_mat',
         )
 
         pf_coils_2 = paramak.RotateStraightShape(
@@ -367,6 +376,7 @@ class EuDemoFrom2015PaperDiagram(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stl_filename='pf_coils_2.stl',
             stp_filename='pf_coils_2.stp',
+            material_tag='pf_coils_mat',
         )
 
         pf_coils_3 = paramak.RotateStraightShape(
@@ -379,6 +389,7 @@ class EuDemoFrom2015PaperDiagram(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stl_filename='pf_coils_3.stl',
             stp_filename='pf_coils_3.stp',
+            material_tag='pf_coils_mat',
         )
 
         pf_coils_4 = paramak.RotateStraightShape(
@@ -391,6 +402,7 @@ class EuDemoFrom2015PaperDiagram(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stl_filename='pf_coils_4.stl',
             stp_filename='pf_coils_4.stp',
+            material_tag='pf_coils_mat',
         )
 
         pf_coils_5 = paramak.RotateStraightShape(
@@ -403,6 +415,7 @@ class EuDemoFrom2015PaperDiagram(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stl_filename='pf_coils_5.stl',
             stp_filename='pf_coils_5.stp',
+            material_tag='pf_coils_mat',
         )
 
         return [outboard_pf_coils, pf_coils_1, pf_coils_2, pf_coils_3,

--- a/paramak/parametric_reactors/iter_reactor.py
+++ b/paramak/parametric_reactors/iter_reactor.py
@@ -49,6 +49,7 @@ class ITERTokamak(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stp_filename="tf_coils.stp",
             stl_filename="tf_coils.stl",
+            material_tag='tf_coils_mat',
         )
 
         return [tf_coil]
@@ -71,6 +72,7 @@ class ITERTokamak(paramak.Reactor):
             offset_from_plasma=[[-70, 0, 90, 180, 230], [50, 20, 59, 16, 50]],
             stp_filename="blanket.stp",
             stl_filename="blanket.stl",
+            material_tag='blanket_mat',
         )
 
         # SN Divertor
@@ -85,6 +87,7 @@ class ITERTokamak(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stp_filename="divertor.stp",
             stl_filename="divertor.stl",
+            material_tag='divertor_mat',
         )
 
         # Vacuum vessel
@@ -94,6 +97,9 @@ class ITERTokamak(paramak.Reactor):
         vac_vessel_inner = paramak.RotateMixedShape(
             points=blanket.outer_points + divertor.casing_points,
             rotation_angle=self.rotation_angle,
+            stp_filename='vacvesselinner.stp',
+            stl_filename='vacvesselinner.stl',
+            material_tag="inner_vacuum_vessel_mat",
         )
 
         vac_vessel = paramak.RotateSplineShape(
@@ -181,6 +187,7 @@ class ITERTokamak(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stp_filename='vacvessel.stp',
             stl_filename='vacvessel.stl',
+            material_tag="vacuum_vessel_mat",
         )
 
         return [divertor, blanket, vac_vessel, vac_vessel_inner]
@@ -200,7 +207,6 @@ class ITERTokamak(paramak.Reactor):
             vertical_displacement=5.7e1,
             configuration="single-null",
             rotation_angle=self.rotation_angle,
-            stp_filename='plasma.stp',
         )
 
         return [self.plasma]
@@ -238,6 +244,7 @@ class ITERTokamak(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stl_filename='outboard_pf_coils.stl',
             stp_filename='outboard_pf_coils.stp',
+            material_tag='outboard_pf_coils_mat',
         )
 
         x_inner, x_outer = 132.73905996758506, 202.26904376012968
@@ -252,6 +259,7 @@ class ITERTokamak(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stl_filename='pf_coils_1.stl',
             stp_filename='pf_coils_1.stp',
+            material_tag='pf_coil_mat',
         )
 
         pf_coils_2 = paramak.RotateStraightShape(
@@ -264,6 +272,7 @@ class ITERTokamak(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stl_filename='pf_coils_2.stl',
             stp_filename='pf_coils_2.stp',
+            material_tag='pf_coil_mat',
         )
 
         pf_coils_3 = paramak.RotateStraightShape(
@@ -276,6 +285,7 @@ class ITERTokamak(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stl_filename='pf_coils_3.stl',
             stp_filename='pf_coils_3.stp',
+            material_tag='pf_coil_mat',
         )
 
         pf_coils_4 = paramak.RotateStraightShape(
@@ -288,6 +298,7 @@ class ITERTokamak(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stl_filename='pf_coils_4.stl',
             stp_filename='pf_coils_4.stp',
+            material_tag='pf_coil_mat',
         )
 
         pf_coils_5 = paramak.RotateStraightShape(
@@ -300,6 +311,7 @@ class ITERTokamak(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stl_filename='pf_coils_5.stl',
             stp_filename='pf_coils_5.stp',
+            material_tag='pf_coil_mat',
         )
 
         pf_coils_6 = paramak.RotateStraightShape(
@@ -312,6 +324,7 @@ class ITERTokamak(paramak.Reactor):
             rotation_angle=self.rotation_angle,
             stl_filename='pf_coils_6.stl',
             stp_filename='pf_coils_6.stp',
+            material_tag='pf_coil_mat',
         )
 
         return [outboard_pf_coils, pf_coils_1, pf_coils_2, pf_coils_3,

--- a/paramak/parametric_reactors/sparc_paper_2020.py
+++ b/paramak/parametric_reactors/sparc_paper_2020.py
@@ -43,7 +43,9 @@ class SparcFrom2020PaperDiagram(paramak.Reactor):
             heights=[41.5, 40.5, 82.95, 82.95, 40.5, 41.5, ],
             widths=[27.7, 27.7, 27.7, 27.7, 27.7, 27.7],
             rotation_angle=self.rotation_angle,
-            stp_filename='inboard_pf_coils.stp'
+            stp_filename='inboard_pf_coils.stp',
+            stl_filename='inboard_pf_coils.stl',
+            material_tag='inboard_pf_coils_mat',
         )
 
         outboard_pf_coils = paramak.PoloidalFieldCoilSet(
@@ -60,7 +62,9 @@ class SparcFrom2020PaperDiagram(paramak.Reactor):
             widths=[32, 32, 50, 50, 43, 43, 48, 48, ],
             heights=[40, 40, 30, 30, 28, 28, 37, 37, ],
             rotation_angle=self.rotation_angle,
-            stp_filename='outboard_pf_coils.stp'
+            stp_filename='outboard_pf_coils.stp',
+            stl_filename='outboard_pf_coils.stl',
+            material_tag='outboard_pf_coils_mat',
         )
 
         div_coils = paramak.PoloidalFieldCoilSet(
@@ -74,7 +78,9 @@ class SparcFrom2020PaperDiagram(paramak.Reactor):
             widths=[15, 15, 15, 15],
             heights=[15, 15, 15, 15],
             rotation_angle=self.rotation_angle,
-            stp_filename='div_coils.stp'
+            stp_filename='div_coils.stp',
+            stl_filename='div_coils.stl',
+            material_tag='div_coils_mat',
         )
 
         efccu_coils_1 = paramak.RotateStraightShape(
@@ -86,6 +92,8 @@ class SparcFrom2020PaperDiagram(paramak.Reactor):
             ],
             rotation_angle=self.rotation_angle,
             stp_filename='efccu_coils_1.stp',
+            stl_filename='efccu_coils_1.stl',
+            material_tag='efccu_coils_1_mat',
         )
 
         efccu_coils_2 = paramak.RotateStraightShape(
@@ -96,7 +104,9 @@ class SparcFrom2020PaperDiagram(paramak.Reactor):
                 (268.82217090069287, -94.47004608294935),
             ],
             rotation_angle=self.rotation_angle,
-            stp_filename='efccu_coils_2.stp'
+            stp_filename='efccu_coils_2.stp',
+            stl_filename='efccu_coils_2.stl',
+            material_tag='efccu_coils_2_mat',
         )
 
         efccu_coils_3 = paramak.RotateStraightShape(
@@ -107,7 +117,9 @@ class SparcFrom2020PaperDiagram(paramak.Reactor):
                 (281.7551963048499, -78.80184331797238),
             ],
             rotation_angle=self.rotation_angle,
-            stp_filename='efccu_coils_3.stp'
+            stp_filename='efccu_coils_3.stp',
+            stl_filename='efccu_coils_3.stl',
+            material_tag='efccu_coils_3_mat',
         )
 
         efccu_coils_4 = paramak.RotateStraightShape(
@@ -118,7 +130,9 @@ class SparcFrom2020PaperDiagram(paramak.Reactor):
                 (242.0323325635104, 132.25806451612902),
             ],
             rotation_angle=self.rotation_angle,
-            stp_filename='efccu_coils_4.stp'
+            stp_filename='efccu_coils_4.stp',
+            stl_filename='efccu_coils_4.stl',
+            material_tag='efccu_coils_4_mat',
         )
 
         efccu_coils_5 = paramak.RotateStraightShape(
@@ -129,7 +143,9 @@ class SparcFrom2020PaperDiagram(paramak.Reactor):
                 (268.82217090069287, 94.47004608294935),
             ],
             rotation_angle=self.rotation_angle,
-            stp_filename='efccu_coils_5.stp'
+            stp_filename='efccu_coils_5.stp',
+            stl_filename='efccu_coils_5.stl',
+            material_tag='efccu_coils_5_mat',
         )
 
         efccu_coils_6 = paramak.RotateStraightShape(
@@ -140,7 +156,9 @@ class SparcFrom2020PaperDiagram(paramak.Reactor):
                 (281.7551963048499, 78.80184331797238),
             ],
             rotation_angle=self.rotation_angle,
-            stp_filename='efccu_coils_6.stp'
+            stp_filename='efccu_coils_6.stp',
+            stl_filename='efccu_coils_6.stl',
+            material_tag='efccu_coils_6_mat',
         )
 
         # these are cut away from the vessel components
@@ -152,7 +170,9 @@ class SparcFrom2020PaperDiagram(paramak.Reactor):
             widths=[10, 10],
             heights=[10, 10],
             rotation_angle=self.rotation_angle,
-            stp_filename='vs_coils.stp'
+            stp_filename='vs_coils.stp',
+            stl_filename='vs_coils.stl',
+            material_tag='vs_coils_mat',
         )
 
         return [
@@ -176,7 +196,9 @@ class SparcFrom2020PaperDiagram(paramak.Reactor):
             distance=33,
             number_of_coils=12,
             rotation_angle=self.rotation_angle,
-            stp_filename='tf_coil.stp'
+            stp_filename='tf_coil.stp',
+            stl_filename='tf_coil.stl',
+            material_tag='tf_coil_mat',
         )
 
         return [tf_coil]
@@ -203,7 +225,9 @@ class SparcFrom2020PaperDiagram(paramak.Reactor):
                 (231.87066974595842, 46.5437788018433, 'straight'),
             ],
             rotation_angle=self.rotation_angle,
-            stp_filename='antenna.stp'
+            stp_filename='antenna.stp',
+            stl_filename='antenna.stl',
+            material_tag='antenna_mat',
         )
 
         vac_vessel = paramak.RotateStraightShape(
@@ -243,7 +267,9 @@ class SparcFrom2020PaperDiagram(paramak.Reactor):
                 (117.32101616628177, 123.04147465437785),
             ],
             rotation_angle=self.rotation_angle,
-            stp_filename='vacvessel.stp',
+            stp_filename='vacuum_vessel.stp',
+            stl_filename='vacuum_vessel.stl',
+            material_tag='vacuum_vessel_mat',
             color=(0., 1., 1.),
         )
 
@@ -294,7 +320,9 @@ class SparcFrom2020PaperDiagram(paramak.Reactor):
                 (269.7459584295612, -63.13364055299536, 'straight'),
             ],
             rotation_angle=self.rotation_angle,
-            stp_filename='inner_vessel.stp',
+            material_tag="vacuum_vessel_inner_mat",
+            stp_filename="vacuum_vessel_inner.stp",
+            stl_filename="vacuum_vessel_inner.stl",
             cut=[vac_vessel, vs_coils, antenna],
             color=(0., 1., 0.498),
         )
@@ -319,7 +347,6 @@ class SparcFrom2020PaperDiagram(paramak.Reactor):
             triangularity=0.31,
             elongation=1.97,
             rotation_angle=self.rotation_angle,
-            stp_filename='plasma.stp',
         )
 
         return [plasma]


### PR DESCRIPTION
## Proposed changes

The material_tags were not set for all the shapes in the EuDemoFrom2015PaperDiagram class. The made it difficult to use in neutronics simulations as the tags default to None.

This PR adds material_tags to all the shapes so that it can be used in neutronics simulations easily

Thanks for reporting this error @tokamaster 


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
