### PR TITLE
changed source of nuclear data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -176,7 +176,6 @@ RUN if [ "$include_neutronics" = "true" ] ; \
     make -j"$compile_cores" install ; \
     cd ..  ; \
     pip install -e .[test] ; \
-    /opt/openmc/tools/ci/download-xs.sh ; \
     fi
 
 RUN if [ "$include_neutronics" = "true" ] ; \
@@ -184,12 +183,13 @@ RUN if [ "$include_neutronics" = "true" ] ; \
     pip install parametric_plasma_source ; \
     pip install neutronics_material_maker==0.3.2 ; \
     pip install openmc_data_downloader ; \
+    openmc_data_downloader -e all -l ENDFB-7.1-NNDC TENDL-2019 ; \
     fi
 
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
-ENV OPENMC_CROSS_SECTIONS=/root/nndc_hdf5/cross_sections.xml
+ENV OPENMC_CROSS_SECTIONS=/cross_sections.xml
 ENV PATH="/MOAB/build/bin:${PATH}"
 ENV PATH="/DAGMC/bin:${PATH}"
 


### PR DESCRIPTION
## Proposed changes

This PR makes use of the openmc-data-downloader to download endf/b 7.1 and tendl 2019 nuclear data for all the stable elements.
https://github.com/openmc-data-storage/openmc_data_downloader

This includes a few cases where endf is missing cross sections for example O18, C13 which was causing simulations to fail elsewhere

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

