### PR TITLE
added ability to load stp files into a shape

### DIFF
--- a/paramak/parametric_components/vacuum_vessel_inner_leg.py
+++ b/paramak/parametric_components/vacuum_vessel_inner_leg.py
@@ -51,7 +51,8 @@ class VacuumVesselInnerLeg(RotateStraightShape):
                 'VacuumVesselInnerLeg.inner_height must be a number. Not', value)
         if value <= 0:
             raise ValueError(
-                'VacuumVesselInnerLeg.inner_height must be a positive number above 0. Not', value)
+                'VacuumVesselInnerLeg.inner_height must be a positive number above 0. Not',
+                value)
         self._inner_height = value
 
     @property
@@ -65,7 +66,8 @@ class VacuumVesselInnerLeg(RotateStraightShape):
                 'VacuumVesselInnerLeg.inner_radius must be a number. Not', value)
         if value <= 0:
             raise ValueError(
-                'VacuumVesselInnerLeg.inner_radius must be a positive number above 0. Not', value)
+                'VacuumVesselInnerLeg.inner_radius must be a positive number above 0. Not',
+                value)
         self._inner_radius = value
 
     def find_points(self):

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -957,8 +957,31 @@ class Reactor:
                 volume_id += 1
                 surface_id += 1
         else:
-            raise NotImplementedError(
-                "Reading a JSON filename and converting to a DAGMC geometry using pymoab is not yet supported")
+            # loads up the json file
+            with open(self.shapes_and_components) as json_file:
+                manifest = json.load(json_file)
+
+            # gets all the stp files and loads them into shapes
+            for entry in manifest:
+                new_shape = paramak.Shape()
+                new_shape.from_stp_file(entry['stp_filename'])  # loads the stp file into a Shape object
+                new_shape.material_tag = entry['material_tag']
+                new_shape.stl_filename = str(Path(entry['stp_filename']).stem) + '.stl'
+
+                new_shape.export_stl(
+                    new_shape.stl_filename,
+                    tolerance=faceting_tolerance)
+
+                moab_core = add_stl_to_moab_core(
+                    moab_core,
+                    surface_id,
+                    volume_id,
+                    new_shape.material_tag,
+                    moab_tags,
+                    new_shape.stl_filename)
+                volume_id += 1
+                surface_id += 1
+
 
         if include_graveyard:
             self.make_graveyard()

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -964,9 +964,11 @@ class Reactor:
             # gets all the stp files and loads them into shapes
             for entry in manifest:
                 new_shape = paramak.Shape()
-                new_shape.from_stp_file(entry['stp_filename'])  # loads the stp file into a Shape object
+                # loads the stp file into a Shape object
+                new_shape.from_stp_file(entry['stp_filename'])
                 new_shape.material_tag = entry['material_tag']
-                new_shape.stl_filename = str(Path(entry['stp_filename']).stem) + '.stl'
+                new_shape.stl_filename = str(
+                    Path(entry['stp_filename']).stem) + '.stl'
 
                 new_shape.export_stl(
                     new_shape.stl_filename,
@@ -981,7 +983,6 @@ class Reactor:
                     new_shape.stl_filename)
                 volume_id += 1
                 surface_id += 1
-
 
         if include_graveyard:
             self.make_graveyard()

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -630,7 +630,7 @@ class Shape:
     def from_stp_file(self, filename: str):
         """Loads the filename using CadQuery and populates the Shape.solid
         with the contents
-        
+
         Args:
             filename: the file name of the stp / step file to be loaded
         """

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -627,7 +627,13 @@ class Shape:
             raise ValueError(msg)
         self._azimuth_placement_angle = value
 
-    def from_stp_file(self, filename):
+    def from_stp_file(self, filename: str):
+        """Loads the filename using CadQuery and populates the Shape.solid
+        with the contents
+        
+        Args:
+            filename: the file name of the stp / step file to be loaded
+        """
         result = cq.importers.importStep(filename)
         self.solid = result
 

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -627,6 +627,10 @@ class Shape:
             raise ValueError(msg)
         self._azimuth_placement_angle = value
 
+    def from_stp_file(self, filename):
+        result = cq.importers.importStep(filename)
+        self.solid = result
+
     def show(self):
         """Shows / renders the CadQuery the 3d object in Jupyter Lab. Imports
         show from jupyter_cadquery.cadquery and returns show(Shape.solid)"""

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -1224,15 +1224,17 @@ class TestReactor(unittest.TestCase):
         )
 
         my_reactor = paramak.Reactor([test_shape1, test_shape2])
-        my_reactor.export_h5m_with_pymoab(include_plasma=False, filename='no_plasma.h5m')
+        my_reactor.export_h5m_with_pymoab(
+            include_plasma=False, filename='no_plasma.h5m')
 
         assert Path('RotateStraightShape.stl').is_file()
         assert Path('plasma.stl').is_file() is False
-        my_reactor.export_h5m_with_pymoab(include_plasma=True, filename='with_plasma.h5m')
+        my_reactor.export_h5m_with_pymoab(
+            include_plasma=True, filename='with_plasma.h5m')
         assert Path('plasma.stl').is_file()
 
-        assert Path('with_plasma.h5m').stat().st_size > Path('no_plasma.h5m').stat().st_size
-
+        assert Path('with_plasma.h5m').stat().st_size > Path(
+            'no_plasma.h5m').stat().st_size
 
     def test_export_h5m_with_pymoab_from_manifest_file(self):
         """exports a h5m file when shapes_and_components is set to a string"""
@@ -1259,7 +1261,9 @@ class TestReactor(unittest.TestCase):
         self.test_reactor.export_vtk()
         assert Path('dagmc.h5m').is_file()
         assert Path('dagmc.vtk').is_file()
-        self.test_reactor.export_vtk(include_graveyard=False, filename='dagmc_no_graveyard.vtk')
+        self.test_reactor.export_vtk(
+            include_graveyard=False,
+            filename='dagmc_no_graveyard.vtk')
         assert Path('dagmc_no_graveyard.vtk').is_file()
         assert self.test_reactor.h5m_filename == 'dagmc.h5m'
 

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -1232,7 +1232,8 @@ class TestReactor(unittest.TestCase):
         my_reactor.export_h5m_with_pymoab(
             include_plasma=True, filename='with_plasma.h5m')
         assert Path('plasma.stl').is_file()
-        assert Path('with_plasma.h5m').stat().st_size > Path('no_plasma.h5m').stat().st_size
+        assert Path('with_plasma.h5m').stat().st_size > Path(
+            'no_plasma.h5m').stat().st_size
 
     def test_export_h5m_with_pymoab_from_manifest_file(self):
         """exports a h5m file when shapes_and_components is set to a string"""

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -1233,21 +1233,17 @@ class TestReactor(unittest.TestCase):
 
         assert Path('with_plasma.h5m').stat().st_size > Path('no_plasma.h5m').stat().st_size
 
-
     def test_export_h5m_with_pymoab_from_manifest_file(self):
         """exports a h5m file when shapes_and_components is set to a string"""
 
-        def check_correct_error_is_rasied():
-            os.system('rm dagmc.h5m')
-            test_shape = paramak.RotateStraightShape(
-                points=[(0, 0), (0, 20), (20, 20)]
-            )
-            test_shape.export_neutronics_description('manifest.json')
-            my_reactor = paramak.Reactor('manifest.json')
-            my_reactor.export_h5m_with_pymoab()
-            assert Path('dagmc.h5m').is_file()
-
-        self.assertRaises(NotImplementedError, check_correct_error_is_rasied)
+        os.system('rm dagmc.h5m')
+        test_shape = paramak.RotateStraightShape(
+            points=[(0, 0), (0, 20), (20, 20)]
+        )
+        test_shape.export_neutronics_description('manifest.json')
+        my_reactor = paramak.Reactor('manifest.json')
+        my_reactor.export_h5m_with_pymoab()
+        assert Path('dagmc.h5m').is_file()
 
     def test_export_vtk(self):
         """Creates vtk files from the h5m files and checks they exist"""


### PR DESCRIPTION
## Proposed changes

This adds ```Shape().from_stp_file``` to the Shape class and makes use of this method in the ```Reactor.export_h5m_with_pymoab``` method.

This allows pymoab to be used as a method when making a reactor from a manifest.json file.

Previously this was only possible with the "trelis" method.

This means one can take a stp file(s) and run a neutronics simulation in the following manner ...

assuming you have a ```manifest.json``` like this
```bash
[
    {
        "stp_filename":"geometry.step",
        "material_tag":"my_material"
    }
]
```

```
import paramak, openmc

my_reactor = paramak.Reactor(
    shapes_and_components='manifest.json'
)

my_reactor.method = 'pymoab'

coords = openmc.stats.Point((0, 0, 0))
energy = openmc.stats.Discrete([1.41E7], [1.0])
source = openmc.Source(space=coords, energy=energy)

my_model = paramak.NeutronicsModel(
    geometry=my_reactor,
    source=source,
    materials={'my_material': 'eurofer'},
    mesh_tally_3d=['flux', 'heating'],
    mesh_3d_corners=[(-1, -1, -1), (1, 1, 1)]  # needed for now as the dimensions are not yet found automatically using this method
)

my_model.simulate()
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
