### PR TITLE
added export_html_3d method

### DIFF
--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -1255,6 +1255,30 @@ class Reactor:
 
         return str(path_filename)
 
+    def export_html_3d(
+            self,
+            filename: Optional[str] = "reactor_3d.html",
+    ):
+        """Saves an interactive 3d html view of the Reactor to a html file.
+
+        Args:
+            filename: the filename used to save the html graph. Defaults to
+                reactor_3d.html
+
+        Returns:
+            str: filename of the created html file
+        """
+
+        from ipywidgets.embed import embed_minimal_html
+
+        embed_minimal_html(
+            filename,
+            views=[self.show().show().cq_view.renderer],
+            title='Renderer'
+        )
+
+        return filename
+
     def export_html(
             self,
             filename: Optional[str] = "reactor.html",

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -1083,6 +1083,30 @@ class Shape:
 
         return str(path_filename)
 
+    def export_html_3d(
+            self,
+            filename: Optional[str] = "shape_3d.html",
+    ):
+        """Saves an interactive 3d html view of the Shape to a html file.
+
+        Args:
+            filename: the filename used to save the html graph. Defaults to
+                shape_3d.html
+
+        Returns:
+            str: filename of the created html file
+        """
+
+        from ipywidgets.embed import embed_minimal_html
+
+        embed_minimal_html(
+            filename,
+            views=[self.show().show().cq_view.renderer],
+            title='Renderer'
+        )
+
+        return filename
+
     def export_html(
             self,
             filename: Optional[str] = "shape.html",

--- a/tests/test_Reactor.py
+++ b/tests/test_Reactor.py
@@ -1020,6 +1020,19 @@ class TestReactor(unittest.TestCase):
         assert Path("test_html.html").exists() is True
         os.system("rm test_html.html")
 
+    def test_export_3d_html(self):
+        """Checks the 3d html file is exported by the export_html_3d method
+        with the correct filename"""
+
+        test_shape = paramak.RotateStraightShape(
+            points=[(0, 0), (0, 20), (20, 20)])
+        test_shape.rotation_angle = 360
+        test_reactor = paramak.Reactor([test_shape])
+
+        os.system("rm filename.html")
+        test_reactor.export_html_3d('filename.html')
+        assert Path("filename.html").exists() is True
+
     def test_tet_meshes_error(self):
         test_shape = paramak.RotateStraightShape(
             points=[(0, 0), (0, 20), (20, 20)])

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -452,6 +452,18 @@ class TestShape(unittest.TestCase):
             test_shape.export_html("out.html")
         self.assertRaises(ValueError, export)
 
+    def test_export_3d_html(self):
+        """Checks the 3d html file is exported by the export_html_3d method
+        with the correct filename"""
+
+        test_shape = paramak.RotateStraightShape(
+            points=[(0, 0), (0, 20), (20, 20), (20, 0)], rotation_angle=360
+        )
+
+        os.system("rm filename.html")
+        test_shape.export_html_3d('filename.html')
+        assert Path("filename.html").exists() is True
+
     def test_invalid_stp_filename(self):
         """Checks ValueError is raised when invalid stp filenames are used."""
 


### PR DESCRIPTION
## Proposed changes

This PR adds the ```export_html_3d``` to the Shape and Reactor class.

The new method allows stand alone 3d interactive objects to be viewed in html files

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
