### PR TITLE
added gap size

### DIFF
--- a/docs/source/paramak.parametric_reactors.rst
+++ b/docs/source/paramak.parametric_reactors.rst
@@ -10,7 +10,7 @@ These are the current reactor designs that can be created using the Paramak.
 BallReactor()
 ^^^^^^^^^^^^^
 
-.. image:: https://user-images.githubusercontent.com/8583900/99136724-91af6f00-261e-11eb-9956-476b818a0ee3.png
+.. image:: https://user-images.githubusercontent.com/8583900/119011892-6458ca80-b98d-11eb-92b1-bbc370cb9c84.png
    :width: 400
    :align: center
 

--- a/docs/source/paramak.parametric_reactors.rst
+++ b/docs/source/paramak.parametric_reactors.rst
@@ -10,7 +10,7 @@ These are the current reactor designs that can be created using the Paramak.
 BallReactor()
 ^^^^^^^^^^^^^
 
-.. image:: https://user-images.githubusercontent.com/8583900/119011892-6458ca80-b98d-11eb-92b1-bbc370cb9c84.png
+.. image:: https://user-images.githubusercontent.com/8583900/99136724-91af6f00-261e-11eb-9956-476b818a0ee3.png
    :width: 400
    :align: center
 
@@ -19,7 +19,7 @@ are red, PF coil cases are yellow, the center column shielding is dark green,
 the blanket is light green, the divertor is orange, the firstwall is grey
 and the rear wall of the blanket is teal.
 
-.. image:: https://user-images.githubusercontent.com/8583900/116444066-41367180-a84c-11eb-8e1b-dfa4815f560b.png
+.. image:: https://user-images.githubusercontent.com/8583900/119011892-6458ca80-b98d-11eb-92b1-bbc370cb9c84.png
    :width: 450
    :align: center
 

--- a/paramak/parametric_reactors/ball_reactor.py
+++ b/paramak/parametric_reactors/ball_reactor.py
@@ -318,16 +318,21 @@ class BallReactor(paramak.Reactor):
         # this is the vertical build sequence, components build on each other
         # in a similar manner to the radial build
 
-        self._firstwall_start_height = (self._plasma.high_point[1] + self.plasma_gap_vertical_thickness)
-        self._firstwall_end_height = self._firstwall_start_height + self.firstwall_radial_thickness
+        self._firstwall_start_height = (
+            self._plasma.high_point[1] +
+            self.plasma_gap_vertical_thickness)
+        self._firstwall_end_height = self._firstwall_start_height + \
+            self.firstwall_radial_thickness
 
         self._blanket_start_height = self._firstwall_end_height
         self._blanket_end_height = self._blanket_start_height + self.blanket_radial_thickness
 
         self._blanket_rear_wall_start_height = self._blanket_end_height
-        self._blanket_rear_wall_end_height = self._blanket_rear_wall_start_height + self.blanket_rear_wall_radial_thickness
+        self._blanket_rear_wall_end_height = self._blanket_rear_wall_start_height + \
+            self.blanket_rear_wall_radial_thickness
 
-        self._tf_coil_start_height = self._blanket_rear_wall_end_height + self.divertor_to_tf_gap_vertical_thickness
+        self._tf_coil_start_height = self._blanket_rear_wall_end_height + \
+            self.divertor_to_tf_gap_vertical_thickness
 
         self._center_column_shield_height = self._blanket_rear_wall_end_height * 2
 


### PR DESCRIPTION
## Proposed changes

This adds the ability to add a gap between the TF and the divertor.

![ball_reactor(2)](https://user-images.githubusercontent.com/8583900/119011892-6458ca80-b98d-11eb-92b1-bbc370cb9c84.png)


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
